### PR TITLE
feat(contract): add set_multisig_config with threshold validation

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -69,6 +69,8 @@ pub enum EventRegistryError {
     InsufficientApprovals = 40,
     /// Target deadline must be in the future
     InvalidTargetDeadline = 44,
+    /// Admin has already approved this proposal
+    AlreadyApproved = 45,
 }
 
 impl core::fmt::Display for EventRegistryError {
@@ -206,6 +208,9 @@ impl core::fmt::Display for EventRegistryError {
             }
             EventRegistryError::InvalidTargetDeadline => {
                 write!(f, "Target deadline must be in the future")
+            }
+            EventRegistryError::AlreadyApproved => {
+                write!(f, "Admin has already approved this proposal")
             }
         }
     }

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -1394,6 +1394,55 @@ impl EventRegistry {
         }
     }
 
+    /// Sets the multi-sig configuration directly. Only callable by an existing admin.
+    ///
+    /// Validates that:
+    /// - `new_admins` is not empty
+    /// - All addresses in `new_admins` are valid
+    /// - `new_threshold` is at least 1
+    /// - `new_threshold` is not greater than the total number of admins
+    ///
+    /// # Arguments
+    /// * `caller` - An existing admin authorizing this change
+    /// * `new_admins` - The new list of admin addresses
+    /// * `new_threshold` - The new approval threshold
+    pub fn set_multisig_config(
+        env: Env,
+        caller: Address,
+        new_admins: Vec<Address>,
+        new_threshold: u32,
+    ) -> Result<(), EventRegistryError> {
+        caller.require_auth();
+
+        let config =
+            storage::get_multisig_config(&env).ok_or(EventRegistryError::NotInitialized)?;
+
+        if !config.admins.contains(&caller) {
+            return Err(EventRegistryError::Unauthorized);
+        }
+
+        if new_admins.is_empty() {
+            return Err(EventRegistryError::CannotRemoveLastAdmin);
+        }
+
+        for addr in new_admins.iter() {
+            validate_address(&env, &addr)?;
+        }
+
+        if new_threshold == 0 || new_threshold > new_admins.len() {
+            return Err(EventRegistryError::InvalidThreshold);
+        }
+
+        let multisig_config = MultiSigConfig {
+            admins: new_admins,
+            threshold: new_threshold,
+        };
+
+        storage::set_multisig_config(&env, &multisig_config);
+
+        Ok(())
+    }
+
     /// Proposes a parameter change. Only callable by an existing admin.
     /// The proposer automatically approves the proposal.
     ///
@@ -1569,7 +1618,7 @@ impl EventRegistry {
 
         // Check if already approved by this admin
         if proposal.approvals.contains(&approver) {
-            return Ok(()); // Already approved, no-op
+            return Err(EventRegistryError::AlreadyApproved);
         }
 
         // Add approval
@@ -1745,6 +1794,5 @@ mod test;
 #[cfg(test)]
 mod test_e2e;
 
-// TODO: Uncomment when multisig functions are implemented
-// #[cfg(test)]
-// mod test_multisig;
+#[cfg(test)]
+mod test_multisig;

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -552,6 +552,10 @@ fn test_register_event_invalid_target_deadline() {
         },
     );
 
+    // Advance ledger timestamp so `now - 1` does not underflow
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
     let now = env.ledger().timestamp();
 
     // Past deadline should fail

