### PR TITLE
feat: add InvalidFeeCalculation to the EventRegistryError enum

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -9,6 +9,7 @@ pub enum EventRegistryError {
     Unauthorized = 3,
     InvalidAddress = 4,
     InvalidFeePercent = 5,
+    InvalidFeeCalculation = 46,
     EventInactive = 6,
     NotInitialized = 7,
     AlreadyInitialized = 8,
@@ -82,6 +83,9 @@ impl core::fmt::Display for EventRegistryError {
             EventRegistryError::InvalidAddress => write!(f, "Invalid Stellar address"),
             EventRegistryError::InvalidFeePercent => {
                 write!(f, "Fee percent must be between 0 and 10000")
+            }
+            EventRegistryError::InvalidFeeCalculation => {
+                write!(f, "Fee calculation failed due to invalid arithmetic inputs")
             }
             EventRegistryError::EventInactive => {
                 write!(f, "Trying to interact with inactive event")

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -240,14 +240,7 @@ impl EventRegistry {
             }
         }
 
-        // Validate restocking fee does not exceed any tier's ticket price
-        if args.restocking_fee > 0 {
-            for tier in args.tiers.values() {
-                if args.restocking_fee > tier.price {
-                    return Err(EventRegistryError::RestockingFeeExceedsTicketPrice);
-                }
-            }
-        }
+        validate_restocking_fee(&args)?;
 
         // Validate milestone plan: total release_percent must not exceed 10000 bps (100%)
         if let Some(ref milestones) = args.milestone_plan {
@@ -1763,6 +1756,29 @@ fn validate_metadata_cid(env: &Env, cid: &String) -> Result<(), EventRegistryErr
 
     if !bytes.is_empty() && bytes.get(0) != Some(b'b') {
         return Err(EventRegistryError::InvalidMetadataCid);
+    }
+
+    Ok(())
+}
+
+fn validate_restocking_fee(args: &EventRegistrationArgs) -> Result<(), EventRegistryError> {
+    if args.restocking_fee < 0 {
+        return Err(EventRegistryError::InvalidFeeCalculation);
+    }
+
+    if args.restocking_fee == 0 {
+        return Ok(());
+    }
+
+    for tier in args.tiers.values() {
+        let remaining_refund = tier
+            .price
+            .checked_sub(args.restocking_fee)
+            .ok_or(EventRegistryError::InvalidFeeCalculation)?;
+
+        if remaining_refund < 0 {
+            return Err(EventRegistryError::RestockingFeeExceedsTicketPrice);
+        }
     }
 
     Ok(())

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -4403,6 +4403,56 @@ fn test_register_event_restocking_fee_zero_always_valid() {
 }
 
 #[test]
+fn test_register_event_restocking_fee_overflow_returns_invalid_fee_calculation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    let organizer = Address::generate(&env);
+    let mut tiers = Map::new(&env);
+    tiers.set(
+        String::from_str(&env, "general"),
+        TicketTier {
+            name: String::from_str(&env, "General"),
+            price: i128::MIN,
+            tier_limit: 50,
+            current_sold: 0,
+            is_refundable: true,
+            auction_config: soroban_sdk::vec![&env],
+        },
+    );
+
+    let result = client.try_register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_restocking_overflow"),
+        organizer_address: organizer.clone(),
+        payment_address: test_payment_address(&env),
+        metadata_cid: String::from_str(
+            &env,
+            "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ),
+        max_supply: 50,
+        milestone_plan: None,
+        tiers,
+        refund_deadline: 0,
+        restocking_fee: 1,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+        banner_cid: None,
+        tags: None,
+    });
+
+    assert_eq!(result, Err(Ok(EventRegistryError::InvalidFeeCalculation)));
+}
+
+#[test]
 fn test_restocking_fee_exceeds_ticket_price_error_message() {
     let buf = fmt_to_str(EventRegistryError::RestockingFeeExceedsTicketPrice);
     assert!(


### PR DESCRIPTION
## Summary

This PR improves fee-related error handling in the `event_registry` contract by introducing a dedicated `InvalidFeeCalculation` error instead of relying on generic arithmetic failures.

## Changes

- Added `InvalidFeeCalculation` to `EventRegistryError`
- Updated fee validation in `lib.rs` to return `InvalidFeeCalculation` for invalid fee arithmetic inputs
- Kept the existing `RestockingFeeExceedsTicketPrice` behavior for normal over-limit cases
- Added a unit test that intentionally triggers the new fee-calculation error path

## Why

Previously, certain fee-validation edge cases could surface as generic arithmetic errors, which made debugging harder. This change makes fee-related failures more explicit and easier for developers to understand.

## Testing

- `cargo test -p event-registry`
- `cargo fmt --check`

Closes #312 