### PR TITLE
feat(contract): add is_paused public view function

### DIFF
--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -237,7 +237,12 @@ impl TicketPaymentContract {
         is_paused(&env)
     }
 
-    /// Sets or clears a dispute for an event. Only callable by admin.
+    /// Returns true if the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        is_paused(&env)
+    }
+
+    /// Sets or clears a dispute for an event.
     pub fn set_event_dispute(
         env: Env,
         event_id: String,

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -3435,6 +3435,19 @@ fn test_set_pause_and_resume() {
 }
 
 #[test]
+fn test_is_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _, _, _) = setup_test(&env);
+
+    assert!(!client.is_paused());
+    client.set_pause(&true);
+    assert!(client.is_paused());
+    client.set_pause(&false);
+    assert!(!client.is_paused());
+}
+
+#[test]
 fn test_process_payment_paused() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #321

Adds the is_paused() public view function to TicketPaymentContract, following the same pattern used by is_event_disputed(). The method delegates to the storage-layer is_paused helper.

The existing get_is_paused() is kept for backwards compatibility.