--- a/contract/contracts/event_registry/src/test_multisig.rs
+++ b/contract/contracts/event_registry/src/test_multisig.rs
@@ -42,7 +42,7 @@ fn test_create_proposal_add_admin() {
     let proposal_id = client.propose_add_admin(&admin1, &admin2, &0);
 
     // Verify proposal was created
-    let proposal = client.get_proposal(&proposal_id);
+    let proposal = client.get_proposal(&proposal_id).unwrap();
     assert_eq!(proposal.proposal_id, proposal_id);
     assert_eq!(proposal.proposer, admin1);
     assert_eq!(proposal.approvals.len(), 1); // Proposer auto-approves
@@ -65,7 +65,7 @@ fn test_execute_proposal_single_admin() {
     assert!(client.is_admin(&admin2));
 
     // Verify proposal was marked as executed
-    let proposal = client.get_proposal(&proposal_id);
+    let proposal = client.get_proposal(&proposal_id).unwrap();
     assert!(proposal.executed);
 }
 
@@ -172,7 +172,7 @@ fn test_remove_admin_with_multisig() {
 }
 
 #[test]
-#[should_panic(expected = "CannotRemoveLastAdmin")]
+#[should_panic(expected = "Error(Contract, #35)")]
 fn test_cannot_remove_last_admin() {
     let (env, client, admin1, _, _) = create_test_env();
     let platform_wallet = Address::generate(&env);
@@ -185,7 +185,7 @@ fn test_cannot_remove_last_admin() {
 }
 
 #[test]
-#[should_panic(expected = "AdminAlreadyExists")]
+#[should_panic(expected = "Error(Contract, #33)")]
 fn test_cannot_add_duplicate_admin() {
     let (env, client, admin1, _, _) = create_test_env();
     let platform_wallet = Address::generate(&env);
@@ -198,7 +198,7 @@ fn test_cannot_add_duplicate_admin() {
 }
 
 #[test]
-#[should_panic(expected = "AlreadyApproved")]
+#[should_panic(expected = "Error(Contract, #45)")]
 fn test_cannot_approve_twice() {
     let (env, client, admin1, admin2, admin3) = create_test_env();
     let platform_wallet = Address::generate(&env);
@@ -222,7 +222,7 @@ fn test_cannot_approve_twice() {
 }
 
 #[test]
-#[should_panic(expected = "ProposalAlreadyExecuted")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_cannot_execute_twice() {
     let (env, client, admin1, admin2, _) = create_test_env();
     let platform_wallet = Address::generate(&env);
@@ -239,7 +239,7 @@ fn test_cannot_execute_twice() {
 }
 
 #[test]
-#[should_panic(expected = "InvalidThreshold")]
+#[should_panic(expected = "Error(Contract, #36)")]
 fn test_invalid_threshold_too_high() {
     let (env, client, admin1, _, _) = create_test_env();
     let platform_wallet = Address::generate(&env);
@@ -252,7 +252,7 @@ fn test_invalid_threshold_too_high() {
 }
 
 #[test]
-#[should_panic(expected = "InvalidThreshold")]
+#[should_panic(expected = "Error(Contract, #36)")]
 fn test_invalid_threshold_zero() {
     let (env, client, admin1, _, _) = create_test_env();
     let platform_wallet = Address::generate(&env);
@@ -348,4 +348,49 @@ fn test_threshold_adjustment_on_admin_removal() {
     let config = client.get_multisig_config();
     assert_eq!(config.admins.len(), 2);
     assert_eq!(config.threshold, 2);
+}
+
+#[test]
+fn test_set_multisig_config_valid() {
+    let (env, client, admin1, admin2, admin3) = create_test_env();
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin1, &platform_wallet, &500, &usdc_token);
+
+    // Set a new multi-sig config with 3 admins and threshold of 2
+    let new_admins = soroban_sdk::vec![&env, admin1.clone(), admin2.clone(), admin3.clone()];
+    client.set_multisig_config(&admin1, &new_admins, &2);
+
+    let config = client.get_multisig_config();
+    assert_eq!(config.admins.len(), 3);
+    assert_eq!(config.threshold, 2);
+    assert!(client.is_admin(&admin1));
+    assert!(client.is_admin(&admin2));
+    assert!(client.is_admin(&admin3));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #36)")]
+fn test_set_multisig_config_invalid_threshold_zero() {
+    let (env, client, admin1, admin2, _) = create_test_env();
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin1, &platform_wallet, &500, &usdc_token);
+
+    // threshold = 0 should fail
+    let new_admins = soroban_sdk::vec![&env, admin1.clone(), admin2.clone()];
+    client.set_multisig_config(&admin1, &new_admins, &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #36)")]
+fn test_set_multisig_config_invalid_threshold_too_high() {
+    let (env, client, admin1, admin2, _) = create_test_env();
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin1, &platform_wallet, &500, &usdc_token);
+
+    // threshold = 5 > 2 admins should fail
+    let new_admins = soroban_sdk::vec![&env, admin1.clone(), admin2.clone()];
+    client.set_multisig_config(&admin1, &new_admins, &5);
 }


### PR DESCRIPTION
## Summary

Closes #222

Adds `set_multisig_config` to the event registry contract with explicit
validation ensuring the multi-sig threshold is always at least 1 and never
exceeds the total number of admins.

## Changes

### `set_multisig_config` (new function — `lib.rs`)
- Callable only by an existing admin (`require_auth`)
- Validates all new admin addresses are non-zero / non-contract
- Returns `InvalidThreshold` if `new_threshold == 0`
- Returns `InvalidThreshold` if `new_threshold > new_admins.len()`
- Returns `CannotRemoveLastAdmin` if `new_admins` is empty
- Updates the multi-sig config atomically in persistent storage

### Supporting fixes
- Added `AlreadyApproved = 45` error variant (`error.rs`) — `approve_proposal`
  now correctly returns this error on a duplicate approval instead of silently
  no-op'ing
- Uncommented `mod test_multisig` — the TODO note said to enable it once
  multisig functions were implemented; `set_multisig_config` fulfils that
- Fixed pre-existing compile errors in `test_multisig.rs` (`Option<Proposal>`
  field access without `.unwrap()`, incorrect `#[should_panic(expected = …)]`
  strings — Soroban surfaces errors as `Error(Contract, #N)`, not by name)
- Fixed pre-existing `u64` underflow in `test_register_event_invalid_target_deadline`
  by advancing the ledger timestamp before computing `now - 1`

## Tests

Three new tests in `test_multisig.rs`:

| Test | Asserts |
|---|---|
| `test_set_multisig_config_valid` | 3-admin config with threshold 2 is accepted |
| `test_set_multisig_config_invalid_threshold_zero` | threshold = 0 → `InvalidThreshold` |
| `test_set_multisig_config_invalid_threshold_too_high` | threshold > admin count → `InvalidThreshold` |

<img width="605" height="238" alt="Screenshot 2026-03-28 at 7 12 20 PM" src="https://github.com/user-attachments/assets/62f6354b-19f7-4d5b-8875-5a5734cac50f" />
