### PR TITLE
feat(contract): add post-event feedback CID support

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -72,6 +72,8 @@ pub enum EventRegistryError {
     InvalidTargetDeadline = 44,
     /// Admin has already approved this proposal
     AlreadyApproved = 45,
+    /// Event has not ended yet; feedback CID can only be set after end_time
+    EventNotEnded = 47,
 }
 
 impl core::fmt::Display for EventRegistryError {
@@ -215,6 +217,12 @@ impl core::fmt::Display for EventRegistryError {
             }
             EventRegistryError::AlreadyApproved => {
                 write!(f, "Admin has already approved this proposal")
+            }
+            EventRegistryError::EventNotEnded => {
+                write!(
+                    f,
+                    "Event has not ended yet; feedback CID can only be set after end_time"
+                )
             }
         }
     }

--- a/contract/contracts/event_registry/src/events.rs
+++ b/contract/contracts/event_registry/src/events.rs
@@ -55,6 +55,8 @@ pub enum AgoraEvent {
     /// A custom fee override has been set for a specific event by an admin.
     CustomFeeSet,
     AdminUpdated,
+    /// Post-event feedback CID has been set by the organizer after event end_time.
+    FeedbackCidSet,
 }
 
 /// Emitted when an event is permanently cancelled.
@@ -502,5 +504,21 @@ pub struct CustomFeeSetEvent {
 pub struct AdminUpdatedEvent {
     pub old_admin: Address,
     pub new_admin: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when a post-event feedback CID is set by the organizer after end_time.
+///
+/// Published with topic `(AgoraEvent::FeedbackCidSet,)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeedbackCidSetEvent {
+    /// The unique identifier of the event.
+    pub event_id: String,
+    /// The IPFS CID pointing to the post-event feedback content.
+    pub feedback_cid: String,
+    /// The organizer address that set the feedback CID.
+    pub updated_by: Address,
+    /// The ledger timestamp when the feedback CID was set.
     pub timestamp: u64,
 }

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -89,10 +89,10 @@ use crate::events::{
     AdminUpdatedEvent, AgoraEvent, CollateralStakedEvent, CollateralUnstakedEvent,
     CustomFeeSetEvent, EventArchivedEvent, EventCancelledEvent, EventPostponedEvent,
     EventRegisteredEvent, EventStatusUpdatedEvent, EventsSuspendedEvent, FeeUpdatedEvent,
-    GlobalPromoUpdatedEvent, GoalMetEvent, InitializationEvent, InventoryIncrementedEvent,
-    LoyaltyScoreUpdatedEvent, MetadataUpdatedEvent, OrganizerBlacklistedEvent,
-    OrganizerRemovedFromBlacklistEvent, RegistryUpgradedEvent, ScannerAuthorizedEvent,
-    StakerRewardsClaimedEvent, StakerRewardsDistributedEvent,
+    FeedbackCidSetEvent, GlobalPromoUpdatedEvent, GoalMetEvent, InitializationEvent,
+    InventoryIncrementedEvent, LoyaltyScoreUpdatedEvent, MetadataUpdatedEvent,
+    OrganizerBlacklistedEvent, OrganizerRemovedFromBlacklistEvent, RegistryUpgradedEvent,
+    ScannerAuthorizedEvent, StakerRewardsClaimedEvent, StakerRewardsDistributedEvent,
 };
 use crate::types::{
     BlacklistAuditEntry, EventInfo, EventReceipt, EventRegistrationArgs, EventStatus, GuestProfile,
@@ -399,6 +399,8 @@ impl EventRegistry {
             custom_fee_bps: None,
             banner_cid: args.banner_cid,
             tags: args.tags,
+            end_time: args.end_time,
+            feedback_cid: None,
         };
 
         storage::store_event(&env, event_info);
@@ -589,6 +591,57 @@ impl EventRegistry {
             }
             None => Err(EventRegistryError::EventNotFound),
         }
+    }
+
+    /// Sets the post-event feedback CID for an event.
+    ///
+    /// Can only be called by the event organizer after the event's `end_time` has passed.
+    /// If `end_time` is 0 (not set), the call is rejected.
+    ///
+    /// # Arguments
+    /// * `event_id` - The event to attach feedback to.
+    /// * `feedback_cid` - IPFS CID pointing to the post-event feedback content.
+    ///
+    /// # Errors
+    /// * `EventNotFound` - If no event with the given ID exists.
+    /// * `EventCancelled` - If the event has been cancelled.
+    /// * `EventNotEnded` - If `end_time` is 0 or the current ledger time is before `end_time`.
+    /// * `InvalidMetadataCid` - If the provided CID fails format validation.
+    pub fn set_feedback_cid(
+        env: Env,
+        event_id: String,
+        feedback_cid: String,
+    ) -> Result<(), EventRegistryError> {
+        let mut event_info =
+            storage::get_event(&env, event_id.clone()).ok_or(EventRegistryError::EventNotFound)?;
+
+        event_info.organizer_address.require_auth();
+
+        if matches!(event_info.status, EventStatus::Cancelled) {
+            return Err(EventRegistryError::EventCancelled);
+        }
+
+        let now = env.ledger().timestamp();
+        if event_info.end_time == 0 || now < event_info.end_time {
+            return Err(EventRegistryError::EventNotEnded);
+        }
+
+        validate_metadata_cid(&env, &feedback_cid)?;
+
+        event_info.feedback_cid = Some(feedback_cid.clone());
+        storage::update_event(&env, event_info.clone());
+
+        env.events().publish(
+            (AgoraEvent::FeedbackCidSet,),
+            FeedbackCidSetEvent {
+                event_id,
+                feedback_cid,
+                updated_by: event_info.organizer_address,
+                timestamp: now,
+            },
+        );
+
+        Ok(())
     }
 
     /// Stores or updates an event (legacy function for backward compatibility).

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -58,6 +58,7 @@ fn test_register_and_get_series() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     client.register_event(&EventRegistrationArgs {
         event_id: event_id2.clone(),
@@ -75,6 +76,7 @@ fn test_register_and_get_series() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Register a series
@@ -127,6 +129,7 @@ fn test_issue_and_use_series_pass() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     let series_id = String::from_str(&env, "series_1");
     let event_ids = soroban_sdk::vec![&env, event_id.clone()];
@@ -303,6 +306,8 @@ fn test_storage_operations() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
+        feedback_cid: None,
     };
 
     client.store_event(&event_info);
@@ -391,6 +396,8 @@ fn test_get_total_tickets_sold_uses_event_current_supply() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
+        feedback_cid: None,
     });
 
     assert_eq!(client.get_total_tickets_sold(&event_id), 9);
