### PR TITLE
Refine tier error messages for TierNotFound and TierSupplyExceeded

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -75,10 +75,13 @@ impl core::fmt::Display for EventRegistryError {
                 write!(f, "Sum of tier limits exceeds event max supply")
             }
             EventRegistryError::TierNotFound => {
-                write!(f, "Ticket tier not found")
+                write!(f, "The specified ticket tier does not exist for this event")
             }
             EventRegistryError::TierSupplyExceeded => {
-                write!(f, "Tier has reached its maximum supply")
+                write!(
+                    f,
+                    "Cannot purchase tickets: the requested tier has reached its maximum supply limit"
+                )
             }
             EventRegistryError::SupplyUnderflow => {
                 write!(f, "Supply counter underflow")

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -2733,3 +2733,27 @@ fn test_non_admin_cannot_add_token_to_whitelist() {
     let client2 = EventRegistryClient::new(&env2, &contract_id);
     client2.add_to_token_whitelist(&new_token);
 }
+
+// ── Display message tests for refined tier error messages ────────────────────
+
+extern crate alloc;
+
+#[test]
+fn test_tier_not_found_display() {
+    let err = EventRegistryError::TierNotFound;
+    let msg = alloc::format!("{}", err);
+    assert_eq!(
+        msg,
+        "The specified ticket tier does not exist for this event"
+    );
+}
+
+#[test]
+fn test_tier_supply_exceeded_display() {
+    let err = EventRegistryError::TierSupplyExceeded;
+    let msg = alloc::format!("{}", err);
+    assert_eq!(
+        msg,
+        "Cannot purchase tickets: the requested tier has reached its maximum supply limit"
+    );
+}


### PR DESCRIPTION
This change touches the `Display` implementation for `EventRegistryError` in `contract/contracts/event_registry/src/error.rs`, specifically the `TierNotFound` and `TierSupplyExceeded` arms. The previous messages were terse one-liners (`"Ticket tier not found"` and `"Tier has reached its maximum supply"`) that gave callers almost no actionable context about what went wrong or what object was involved. The new strings spell out the situation clearly: `TierNotFound` now reads *"The specified ticket tier does not exist for this event"*, anchoring the error to the event scope, and `TierSupplyExceeded` now reads *"Cannot purchase tickets: the requested tier has reached its maximum supply limit"*, which front-loads the failed action so a frontend or CLI consumer can surface it directly to end users without rewording.

The design choice was intentional: each message leads with the domain concept the caller cares about (the tier's existence, the purchase action) rather than a generic label, and avoids embedding IDs or dynamic values that would complicate localization or log grep-ability down the road. Keeping the strings static also means no extra runtime allocation beyond what `write!` already does, so the change is purely cosmetic from a performance standpoint.

Two dedicated unit tests were added in `contract/contracts/event_registry/src/test.rs` — `test_tier_not_found_display` and `test_tier_supply_exceeded_display` — each constructing the error variant, formatting it via `alloc::format!`, and asserting the exact expected string. I ran `cargo test` locally against the `event_registry` contract crate and confirmed both new tests pass with no panics and no regressions in the existing suite.

Closes https://github.com/Agora-Events/agora/issues/194