### PR TITLE
Loyalty Points Best-Effort Error Handling

### DIFF
--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -789,12 +789,14 @@ impl TicketPaymentContract {
         );
 
         // 8a. Award loyalty points to buyer (best-effort; ignore failures)
-        let _ = registry_client_promo.try_update_loyalty_score(
+        match registry_client_promo.try_update_loyalty_score(
             &env.current_contract_address(),
             &buyer_address,
             &quantity,
             &effective_total,
-        );
+        ) {
+            Ok(_) | Err(_) => {}
+        }
 
         // 9. Emit discount applied event if a code was used
         if let Some(hash) = discount_code_hash {

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -4024,6 +4024,129 @@ fn test_governance_unauthorized_propose_and_vote() {
 // Loyalty Discount Integration Tests
 // ════════════════════════════════════════════════════════════════
 
+#[soroban_sdk::contract]
+pub struct MockEventRegistryWithFailingLoyaltyUpdate;
+
+#[soroban_sdk::contractimpl]
+impl MockEventRegistryWithFailingLoyaltyUpdate {
+    pub fn get_event(env: Env, event_id: String) -> Option<event_registry::EventInfo> {
+        Some(event_registry::EventInfo {
+            event_id,
+            organizer_address: Address::generate(&env),
+            payment_address: Address::generate(&env),
+            platform_fee_percent: 500,
+            custom_fee_bps: None,
+            is_active: true,
+            status: event_registry::EventStatus::Active,
+            created_at: 0,
+            metadata_cid: String::from_str(
+                &env,
+                "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+            ),
+            max_supply: 0,
+            current_supply: 0,
+            milestone_plan: None,
+            tiers: {
+                let mut tiers = soroban_sdk::Map::new(&env);
+                tiers.set(
+                    String::from_str(&env, "tier_1"),
+                    event_registry::TicketTier {
+                        name: String::from_str(&env, "General"),
+                        price: 1000_0000000i128,
+                        early_bird_price: 1000_0000000i128,
+                        early_bird_deadline: 0,
+                        usd_price: 0,
+                        tier_limit: 100,
+                        current_sold: 0,
+                        is_refundable: true,
+                        auction_config: soroban_sdk::vec![&env],
+                    },
+                );
+                tiers
+            },
+            refund_deadline: 0,
+            restocking_fee: 0,
+            resale_cap_bps: None,
+            min_sales_target: 0,
+            target_deadline: 0,
+            goal_met: false,
+        })
+    }
+    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn get_global_promo_bps(_env: Env) -> u32 {
+        0
+    }
+    pub fn get_promo_expiry(_env: Env) -> u64 {
+        0
+    }
+    pub fn get_loyalty_discount_bps(_env: Env, _guest: Address) -> u32 {
+        0
+    }
+    pub fn update_loyalty_score(
+        _env: Env,
+        _caller: Address,
+        _guest: Address,
+        _tickets: u32,
+        _amount: i128,
+    ) {
+        panic!("simulated registry failure");
+    }
+    pub fn get_guest_profile(_env: Env, _guest: Address) -> Option<event_registry::GuestProfile> {
+        None
+    }
+    pub fn get_event_payment_info(env: Env, _event_id: String) -> event_registry::PaymentInfo {
+        event_registry::PaymentInfo {
+            payment_address: Address::generate(&env),
+            platform_fee_percent: 500,
+            custom_fee_bps: None,
+        }
+    }
+}
+
+#[test]
+fn test_process_payment_ignores_loyalty_update_failure() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TicketPaymentContract, ());
+    let client = TicketPaymentContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let platform_wallet = Address::generate(&env);
+    let registry_id = env.register(MockEventRegistryWithFailingLoyaltyUpdate, ());
+
+    client.initialize(&admin, &usdc_id, &platform_wallet, &registry_id);
+
+    let buyer = Address::generate(&env);
+    let price = 1000_0000000i128;
+
+    let usdc_token = token::StellarAssetClient::new(&env, &usdc_id);
+    usdc_token.mint(&buyer, &price);
+    token::Client::new(&env, &usdc_id).approve(&buyer, &client.address, &price, &99999);
+
+    let payment_id = String::from_str(&env, "pay_loyalty_fail");
+    let result = client.try_process_payment(
+        &payment_id,
+        &String::from_str(&env, "event_1"),
+        &String::from_str(&env, "tier_1"),
+        &buyer,
+        &usdc_id,
+        &price,
+        &1,
+        &None,
+        &None,
+    );
+    assert_eq!(result, Ok(Ok(payment_id.clone())));
+
+    let payment = client.get_payment_status(&payment_id).unwrap();
+    assert_eq!(payment.amount, price);
+    assert_eq!(payment.platform_fee, 50_0000000i128);
+    assert_eq!(payment.organizer_amount, 950_0000000i128);
+}
+
 /// Mock event registry that returns a loyalty discount (1000 bps = 10%)
 /// for buyers, simulating a high-loyalty-score guest.
 #[soroban_sdk::contract]


### PR DESCRIPTION
## Description
Make loyalty point updates explicitly best-effort so payment completion is not blocked by registry-side failures.
Closes #226
## Changes proposed
### What were you told to do?
Ensure that if `update_loyalty_score` fails, payment processing still succeeds, add a test that simulates registry failure during payment, and keep CI green.
### What did I do?
#### Best-Effort Loyalty Update
- Wrapped the `try_update_loyalty_score` call in an explicit `match` that ignores both success and failure outcomes.
- Kept the payment path unchanged so funds, inventory, and payment records complete before loyalty side effects are attempted.
#### Regression Coverage
- Added a mock event registry whose `update_loyalty_score` call fails deliberately.
- Verified that `process_payment` still returns success and stores the expected payment amounts even when the loyalty update traps.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
Validated locally from `contract/` with `cargo fmt --all`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings`.