@@ -436,6 +443,7 @@ fn test_get_active_events_count_tracks_status_changes() {
             target_deadline: None,
             banner_cid: None,
             tags: None,
+            end_time: 0,
         });
     }
 
@@ -494,6 +502,8 @@ fn test_organizer_events_list() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
+        feedback_cid: None,
     };
 
     let event_2 = EventInfo {
@@ -524,6 +534,8 @@ fn test_organizer_events_list() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
+        feedback_cid: None,
     };
 
     let contract_id = env.register(EventRegistry, ());
@@ -581,6 +593,8 @@ fn test_get_organizer_receipts_returns_archived_receipts() {
             custom_fee_bps: None,
             banner_cid: None,
             tags: None,
+            end_time: 0,
+            feedback_cid: None,
         };
 
     let event_id_1 = String::from_str(&env, "archived_1");
@@ -679,6 +693,7 @@ fn test_register_event_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let payment_info = client.get_event_payment_info(&event_id);
@@ -732,6 +747,7 @@ fn test_register_event_name_trimming() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let stored = client.get_event(&event_id).unwrap();
@@ -796,6 +812,7 @@ fn test_register_event_invalid_target_deadline() {
         target_deadline: Some(now - 1),
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidTargetDeadline)));
 
@@ -816,6 +833,7 @@ fn test_register_event_invalid_target_deadline() {
         target_deadline: Some(now),
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidTargetDeadline)));
 
@@ -836,6 +854,7 @@ fn test_register_event_invalid_target_deadline() {
         target_deadline: Some(now + 100),
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let stored = client.get_event(&event_id).unwrap();
@@ -872,6 +891,7 @@ fn test_register_event_rejects_contract_as_organizer() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidAddress)));
@@ -912,6 +932,7 @@ fn test_register_event_rejects_zero_organizer_address() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidAddress)));
@@ -954,6 +975,7 @@ fn test_register_event_unlimited_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -998,6 +1020,7 @@ fn test_register_duplicate_event_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let result = client.try_register_event(&EventRegistrationArgs {
@@ -1016,6 +1039,7 @@ fn test_register_duplicate_event_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::EventAlreadyExists)));
 }
