### PR TITLE
[Contract] Add get_version function to contract #325

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -111,6 +111,7 @@ use crate::error::EventRegistryError;
 
 const MIN_METADATA_CID_LEN: u32 = 46;
 const MAX_METADATA_CID_LEN: u32 = 100;
+const VERSION: u32 = 1;
 
 #[contract]
 pub struct EventRegistry;
@@ -118,6 +119,11 @@ pub struct EventRegistry;
 #[contractimpl]
 #[allow(deprecated)]
 impl EventRegistry {
+    /// Returns the current version of the contract for off-chain services.
+    pub fn get_version(_env: Env) -> u32 {
+        VERSION
+    }
+
     /// Register a new series grouping multiple events
     pub fn register_series(
         env: Env,

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -15,6 +15,14 @@ fn test_payment_address(env: &Env) -> Address {
 }
 
 #[test]
+fn test_get_version() {
+    let env = Env::default();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    assert_eq!(client.get_version(), 1);
+}
+
+#[test]
 fn test_register_and_get_series() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Overview
This PR implements a public view function `get_version` for the `EventRegistry` contract, as requested in issue #325. This allows off-chain services to programmatically identify the contract's current version.

## Changes
- **Constant**: Added `const VERSION: u32 = 1;` to `event_registry/lib.rs`.
- **Function**: Implemented `get_version(env: Env) -> u32` in the `EventRegistry` contract.
- **Testing**: Added a unit test `test_get_version` to verify the functionality.

## Verification
Unit tests passed for the `event-registry` contract:
```bash
cargo test -p event-registry --lib test::test_get_version
# Result: ok. 1 passed; 0 failed
```

closes #325 