### PR TITLE
feat: add get_organizer_address helper to EventRegistry contract

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -505,15 +505,9 @@ impl EventRegistry {
         storage::get_event(&env, event_id)
     }
 
-    /// Returns the organizer address for a given event ID.
-    /// Returns `EventNotFound` if the event does not exist.
-    pub fn get_organizer_address(
-        env: Env,
-        event_id: String,
-    ) -> Result<Address, EventRegistryError> {
-        storage::get_event(&env, event_id)
-            .map(|e| e.organizer_address)
-            .ok_or(EventRegistryError::EventNotFound)
+    /// Returns the organizer address for a given event ID, or `None` if the event does not exist.
+    pub fn get_organizer_address(env: Env, event_id: String) -> Option<Address> {
+        storage::get_event(&env, event_id).map(|e| e.organizer_address)
     }
 
     /// Returns the total number of tickets sold for an event across all tiers.
@@ -1030,7 +1024,8 @@ impl EventRegistry {
         event_id: String,
         scanner: Address,
     ) -> Result<(), EventRegistryError> {
-        let organizer = Self::get_organizer_address(env.clone(), event_id.clone())?;
+        let organizer = Self::get_organizer_address(env.clone(), event_id.clone())
+            .ok_or(EventRegistryError::EventNotFound)?;
         organizer.require_auth();
 
         storage::authorize_scanner(&env, event_id.clone(), &scanner);

--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -102,7 +102,7 @@ pub mod event_registry {
     pub trait EventRegistryInterface {
         fn get_event_payment_info(env: Env, event_id: String) -> PaymentInfo;
         fn get_event(env: Env, event_id: String) -> Option<EventInfo>;
-        fn get_organizer_address(env: Env, event_id: String) -> Result<Address, ()>;
+        fn get_organizer_address(env: Env, event_id: String) -> Option<Address>;
         fn increment_inventory(env: Env, event_id: String, tier_id: String, quantity: u32);
         fn decrement_inventory(env: Env, event_id: String, tier_id: String);
         fn get_global_promo_bps(env: Env) -> u32;


### PR DESCRIPTION
Closes #319

---

## Summary

Centralizes organizer address lookup behind a dedicated public function on the `EventRegistry` contract.

## Changes

### `event_registry/src/lib.rs`
- Added `pub fn get_organizer_address(env, event_id) -> Result<Address, EventRegistryError>`
  - Returns `EventNotFound` if the event does not exist
- Refactored `authorize_scanner` to use the helper instead of fetching the full `EventInfo`

### `ticket_payment/src/contract.rs`
- Added `get_organizer_address` to the `EventRegistryInterface` trait for cross-contract use