@@ -1053,6 +1077,7 @@ fn test_register_event_invalid_metadata_cid_formats() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(
         short_result,
@@ -1079,6 +1104,7 @@ fn test_register_event_invalid_metadata_cid_formats() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(
         wrong_prefix_result,
@@ -1105,6 +1131,7 @@ fn test_register_event_invalid_metadata_cid_formats() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(
         oversized_result,
@@ -1149,6 +1176,7 @@ fn test_get_event_payment_info() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let info = client.get_event_payment_info(&event_id);
@@ -1193,6 +1221,7 @@ fn test_update_event_status() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     client.update_event_status(&event_id, &false);
 
@@ -1236,6 +1265,7 @@ fn test_event_inactive_error() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     client.update_event_status(&event_id, &false);
 
@@ -1280,6 +1310,7 @@ fn test_complete_event_lifecycle() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let payment_info = client.get_event_payment_info(&event_id);
@@ -1336,6 +1367,7 @@ fn test_update_metadata_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let new_metadata_cid = String::from_str(
@@ -1385,6 +1417,7 @@ fn test_update_metadata_invalid_cid() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let wrong_char_cid = String::from_str(
@@ -1480,6 +1513,7 @@ fn test_set_custom_event_fee() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Default fee
@@ -1536,6 +1570,7 @@ fn test_set_custom_event_fee_exceeds_max() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Try to set custom fee exceeding 10000 bps (100%)
@@ -1606,6 +1641,7 @@ fn test_increment_inventory_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.increment_inventory(&event_id, &tier_id, &1);
@@ -1678,6 +1714,7 @@ fn test_increment_inventory_max_supply_exceeded() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.increment_inventory(&event_id, &tier_id, &1);
@@ -1745,6 +1782,7 @@ fn test_increment_inventory_bulk_exceeds_max_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Fill one slot, then attempt a bulk call that overshoots max_supply in one shot
@@ -1812,6 +1850,7 @@ fn test_increment_inventory_unlimited_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     for _ in 0..10 {
@@ -1897,6 +1936,7 @@ fn test_increment_inventory_inactive_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.update_event_status(&event_id, &false);
@@ -1957,6 +1997,7 @@ fn test_increment_inventory_persists_across_reads() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     for _ in 0..5 {
@@ -2034,6 +2075,7 @@ fn test_tier_limit_exceeds_max_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(
         result,
@@ -2094,6 +2136,7 @@ fn test_tier_not_found() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let wrong_tier_id = String::from_str(&env, "nonexistent");
@@ -2155,6 +2198,7 @@ fn test_tier_supply_exceeded() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.increment_inventory(&event_id, &tier_id, &1);
@@ -2232,6 +2276,7 @@ fn test_multiple_tiers_inventory() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.increment_inventory(&event_id, &general_id, &1);
@@ -2310,6 +2355,8 @@ fn test_increment_inventory_supply_overflow() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
+        feedback_cid: None,
     });
 
     let result = client.try_increment_inventory(&event_id, &tier_id, &1);
@@ -2377,6 +2424,8 @@ fn test_increment_inventory_tier_sold_overflow() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
+        feedback_cid: None,
     });
 
     let result = client.try_increment_inventory(&event_id, &tier_id, &1);
@@ -2422,6 +2471,7 @@ fn test_update_event_status_noop_skips_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let _ = env.events().all();
@@ -2499,6 +2549,7 @@ fn test_blacklist_prevents_event_registration() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     assert_eq!(result, Err(Ok(EventRegistryError::OrganizerBlacklisted)));
@@ -2544,6 +2595,7 @@ fn test_update_metadata_noop_skips_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let _ = env.events().all();
@@ -2628,6 +2680,7 @@ fn test_blacklist_suspends_active_events() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2754,6 +2807,7 @@ fn test_register_event_with_resale_cap() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2798,6 +2852,7 @@ fn test_register_event_resale_cap_zero() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2842,6 +2897,7 @@ fn test_register_event_resale_cap_none() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2886,6 +2942,7 @@ fn test_postpone_event_sets_grace_period() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Set ledger time and grace period end in the future
@@ -2937,6 +2994,7 @@ fn test_register_event_resale_cap_invalid() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidResaleCapBps)));
 }
