### PR TITLE
fix: auto-close mobile menu on navigation

### DIFF
--- a/apps/web/components/layout/navbar.tsx
+++ b/apps/web/components/layout/navbar.tsx
@@ -144,6 +144,7 @@ export function Navbar() {
                       icon="/icons/home.svg"
                       text="Home"
                       isActive={pathname === "/"}
+                      onClose={() => setIsOpen(false)}
                     />
                     <MobileNavLink
                       i={1}
@@ -154,6 +155,7 @@ export function Navbar() {
                         pathname === "/discover" ||
                         pathname.startsWith("/events")
                       }
+                      onClose={() => setIsOpen(false)}
                     />
                     <MobileNavLink
                       i={2}
@@ -161,6 +163,7 @@ export function Navbar() {
                       icon="/icons/user-group.svg"
                       text="Organizers"
                       isActive={pathname === "/organizers"}
+                      onClose={() => setIsOpen(false)}
                     />
                     <MobileNavLink
                       i={3}
@@ -168,6 +171,7 @@ export function Navbar() {
                       icon="/icons/stellar-xlm-logo 1.svg"
                       text="Stellar Ecosystem"
                       isActive={pathname === "/stellar"}
+                      onClose={() => setIsOpen(false)}
                     />
                   </>
                 ) : (
@@ -181,6 +185,7 @@ export function Navbar() {
                         pathname === "/discover" ||
                         pathname.startsWith("/events")
                       }
+                      onClose={() => setIsOpen(false)}
                     />
                     <MobileNavLink
                       i={1}
@@ -188,6 +193,7 @@ export function Navbar() {
                       icon="/icons/dollar-circle.svg"
                       text="Pricing"
                       isActive={pathname === "/pricing"}
+                      onClose={() => setIsOpen(false)}
                     />
                     <MobileNavLink
                       i={2}
@@ -195,6 +201,7 @@ export function Navbar() {
                       icon="/icons/stellar-xlm-logo 1.svg"
                       text="Stellar Ecosystem"
                       isActive={pathname === "/stellar"}
+                      onClose={() => setIsOpen(false)}
                     />
                     <MobileNavLink
                       i={3}
@@ -202,6 +209,7 @@ export function Navbar() {
                       icon="/icons/help-circle.svg"
                       text="FAQs"
                       isActive={pathname === "/faqs"}
+                      onClose={() => setIsOpen(false)}
                     />
                   </>
                 )}

--- a/apps/web/components/layout/navbar/mobile-nav-link.tsx
+++ b/apps/web/components/layout/navbar/mobile-nav-link.tsx
@@ -9,12 +9,14 @@ export function MobileNavLink({
   text,
   i,
   isActive,
+  onClose,
 }: {
   href: string;
   icon: string;
   text: string;
   i: number;
   isActive: boolean;
+  onClose?: () => void;
 }) {
   const linkVariants = {
     closed: { opacity: 0, x: 20 },
@@ -33,6 +35,7 @@ export function MobileNavLink({
     <motion.div custom={i} variants={linkVariants}>
       <Link
         href={href}
+        onClick={onClose}
         className={`flex items-center gap-3 text-lg font-medium transition-colors p-2 rounded-lg ${
           isActive ? "text-[#FDDA23]" : "hover:opacity-80"
         }`}


### PR DESCRIPTION
# [Bug Fix] Mobile Menu Auto-Close Logic

## Description
Fixed an issue where the mobile menu would remain open after navigating via a link, requiring users to manually close it each time.

## Changes
- Modified `MobileNavLink` component to accept an optional `onClose` callback prop
- Updated `Navbar` component to pass `setIsOpen(false)` callback to all mobile navigation links
- Menu now automatically closes with smooth transitions when any navigation link is clicked

## How to Test
1. Open the app on a mobile device or use browser dev tools to simulate mobile view
2. Open the mobile menu by clicking the hamburger icon
3. Click any navigation link
4. Verify the menu closes automatically while the page navigates

## Acceptance Criteria
- ✅ Mobile menu closes automatically upon clicking any navigation link
- ✅ Page navigation still works as expected
- ✅ Smooth transition for the menu closing

Closes #121