### PR TITLE
Loyalty Discount Cap Validation

### DIFF
--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -639,10 +639,13 @@ impl TicketPaymentContract {
             .unwrap_or(0);
 
         let loyalty_discount_amount = if loyalty_discount_bps > 0 {
-            total_platform_fee
-                .checked_mul(loyalty_discount_bps as i128)
-                .and_then(|v| v.checked_div(10000))
-                .ok_or(TicketPaymentError::ArithmeticError)?
+            core::cmp::min(
+                total_platform_fee
+                    .checked_mul(loyalty_discount_bps as i128)
+                    .and_then(|v| v.checked_div(10000))
+                    .ok_or(TicketPaymentError::ArithmeticError)?,
+                total_platform_fee,
+            )
         } else {
             0
         };

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -4105,6 +4105,129 @@ impl MockEventRegistryWithLoyalty {
     }
 }
 
+#[soroban_sdk::contract]
+pub struct MockEventRegistryWithExcessiveLoyaltyDiscount;
+
+#[soroban_sdk::contractimpl]
+impl MockEventRegistryWithExcessiveLoyaltyDiscount {
+    pub fn get_event(env: Env, event_id: String) -> Option<event_registry::EventInfo> {
+        Some(event_registry::EventInfo {
+            event_id,
+            organizer_address: Address::generate(&env),
+            payment_address: Address::generate(&env),
+            platform_fee_percent: 500,
+            custom_fee_bps: None,
+            is_active: true,
+            status: event_registry::EventStatus::Active,
+            created_at: 0,
+            metadata_cid: String::from_str(
+                &env,
+                "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+            ),
+            max_supply: 0,
+            current_supply: 0,
+            milestone_plan: None,
+            tiers: {
+                let mut tiers = soroban_sdk::Map::new(&env);
+                tiers.set(
+                    String::from_str(&env, "tier_1"),
+                    event_registry::TicketTier {
+                        name: String::from_str(&env, "General"),
+                        price: 1000_0000000i128,
+                        early_bird_price: 1000_0000000i128,
+                        early_bird_deadline: 0,
+                        usd_price: 0,
+                        tier_limit: 100,
+                        current_sold: 0,
+                        is_refundable: true,
+                        auction_config: soroban_sdk::vec![&env],
+                    },
+                );
+                tiers
+            },
+            refund_deadline: 0,
+            restocking_fee: 0,
+            resale_cap_bps: None,
+            min_sales_target: 0,
+            target_deadline: 0,
+            goal_met: false,
+        })
+    }
+    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn get_global_promo_bps(_env: Env) -> u32 {
+        0
+    }
+    pub fn get_promo_expiry(_env: Env) -> u64 {
+        0
+    }
+    pub fn get_loyalty_discount_bps(_env: Env, _guest: Address) -> u32 {
+        20_000
+    }
+    pub fn update_loyalty_score(
+        _env: Env,
+        _caller: Address,
+        _guest: Address,
+        _tickets: u32,
+        _amount: i128,
+    ) {
+    }
+    pub fn get_guest_profile(_env: Env, _guest: Address) -> Option<event_registry::GuestProfile> {
+        None
+    }
+    pub fn get_event_payment_info(env: Env, _event_id: String) -> event_registry::PaymentInfo {
+        event_registry::PaymentInfo {
+            payment_address: Address::generate(&env),
+            platform_fee_percent: 500,
+            custom_fee_bps: None,
+        }
+    }
+}
+
+#[test]
+fn test_loyalty_discount_is_capped_by_platform_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TicketPaymentContract, ());
+    let client = TicketPaymentContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let platform_wallet = Address::generate(&env);
+    let registry_id = env.register(MockEventRegistryWithExcessiveLoyaltyDiscount, ());
+
+    client.initialize(&admin, &usdc_id, &platform_wallet, &registry_id);
+
+    let buyer = Address::generate(&env);
+    let price = 1000_0000000i128;
+
+    let usdc_token = token::StellarAssetClient::new(&env, &usdc_id);
+    usdc_token.mint(&buyer, &price);
+    token::Client::new(&env, &usdc_id).approve(&buyer, &client.address, &price, &99999);
+
+    let payment_id = String::from_str(&env, "pay_loyalty_cap");
+    client.process_payment(
+        &payment_id,
+        &String::from_str(&env, "event_1"),
+        &String::from_str(&env, "tier_1"),
+        &buyer,
+        &usdc_id,
+        &price,
+        &1,
+        &None,
+        &None,
+    );
+
+    let payment = client.get_payment_status(&payment_id).unwrap();
+    assert_eq!(payment.platform_fee, 0);
+    assert_eq!(payment.organizer_amount, 950_0000000i128);
+
+    let remaining = token::Client::new(&env, &usdc_id).balance(&buyer);
+    assert_eq!(remaining, 50_0000000i128);
+}
+
 #[test]
 fn test_loyalty_discount_reduces_platform_fee() {
     let env = Env::default();


### PR DESCRIPTION
## Description
Cap loyalty discounts so they can never reduce the computed platform fee below zero during payment processing.
Closes #197
## Changes proposed
### What were you told to do?
Verify that loyalty_discount_bps never exceeds the platform fee during calculation, add the guard in process_payment, cover a high loyalty-score scenario with tests, and keep CI green.
### What did I do?
#### Loyalty Fee Guard
- Capped the computed loyalty discount amount at the current platform-fee amount inside `process_payment`.
- Preserved the existing payment flow so buyers can still receive up to a full platform-fee waiver, but never more than that.
#### Regression Coverage
- Added a mock-registry test that returns an oversized loyalty discount and verifies payment still succeeds.
- Asserted the fee drops to zero, organizer proceeds stay correct, and the buyer is charged only the ticket price minus the platform fee.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
Validated locally from `contract/` with `cargo fmt --all`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings`.