@@ -2977,6 +3035,7 @@ fn test_cancel_event_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.cancel_event(&event_id);
@@ -3020,6 +3079,7 @@ fn test_archive_event_rejects_active_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     let result = client.try_archive_event(&event_id);
@@ -3061,6 +3121,7 @@ fn test_cancel_already_cancelled_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.cancel_event(&event_id);
@@ -3103,6 +3164,7 @@ fn test_update_status_on_cancelled_event_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     client.cancel_event(&event_id);
@@ -3747,6 +3809,7 @@ fn test_register_event_with_banner_cid() {
         target_deadline: None,
         banner_cid: banner_cid.clone(),
         tags: None,
+        end_time: 0,
     });
 
     let event = client.get_event(&event_id).unwrap();
@@ -3797,6 +3860,7 @@ fn test_goal_met_event_fires_only_once() {
         target_deadline: None,
         banner_cid: banner_cid.clone(),
         tags: None,
+        end_time: 0,
     });
 
     let event = client.get_event(&event_id).unwrap();
@@ -3854,6 +3918,7 @@ fn test_register_event_without_banner_cid() {
         target_deadline: Some(1000),
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Drain setup events
@@ -3921,6 +3986,7 @@ fn test_series_pass_issued_at_timestamp() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Register a series
@@ -3998,6 +4064,7 @@ fn base_args(
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     }
 }
 
@@ -4335,6 +4402,7 @@ fn test_cancelled_status_guard() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     // Cancel event
@@ -4468,6 +4536,7 @@ fn test_register_event_restocking_fee_exceeds_tier_price_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     assert_eq!(
@@ -4523,6 +4592,7 @@ fn test_register_event_restocking_fee_equal_to_tier_price_succeeds() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     assert!(result.is_ok());
@@ -4574,6 +4644,7 @@ fn test_register_event_restocking_fee_zero_always_valid() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     assert!(result.is_ok());
@@ -4625,6 +4696,7 @@ fn test_register_event_restocking_fee_overflow_returns_invalid_fee_calculation()
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
 
     assert_eq!(
@@ -4707,6 +4779,7 @@ fn test_register_event_tier_limit_overflow() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::SupplyOverflow)));
 }
@@ -4761,6 +4834,7 @@ fn test_register_event_invalid_tier_limit_negative() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidQuantity)));
 }
@@ -4814,6 +4888,7 @@ fn test_register_event_milestone_overflow() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::SupplyOverflow)));
 }
@@ -4852,6 +4927,7 @@ fn tags_base_args(env: &Env, event_id: &str, organizer: &Address) -> EventRegist
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     }
 }
 
