### PR TITLE
test(event-registry): verify platform fee bps limit #198

### DIFF
--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -3840,3 +3840,24 @@ fn test_active_proposals_list() {
     assert!(!active_proposals.contains(proposal_id1));
     assert!(active_proposals.contains(proposal_id2));
 }
+
+#[test]
+fn test_set_platform_fee_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    // Set to 100% (10000 bps) - should pass
+    client.set_platform_fee(&10000);
+    assert_eq!(client.get_platform_fee(), 10000);
+
+    // Set to 100.01% (10001 bps) - should fail
+    let result = client.try_set_platform_fee(&10001);
+    assert_eq!(result, Err(Ok(EventRegistryError::InvalidFeePercent)));
+}


### PR DESCRIPTION
Verified that platform fee cannot exceed 10,000 bps (100%). The check was already present in EventRegistry::set_platform_fee but added test_set_platform_fee_boundary to ensure it's correctly enforced.

Closes #198 