### PR TITLE
Unit Test: register_event Edge Cases

### DIFF
--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -527,6 +527,66 @@ fn test_register_duplicate_event_fails() {
 }
 
 #[test]
+fn test_register_event_invalid_metadata_cid_formats() {
+    let env = Env::default();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let payment_addr = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    env.mock_all_auths();
+
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    let tiers = Map::new(&env);
+    let short_cid = String::from_str(&env, "bafy");
+    let short_result = client.try_register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "event_short_cid"),
+        organizer_address: organizer.clone(),
+        payment_address: payment_addr.clone(),
+        metadata_cid: short_cid,
+        max_supply: 100,
+        milestone_plan: None,
+        tiers: tiers.clone(),
+        refund_deadline: 0,
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+    });
+    assert_eq!(
+        short_result,
+        Err(Ok(EventRegistryError::InvalidMetadataCid))
+    );
+
+    let wrong_prefix_cid = String::from_str(
+        &env,
+        "Qafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+    let wrong_prefix_result = client.try_register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "event_wrong_prefix_cid"),
+        organizer_address: organizer,
+        payment_address: payment_addr,
+        metadata_cid: wrong_prefix_cid,
+        max_supply: 100,
+        milestone_plan: None,
+        tiers,
+        refund_deadline: 0,
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+    });
+    assert_eq!(
+        wrong_prefix_result,
+        Err(Ok(EventRegistryError::InvalidMetadataCid))
+    );
+}
+
+#[test]
 fn test_get_event_payment_info() {
     let env = Env::default();
     let contract_id = env.register(EventRegistry, ());


### PR DESCRIPTION
## Description
Add register_event regression coverage for invalid metadata CID inputs so event registration rejects malformed arguments before state changes occur.
Closes #192
## Changes proposed
### What were you told to do?
Add comprehensive unit tests for register_event invalid arguments, specifically covering max_supply less than total tier limits and invalid metadata CID formats, while keeping CI green.
### What did I do?
#### Register Event Edge Cases
- Added a direct register_event unit test that rejects too-short metadata CIDs.
- Added a direct register_event unit test that rejects metadata CIDs with an invalid prefix.
#### Validation Coverage
- Kept the existing max_supply versus tier-limit regression coverage in place and verified it still passes alongside the new register_event cases.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
Validated locally from `contract/` with `cargo fmt --all`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings`.