@@ -5044,4 +5120,170 @@ fn test_version_fn_returns_1() {
     let contract_id = env.register(EventRegistry, ());
     let client = EventRegistryClient::new(&env, &contract_id);
     assert_eq!(client.version(), 1u32);
+}
+
+// ── set_feedback_cid tests ────────────────────────────────────────────────────
+
+fn setup_event_with_end_time(
+    env: &Env,
+    client: &EventRegistryClient,
+    event_id: &str,
+    end_time: u64,
+) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let organizer = Address::generate(env);
+    let platform_wallet = Address::generate(env);
+    let usdc_token = Address::generate(env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    let metadata_cid = String::from_str(
+        env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+    client.register_event(&EventRegistrationArgs {
+        event_id: String::from_str(env, event_id),
+        name: String::from_str(env, "Test Event"),
+        organizer_address: organizer.clone(),
+        payment_address: test_payment_address(env),
+        metadata_cid,
+        max_supply: 100,
+        milestone_plan: None,
+        tiers: Map::new(env),
+        refund_deadline: 0,
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+        banner_cid: None,
+        tags: None,
+        end_time,
+    });
+    (admin, organizer)
+}
+
+/// Organizer can set feedback CID after end_time has passed.
+#[test]
+fn test_set_feedback_cid_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    // Set ledger time to 1000 so we can have a past end_time
+    env.ledger().set_timestamp(1000);
+    let past_end_time = 500u64;
+    setup_event_with_end_time(&env, &client, "evt_feedback", past_end_time);
+
+    let feedback_cid = String::from_str(
+        &env,
+        "bafkreifeedback222222222222222222222222222222222222222222222",
+    );
+    client.set_feedback_cid(&String::from_str(&env, "evt_feedback"), &feedback_cid);
+
+    let event = client
+        .get_event(&String::from_str(&env, "evt_feedback"))
+        .unwrap();
+    assert_eq!(event.feedback_cid, Some(feedback_cid));
+}
+
+/// set_feedback_cid fails when end_time is 0 (not set).
+#[test]
+fn test_set_feedback_cid_no_end_time_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    setup_event_with_end_time(&env, &client, "evt_no_end", 0);
+
+    let feedback_cid = String::from_str(
+        &env,
+        "bafkreifeedback222222222222222222222222222222222222222222222",
+    );
+    let result = client.try_set_feedback_cid(&String::from_str(&env, "evt_no_end"), &feedback_cid);
+    assert_eq!(result, Err(Ok(EventRegistryError::EventNotEnded)));
+}
+
+/// set_feedback_cid fails when end_time is in the future.
+#[test]
+fn test_set_feedback_cid_before_end_time_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let future_end_time = env.ledger().timestamp() + 10_000;
+    setup_event_with_end_time(&env, &client, "evt_future", future_end_time);
+
+    let feedback_cid = String::from_str(
+        &env,
+        "bafkreifeedback222222222222222222222222222222222222222222222",
+    );
+    let result = client.try_set_feedback_cid(&String::from_str(&env, "evt_future"), &feedback_cid);
+    assert_eq!(result, Err(Ok(EventRegistryError::EventNotEnded)));
+}
+
+/// set_feedback_cid fails for a non-existent event.
+#[test]
+fn test_set_feedback_cid_event_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    let result = client.try_set_feedback_cid(
+        &String::from_str(&env, "nonexistent"),
+        &String::from_str(
+            &env,
+            "bafkreifeedback222222222222222222222222222222222222222222222",
+        ),
+    );
+    assert_eq!(result, Err(Ok(EventRegistryError::EventNotFound)));
+}
+
+/// set_feedback_cid fails with an invalid CID format.
+#[test]
+fn test_set_feedback_cid_invalid_cid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    env.ledger().set_timestamp(1000);
+    setup_event_with_end_time(&env, &client, "evt_bad_cid", 500);
+
+    let result = client.try_set_feedback_cid(
+        &String::from_str(&env, "evt_bad_cid"),
+        &String::from_str(&env, "short"),
+    );
+    assert_eq!(result, Err(Ok(EventRegistryError::InvalidMetadataCid)));
+}
+
+/// set_feedback_cid fails on a cancelled event.
+#[test]
+fn test_set_feedback_cid_cancelled_event_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    env.ledger().set_timestamp(1000);
+    setup_event_with_end_time(&env, &client, "evt_cancelled", 500);
+
+    let event_id = String::from_str(&env, "evt_cancelled");
+    client.cancel_event(&event_id);
+
+    let result = client.try_set_feedback_cid(
+        &event_id,
+        &String::from_str(
+            &env,
+            "bafkreifeedback222222222222222222222222222222222222222222222",
+        ),
+    );
+    assert_eq!(result, Err(Ok(EventRegistryError::EventCancelled)));
 }

--- a/contract/contracts/event_registry/src/test_e2e.rs
+++ b/contract/contracts/event_registry/src/test_e2e.rs
@@ -49,6 +49,7 @@ fn make_event_args(
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     }
 }
 

--- a/contract/contracts/event_registry/src/test_free_ticket.rs
+++ b/contract/contracts/event_registry/src/test_free_ticket.rs
@@ -84,6 +84,7 @@ fn register_free_event(
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        end_time: 0,
     });
     id
 }

--- a/contract/contracts/event_registry/src/types.rs
+++ b/contract/contracts/event_registry/src/types.rs
@@ -139,6 +139,10 @@ pub struct EventInfo {
     pub banner_cid: Option<String>,
     /// Optional categorical tags for the event (e.g., "Music", "Tech")
     pub tags: Option<Vec<String>>,
+    /// Unix timestamp when the event ends (0 = not set)
+    pub end_time: u64,
+    /// Optional IPFS CID for post-event feedback (only settable after end_time)
+    pub feedback_cid: Option<String>,
 }
 
 /// Payment information for an event
