### PR TITLE
feat: Automated platform fee distribution

### DIFF
--- a/contract/contracts/ticket_payment/src/events.rs
+++ b/contract/contracts/ticket_payment/src/events.rs
@@ -13,6 +13,7 @@ pub enum AgoraEvent {
     BulkRefundProcessed,
     DiscountCodeApplied,
     RevenueClaimed,
+    FeeSettled,
 }
 
 #[contracttype]
@@ -94,5 +95,15 @@ pub struct RevenueClaimedEvent {
     pub event_id: String,
     pub organizer_address: Address,
     pub amount: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeSettledEvent {
+    pub event_id: String,
+    pub platform_wallet: Address,
+    pub fee_amount: i128,
+    pub fee_bps: u32,
     pub timestamp: u64,
 }


### PR DESCRIPTION
close #54 


### Changes Made:

1. Added FeeSettled event (events.rs):
- Added FeeSettled variant to the AgoraEvent enum
- Created FeeSettledEvent struct with fields:
  - event_id: Event identifier
  - platform_wallet: Destination wallet address
  - fee_amount: Amount transferred to treasury
  - fee_bps: Basis points used for fee calculation (from Registry)
  - timestamp: When the fee was settled

2. Updated claim_revenue function (contract.rs):
- **Two-transfer system**: Platform fee is transferred first, then organizer revenue
- **Dynamic fee calculation**: Uses event_info.platform_fee_percent (basis points) from the Registry
- **Treasury safety**: Platform fee transfer happens before organizer transfer as a safeguard
- **Detailed event emission**: Emits FeeSettledEvent with all accounting details including the bps used
- **Updated balance check**: Now checks if both organizer_amount and platform_fee are zero before returning error
- **Proper escrow accounting**: Both transfers are subtracted from active escrow totals

### Key Implementation Details:

- Fee is calculated dynamically from the Registry's platform_fee_percent field (already stored in basis points where 10000 = 100%)
- Platform fee transfer executes first to prioritize treasury safety
- The FeeSettledEvent is emitted immediately after the platform fee transfer for accurate accounting
- Both amounts are properly tracked and subtracted from escrow
- Code is minimal and focused on the requirements



@Yunusabdul38 please review