### PR TITLE
feat: implement organizer revenue claim function

### DIFF
--- a/contract/contracts/ticket_payment/src/error.rs
+++ b/contract/contracts/ticket_payment/src/error.rs
@@ -23,6 +23,9 @@ pub enum TicketPaymentError {
     InvalidPrice = 17,
     InvalidDiscountCode = 18,
     DiscountCodeAlreadyUsed = 19,
+    Unauthorized = 20,
+    EventNotCompleted = 21,
+    NoFundsAvailable = 22,
 }
 
 impl core::fmt::Display for TicketPaymentError {
@@ -70,6 +73,9 @@ impl core::fmt::Display for TicketPaymentError {
             TicketPaymentError::DiscountCodeAlreadyUsed => {
                 write!(f, "Discount code has already been used")
             }
+            TicketPaymentError::Unauthorized => write!(f, "Unauthorized caller"),
+            TicketPaymentError::EventNotCompleted => write!(f, "Event is not completed"),
+            TicketPaymentError::NoFundsAvailable => write!(f, "No funds available to claim"),
         }
     }
 }

--- a/contract/contracts/ticket_payment/src/events.rs
+++ b/contract/contracts/ticket_payment/src/events.rs
@@ -12,6 +12,7 @@ pub enum AgoraEvent {
     PriceSwitched,
     BulkRefundProcessed,
     DiscountCodeApplied,
+    RevenueClaimed,
 }
 
 #[contracttype]
@@ -84,5 +85,14 @@ pub struct DiscountCodeAppliedEvent {
     pub event_id: String,
     pub code_hash: BytesN<32>,
     pub discount_amount: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RevenueClaimedEvent {
+    pub event_id: String,
+    pub organizer_address: Address,
+    pub amount: i128,
     pub timestamp: u64,
 }


### PR DESCRIPTION
close #53 

- Add claim_revenue entry point with organizer authentication
- Verify event completion status before allowing claims
- Transfer net revenue to organizer's payment address
- Prevent double-claims by clearing organizer_amount
- Add RevenueClaimed event for transparency
- Add error types: Unauthorized, EventNotCompleted, NoFundsAvailable