@@ -180,6 +184,8 @@ pub struct EventRegistrationArgs {
     pub banner_cid: Option<String>,
     /// Optional categorical tags for the event (e.g., "Music", "Tech")
     pub tags: Option<Vec<String>>,
+    /// Unix timestamp when the event ends (0 = not set)
+    pub end_time: u64,
 }
 
 /// Audit log entry for blacklist actions

--- a/contract/contracts/event_registry/test_snapshots/test/test_complete_event_lifecycle.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_complete_event_lifecycle.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -278,11 +286,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "lifecycle_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_event_inactive_error.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_event_inactive_error.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -275,11 +283,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_001"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_get_event_payment_info.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_get_event_payment_info.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -253,11 +261,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_002"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_inactive_event.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_inactive_event.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -352,11 +360,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "inactive_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_max_supply_exceeded.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_max_supply_exceeded.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -381,11 +389,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "limited_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_persists_across_reads.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_persists_across_reads.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -456,11 +464,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "persist_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_success.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -381,11 +389,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "supply_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_unlimited_supply.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_unlimited_supply.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -580,11 +588,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "unlimited_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_multiple_tiers_inventory.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_multiple_tiers_inventory.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -462,11 +470,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "multi_tier_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_organizer_events_list.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_organizer_events_list.1.json
@@ -47,11 +47,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "e1"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -253,11 +267,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "e2"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -563,11 +591,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "e1"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -795,11 +837,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "e2"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_duplicate_event_fails.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_duplicate_event_fails.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -253,11 +261,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_001"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_event_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_event_success.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -312,11 +320,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_001"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_event_unlimited_supply.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_event_unlimited_supply.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -253,11 +261,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "unlimited_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_storage_operations.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_storage_operations.1.json
@@ -48,11 +48,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_123"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -334,11 +348,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_123"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_tier_not_found.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_tier_not_found.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -330,11 +338,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "tier_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_tier_supply_exceeded.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_tier_supply_exceeded.1.json
@@ -45,6 +45,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -405,11 +413,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "tier_limit_event"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_event_status.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_event_status.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -275,11 +283,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_001"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_invalid_cid.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_invalid_cid.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -255,11 +263,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_metadata"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_success.1.json
@@ -26,6 +26,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
@@ -275,11 +283,25 @@
                     },
                     {
                       "key": {
+                        "symbol": "end_time"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "event_id"
                       },
                       "val": {
                         "string": "event_metadata"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "feedback_cid"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {


### PR DESCRIPTION
Closes #393

---

Add the ability for event organizers to attach a post-event feedback IPFS CID to an event after its end_time has passed.

Changes:
- types.rs: Added `end_time: u64` and `feedback_cid: Option<String>` fields to `EventInfo`; added `end_time: u64` to `EventRegistrationArgs` (feedback_cid is set via the new function, not at registration time).
- error.rs: Added `EventNotEnded = 47` error variant returned when set_feedback_cid is called before end_time has elapsed or when end_time is 0 (not configured).
- events.rs: Added `FeedbackCidSet` variant to `AgoraEvent` enum and the corresponding `FeedbackCidSetEvent` struct.
- lib.rs: Implemented `set_feedback_cid(event_id, feedback_cid)` function — organizer-authenticated, validates end_time > 0 and current ledger time >= end_time, validates CID format, persists the CID, and emits a `FeedbackCidSet` event.
- test.rs / test_e2e.rs / test_free_ticket.rs: Updated all existing `EventRegistrationArgs` and `EventInfo` struct literals to include the new `end_time` (and `feedback_cid`) fields. Added 6 new tests covering success, no end_time set, future end_time, event not found, invalid CID, and cancelled event edge cases.

Why: Issue #393 requests that organizers be able to add feedback metadata (as an IPFS CID) after an event has concluded. Gating on end_time ensures feedback can only be submitted for events that have actually ended.

Assumptions: end_time = 0 is treated as "not configured" and always rejects feedback submission, consistent with how other optional timestamps (grace_period_end, target_deadline) are handled in this contract.