### PR TITLE
ci(contracts): Refactor workflow into separate lint, test, and build …

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -66,3 +66,46 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace
+
+  build-wasm:
+    name: Build Stellar WASM
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+
+    defaults:
+      run:
+        working-directory: contract
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contract -> target
+
+      - name: Install Stellar CLI
+        run: cargo install stellar-cli --locked --quiet || cargo install --locked soroban-cli --quiet
+
+      - name: Build optimised WASM
+        run: stellar contract build
+
+      - name: Verify WASM artifacts
+        run: |
+          for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
+            echo "✓ $(basename "$wasm") — $(wc -c < "$wasm") bytes"
+          done
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-wasm
+          path: contract/target/wasm32-unknown-unknown/release/*.wasm
+          retention-days: 14


### PR DESCRIPTION
…jobs

- Split monolithic job into three focused jobs: lint, test, and build-wasm
- Add workflow file itself to trigger paths for both push and pull request events
- Move cargo clippy linting to dedicated lint job
- Separate cargo test into independent test job with workspace flag
- Add new build-wasm job to compile Stellar WASM contracts with wasm32 target
- Install Stellar CLI and verify WASM artifact generation and sizes
- Upload compiled WASM artifacts with 14-day retention policy
- Improves CI/CD clarity, enables parallel job execution, and provides artifact tracking

closes #159 