### PR TITLE
feat(ticket-payment): add post-upgrade state verification #208

### DIFF
--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -25,14 +25,17 @@ use crate::{
     error::TicketPaymentError,
     events::{
         AgoraEvent, AuctionClosedEvent, BidPlacedEvent, BulkRefundProcessedEvent,
-        ContractPausedEvent, ContractUpgraded, DiscountCodeAppliedEvent, DisputeStatusChangedEvent,
-        FeeSettledEvent, GlobalPromoAppliedEvent, GovernanceActionExecutedEvent,
-        InitializationEvent, PartialRefundProcessedEvent, PaymentProcessedEvent,
-        PaymentStatusChangedEvent, PriceSwitchedEvent, ProposalCreatedEvent, ProposalVotedEvent,
-        RevenueClaimedEvent, TicketTransferredEvent,
+        ContractPausedEvent, ContractUpgraded, ContractVerificationFailedEvent,
+        DiscountCodeAppliedEvent, DisputeStatusChangedEvent, FeeSettledEvent,
+        GlobalPromoAppliedEvent, GovernanceActionExecutedEvent, InitializationEvent,
+        PartialRefundProcessedEvent, PaymentProcessedEvent, PaymentStatusChangedEvent,
+        PriceSwitchedEvent, ProposalCreatedEvent, ProposalVotedEvent, RevenueClaimedEvent,
+        TicketTransferredEvent,
     },
 };
-use soroban_sdk::{contract, contractimpl, token, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{
+    contract, contractimpl, token, Address, Bytes, BytesN, Env, String, Symbol, Vec,
+};
 
 // Price Oracle interface
 pub mod price_oracle {
@@ -275,6 +278,33 @@ impl TicketPaymentContract {
                 new_wasm_hash,
             },
         );
+
+        // Post-upgrade state verification
+        let mut missing_keys = soroban_sdk::Vec::new(&env);
+        if !env.storage().persistent().has(&DataKey::Admin) {
+            missing_keys.push_back(String::from_str(&env, "Admin"));
+        }
+        if !env.storage().persistent().has(&DataKey::UsdcToken) {
+            missing_keys.push_back(String::from_str(&env, "UsdcToken"));
+        }
+        if !env.storage().persistent().has(&DataKey::PlatformWallet) {
+            missing_keys.push_back(String::from_str(&env, "PlatformWallet"));
+        }
+        if !env.storage().persistent().has(&DataKey::EventRegistry) {
+            missing_keys.push_back(String::from_str(&env, "EventRegistry"));
+        }
+
+        if !missing_keys.is_empty() {
+            for key in missing_keys.iter() {
+                env.events().publish(
+                    (Symbol::new(&env, "ContractVerificationFailed"),),
+                    ContractVerificationFailedEvent {
+                        missing_key: key,
+                        timestamp: env.ledger().timestamp(),
+                    },
+                );
+            }
+        }
     }
 
     /// Proposes a parameter change for the platform. Only callable by a governor.

--- a/contract/contracts/ticket_payment/src/events.rs
+++ b/contract/contracts/ticket_payment/src/events.rs
@@ -24,6 +24,7 @@ pub enum AgoraEvent {
     ProposalCreated,
     ProposalVoted,
     GovernanceActionExecuted,
+    ContractVerificationFailed,
 }
 
 #[contracttype]
@@ -204,5 +205,12 @@ pub struct ProposalVotedEvent {
 pub struct GovernanceActionExecutedEvent {
     pub proposal_id: u64,
     pub change: crate::types::ParameterChange,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractVerificationFailedEvent {
+    pub missing_key: String,
     pub timestamp: u64,
 }

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -2,7 +2,7 @@ use super::contract::{
     event_registry, price_oracle, TicketPaymentContract, TicketPaymentContractClient,
 };
 use super::storage::*;
-use super::types::{ParameterChange, Payment, PaymentStatus};
+use super::types::{DataKey, ParameterChange, Payment, PaymentStatus};
 use crate::error::TicketPaymentError;
 use soroban_sdk::{
     testutils::{Address as _, EnvTestConfig, Events, Ledger},
@@ -753,6 +753,43 @@ fn test_upgrade_preserves_initialization_addresses_and_emits_event() {
         });
         assert!(upgraded_event.is_some());
     }
+}
+
+#[test]
+fn test_upgrade_verification_failure() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, _, _, _) = setup_test(&env);
+
+    let dummy_id = env.register(DummyUpgradeable, ());
+    let new_wasm_hash = match dummy_id.executable() {
+        Some(soroban_sdk::Executable::Wasm(hash)) => hash,
+        _ => panic!("Dummy contract is not a Wasm contract"),
+    };
+
+    // Simulate losing a key during upgrade (this is artificial for testing the verification logic)
+    env.as_contract(&client.address, || {
+        env.storage().persistent().remove(&DataKey::EventRegistry);
+    });
+
+    client.upgrade(&new_wasm_hash);
+
+    // Check for ContractVerificationFailed event
+    let events = env.events().all();
+    let topic_name = Symbol::new(&env, "ContractVerificationFailed");
+    let failure_event = events.iter().find(|e| {
+        for t in e.1.iter() {
+            let s_res: Result<Symbol, _> = t.clone().try_into_val(&env);
+            if let Ok(s) = s_res {
+                if s == topic_name {
+                    return true;
+                }
+            }
+        }
+        false
+    });
+    assert!(failure_event.is_some());
 }
 
 #[test]


### PR DESCRIPTION
Implementation:
- Added ContractVerificationFailed event to events.rs.
- Updated upgrade function in contract.rs to verify critical storage keys (Admin, UsdcToken, PlatformWallet, EventRegistry) after WASM update.
- Emits ContractVerificationFailed event for each missing key.

Testing:
- Added test_upgrade_verification_failure to test.rs.
- Verified that normal upgrades still pass and preserve addresses.
- Passed cargo fmt and cargo clippy.

Closes #208 