### PR TITLE
feat(contract): add loyalty_multiplier to TicketTier for scaled points

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -1424,12 +1424,14 @@ impl EventRegistry {
     /// * `guest` - Guest wallet address
     /// * `tickets_purchased` - Number of tickets purchased in this transaction
     /// * `amount_spent` - Amount spent in this transaction (in token stroops)
+    /// * `loyalty_multiplier` - Points multiplier from the purchased tier (0 or 1 = 1x, 2 = 2x, etc.)
     pub fn update_loyalty_score(
         env: Env,
         caller: Address,
         guest: Address,
         tickets_purchased: u32,
         amount_spent: i128,
+        loyalty_multiplier: u32,
     ) -> Result<(), EventRegistryError> {
         caller.require_auth();
 
@@ -1459,8 +1461,16 @@ impl EventRegistry {
             last_updated: 0,
         });
 
-        // Award 10 points per ticket purchased
-        let points_earned = (tickets_purchased as u64).saturating_mul(10);
+        // Award 10 points per ticket, scaled by the tier's loyalty_multiplier.
+        // A multiplier of 0 is treated as 1x to avoid zeroing out points.
+        let effective_multiplier = if loyalty_multiplier == 0 {
+            1u64
+        } else {
+            loyalty_multiplier as u64
+        };
+        let points_earned = (tickets_purchased as u64)
+            .saturating_mul(10)
+            .saturating_mul(effective_multiplier);
         profile.loyalty_score = profile.loyalty_score.saturating_add(points_earned);
         profile.total_tickets_purchased = profile
             .total_tickets_purchased

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -349,6 +349,7 @@ fn test_get_total_tickets_sold_uses_event_current_supply() {
             current_sold: 3,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     tiers.set(
@@ -360,6 +361,7 @@ fn test_get_total_tickets_sold_uses_event_current_supply() {
             current_sold: 4,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -660,6 +662,7 @@ fn test_register_event_success() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -770,6 +773,7 @@ fn test_register_event_invalid_target_deadline() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -1461,6 +1465,7 @@ fn test_set_custom_event_fee() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -1587,6 +1592,7 @@ fn test_increment_inventory_success() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -1659,6 +1665,7 @@ fn test_increment_inventory_max_supply_exceeded() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -1726,6 +1733,7 @@ fn test_increment_inventory_bulk_exceeds_max_supply() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -1793,6 +1801,7 @@ fn test_increment_inventory_unlimited_supply() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -1879,6 +1888,7 @@ fn test_increment_inventory_inactive_event() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     client.register_event(&EventRegistrationArgs {
@@ -1939,6 +1949,7 @@ fn test_increment_inventory_persists_across_reads() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     client.register_event(&EventRegistrationArgs {
@@ -2004,6 +2015,7 @@ fn test_tier_limit_exceeds_max_supply() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     tiers.set(
@@ -2015,6 +2027,7 @@ fn test_tier_limit_exceeds_max_supply() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -2075,6 +2088,7 @@ fn test_tier_not_found() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -2136,6 +2150,7 @@ fn test_tier_supply_exceeded() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -2202,6 +2217,7 @@ fn test_multiple_tiers_inventory() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     tiers.set(
@@ -2213,6 +2229,7 @@ fn test_multiple_tiers_inventory() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -2278,6 +2295,7 @@ fn test_increment_inventory_supply_overflow() {
             current_sold: i128::MAX - 1,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -2346,6 +2364,7 @@ fn test_increment_inventory_tier_sold_overflow() {
             current_sold: i128::MAX, // tier current_sold at max
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -2735,6 +2754,7 @@ fn test_register_event_with_resale_cap() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -3144,7 +3164,7 @@ fn test_update_loyalty_score_creates_profile() {
     let (client, admin, _) = setup_loyalty_env(&env);
 
     let guest = Address::generate(&env);
-    client.update_loyalty_score(&admin, &guest, &2, &2000_0000000i128);
+    client.update_loyalty_score(&admin, &guest, &2, &2000_0000000i128, &1u32);
 
     let profile = client.get_guest_profile(&guest).unwrap();
     assert_eq!(profile.guest_address, guest);
@@ -3162,9 +3182,9 @@ fn test_update_loyalty_score_accumulates() {
     let guest = Address::generate(&env);
 
     // First purchase: 5 tickets
-    client.update_loyalty_score(&admin, &guest, &5, &5000_0000000i128);
+    client.update_loyalty_score(&admin, &guest, &5, &5000_0000000i128, &1u32);
     // Second purchase: 3 tickets
-    client.update_loyalty_score(&admin, &guest, &3, &3000_0000000i128);
+    client.update_loyalty_score(&admin, &guest, &3, &3000_0000000i128, &1u32);
 
     let profile = client.get_guest_profile(&guest).unwrap();
     assert_eq!(profile.loyalty_score, 80); // (5+3) × 10
@@ -3181,7 +3201,7 @@ fn test_update_loyalty_score_unauthorized_fails() {
     let guest = Address::generate(&env);
     let random_caller = Address::generate(&env);
 
-    let result = client.try_update_loyalty_score(&random_caller, &guest, &1, &1000i128);
+    let result = client.try_update_loyalty_score(&random_caller, &guest, &1, &1000i128, &1u32);
     assert_eq!(result, Err(Ok(EventRegistryError::Unauthorized)));
 }
 
@@ -3192,7 +3212,7 @@ fn test_update_loyalty_score_zero_tickets_fails() {
     let (client, admin, _) = setup_loyalty_env(&env);
 
     let guest = Address::generate(&env);
-    let result = client.try_update_loyalty_score(&admin, &guest, &0, &0i128);
+    let result = client.try_update_loyalty_score(&admin, &guest, &0, &0i128, &1u32);
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidQuantity)));
 }
 
@@ -3217,21 +3237,21 @@ fn test_loyalty_discount_bps_tiers() {
     let guest = Address::generate(&env);
 
     // Score < 100 → 0 bps
-    client.update_loyalty_score(&admin, &guest, &5, &100i128); // 50 pts
+    client.update_loyalty_score(&admin, &guest, &5, &100i128, &1u32); // 50 pts
     assert_eq!(client.get_loyalty_discount_bps(&guest), 0);
 
     // Score 100–499 → 250 bps
-    client.update_loyalty_score(&admin, &guest, &5, &100i128); // +50 = 100 pts
+    client.update_loyalty_score(&admin, &guest, &5, &100i128, &1u32); // +50 = 100 pts
     assert_eq!(client.get_loyalty_discount_bps(&guest), 250);
 
     // Score 500–999 → 500 bps
     // Need to get to 500 pts: currently 100, need 400 more = 40 tickets
-    client.update_loyalty_score(&admin, &guest, &40, &1000i128); // +400 = 500 pts
+    client.update_loyalty_score(&admin, &guest, &40, &1000i128, &1u32); // +400 = 500 pts
     assert_eq!(client.get_loyalty_discount_bps(&guest), 500);
 
     // Score ≥ 1000 → 1000 bps
     // Need 500 more pts = 50 tickets
-    client.update_loyalty_score(&admin, &guest, &50, &1000i128); // +500 = 1000 pts
+    client.update_loyalty_score(&admin, &guest, &50, &1000i128, &1u32); // +500 = 1000 pts
     assert_eq!(client.get_loyalty_discount_bps(&guest), 1000);
 }
 
@@ -3835,6 +3855,7 @@ fn test_register_event_without_banner_cid() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -4445,6 +4466,7 @@ fn test_register_event_restocking_fee_exceeds_tier_price_fails() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -4500,6 +4522,7 @@ fn test_register_event_restocking_fee_equal_to_tier_price_succeeds() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -4552,6 +4575,7 @@ fn test_register_event_restocking_fee_zero_always_valid() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -4603,6 +4627,7 @@ fn test_register_event_restocking_fee_overflow_returns_invalid_fee_calculation()
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -4677,6 +4702,7 @@ fn test_register_event_tier_limit_overflow() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     tiers.set(
@@ -4688,6 +4714,7 @@ fn test_register_event_tier_limit_overflow() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -4742,6 +4769,7 @@ fn test_register_event_invalid_tier_limit_negative() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
 
@@ -5044,4 +5072,156 @@ fn test_version_fn_returns_1() {
     let contract_id = env.register(EventRegistry, ());
     let client = EventRegistryClient::new(&env, &contract_id);
     assert_eq!(client.version(), 1u32);
+}
+
+// ── Tier-Specific Loyalty Multipliers ────────────────────────────────────────
+
+/// A multiplier of 1 (standard) awards 10 points per ticket — baseline behaviour.
+#[test]
+fn test_loyalty_multiplier_1x_awards_base_points() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_loyalty_env(&env);
+
+    let guest = Address::generate(&env);
+    // 3 tickets × 10 pts × 1x = 30 pts
+    client.update_loyalty_score(&admin, &guest, &3, &3000i128, &1u32);
+
+    let profile = client.get_guest_profile(&guest).unwrap();
+    assert_eq!(profile.loyalty_score, 30);
+}
+
+/// A multiplier of 2 (e.g., VIP tier) awards 20 points per ticket.
+#[test]
+fn test_loyalty_multiplier_2x_doubles_points() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_loyalty_env(&env);
+
+    let guest = Address::generate(&env);
+    // 3 tickets × 10 pts × 2x = 60 pts
+    client.update_loyalty_score(&admin, &guest, &3, &6000i128, &2u32);
+
+    let profile = client.get_guest_profile(&guest).unwrap();
+    assert_eq!(profile.loyalty_score, 60);
+}
+
+/// A multiplier of 3 (e.g., Platinum tier) awards 30 points per ticket.
+#[test]
+fn test_loyalty_multiplier_3x_triples_points() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_loyalty_env(&env);
+
+    let guest = Address::generate(&env);
+    // 2 tickets × 10 pts × 3x = 60 pts
+    client.update_loyalty_score(&admin, &guest, &2, &9000i128, &3u32);
+
+    let profile = client.get_guest_profile(&guest).unwrap();
+    assert_eq!(profile.loyalty_score, 60);
+}
+
+/// A multiplier of 0 is treated as 1x (no zeroing of points).
+#[test]
+fn test_loyalty_multiplier_0_treated_as_1x() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_loyalty_env(&env);
+
+    let guest = Address::generate(&env);
+    // 4 tickets × 10 pts × 1x (0 treated as 1) = 40 pts
+    client.update_loyalty_score(&admin, &guest, &4, &4000i128, &0u32);
+
+    let profile = client.get_guest_profile(&guest).unwrap();
+    assert_eq!(profile.loyalty_score, 40);
+}
+
+/// Points from multiple purchases with different multipliers accumulate correctly.
+#[test]
+fn test_loyalty_multiplier_accumulates_across_purchases() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_loyalty_env(&env);
+
+    let guest = Address::generate(&env);
+    // Purchase 1: 2 tickets × 10 × 1x = 20 pts
+    client.update_loyalty_score(&admin, &guest, &2, &2000i128, &1u32);
+    // Purchase 2: 1 ticket × 10 × 2x = 20 pts
+    client.update_loyalty_score(&admin, &guest, &1, &5000i128, &2u32);
+    // Total: 40 pts
+
+    let profile = client.get_guest_profile(&guest).unwrap();
+    assert_eq!(profile.loyalty_score, 40);
+}
+
+/// TicketTier with loyalty_multiplier = 2 stores and retrieves the field correctly.
+#[test]
+fn test_ticket_tier_loyalty_multiplier_stored_in_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    let mut tiers = Map::new(&env);
+    tiers.set(
+        String::from_str(&env, "vip"),
+        crate::types::TicketTier {
+            name: String::from_str(&env, "VIP"),
+            price: 5000,
+            tier_limit: 50,
+            current_sold: 0,
+            is_refundable: true,
+            auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 2,
+        },
+    );
+    tiers.set(
+        String::from_str(&env, "general"),
+        crate::types::TicketTier {
+            name: String::from_str(&env, "General"),
+            price: 1000,
+            tier_limit: 200,
+            current_sold: 0,
+            is_refundable: false,
+            auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
+        },
+    );
+
+    let metadata_cid = String::from_str(
+        &env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+    client.register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_multiplier"),
+        name: String::from_str(&env, "Multiplier Event"),
+        organizer_address: organizer.clone(),
+        payment_address: test_payment_address(&env),
+        metadata_cid,
+        max_supply: 250,
+        milestone_plan: None,
+        tiers,
+        refund_deadline: 0,
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+        banner_cid: None,
+        tags: None,
+    });
+
+    let event = client
+        .get_event(&String::from_str(&env, "evt_multiplier"))
+        .unwrap();
+    let vip_tier = event.tiers.get(String::from_str(&env, "vip")).unwrap();
+    let general_tier = event.tiers.get(String::from_str(&env, "general")).unwrap();
+
+    assert_eq!(vip_tier.loyalty_multiplier, 2);
+    assert_eq!(general_tier.loyalty_multiplier, 1);
 }

--- a/contract/contracts/event_registry/src/test_e2e.rs
+++ b/contract/contracts/event_registry/src/test_e2e.rs
@@ -64,6 +64,7 @@ fn single_tier(env: &Env, tier_limit: i128) -> Map<String, TicketTier> {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     tiers
@@ -139,6 +140,7 @@ fn test_e2e_zero_max_supply_means_unlimited() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     let args = make_event_args(&env, "evt_unlim", &organizer, 0, tiers);

--- a/contract/contracts/event_registry/src/test_free_ticket.rs
+++ b/contract/contracts/event_registry/src/test_free_ticket.rs
@@ -53,6 +53,7 @@ fn free_tier(env: &Env, limit: i128) -> Map<String, TicketTier> {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![env],
+            loyalty_multiplier: 1,
         },
     );
     tiers

--- a/contract/contracts/event_registry/src/types.rs
+++ b/contract/contracts/event_registry/src/types.rs
@@ -64,6 +64,9 @@ pub struct TicketTier {
     pub is_refundable: bool,
     /// Optional configuration for an auction
     pub auction_config: soroban_sdk::Vec<AuctionConfig>,
+    /// Loyalty points multiplier for this tier (e.g., 1 = 1x, 2 = 2x).
+    /// A value of 0 is treated as 1x. VIP tiers can award more points.
+    pub loyalty_multiplier: u32,
 }
 
 /// Represents an early revenue release milestone.

--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -115,6 +115,7 @@ pub mod event_registry {
             guest: Address,
             tickets_purchased: u32,
             amount_spent: i128,
+            loyalty_multiplier: u32,
         );
         fn get_loyalty_discount_bps(env: Env, guest: Address) -> u32;
         fn get_guest_profile(env: Env, guest: Address) -> Option<GuestProfile>;
@@ -134,6 +135,7 @@ pub mod event_registry {
         pub current_sold: i128,
         pub is_refundable: bool,
         pub auction_config: soroban_sdk::Vec<AuctionConfig>,
+        pub loyalty_multiplier: u32,
     }
 
     #[soroban_sdk::contracttype]
@@ -847,6 +849,7 @@ impl TicketPaymentContract {
             &buyer_address,
             &quantity,
             &effective_total,
+            &tier.loyalty_multiplier,
         ) {
             Ok(_) | Err(_) => {}
         }

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -50,6 +50,7 @@ impl MockCancelledRegistry {
                         current_sold: 0,
                         is_refundable: false,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -118,6 +119,7 @@ impl MockEventRegistry {
                             current_sold: 0,
                             is_refundable: true,
                             auction_config: soroban_sdk::vec![&env],
+                            loyalty_multiplier: 1,
                         },
                     );
                     tiers
@@ -191,6 +193,7 @@ impl MockEventRegistry2 {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -249,6 +252,7 @@ impl MockAuctionEventRegistry {
                         min_increment: 100_0000000i128,
                     }
                 ],
+                loyalty_multiplier: 1,
             },
         );
 
@@ -1017,6 +1021,7 @@ impl MockEventRegistryMaxSupply {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -1129,6 +1134,7 @@ impl MockEventRegistryWithInventory {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -1353,6 +1359,7 @@ impl MockEventRegistryWithMilestones {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -1691,6 +1698,7 @@ impl MockEventRegistryEarlyBird {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -2182,6 +2190,7 @@ impl MockEventRegistryWithOrganizer {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -2643,6 +2652,7 @@ fn test_integration_full_platform_day() {
                 current_sold: 0,
                 is_refundable: true,
                 auction_config: soroban_sdk::vec![&env],
+                loyalty_multiplier: 1,
             },
         );
     }
@@ -2776,6 +2786,7 @@ fn test_integration_edge_cases() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     registry.create_event(
@@ -2880,6 +2891,7 @@ fn test_integration_concurrent_multi_guest_sales_no_state_corruption() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     registry.create_event(&event_id, &organizer, &event_payment_addr, &10, &tiers);
@@ -2965,6 +2977,7 @@ impl MockEventRegistryRefund {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -3038,6 +3051,7 @@ impl MockEventRegistryWithResaleCap {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -3307,6 +3321,7 @@ impl MockRegistryZeroCap {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -3591,6 +3606,7 @@ fn test_claim_revenue_rejects_event_not_marked_inactive() {
             current_sold: 0,
             is_refundable: true,
             auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
         },
     );
     registry.create_event(&event_id, &organizer, &event_payment_addr, &10, &tiers);
@@ -3922,6 +3938,7 @@ impl MockEventRegistryUsdPriced {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -4616,6 +4633,7 @@ impl MockEventRegistryWithFailingLoyaltyUpdate {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -4744,6 +4762,7 @@ impl MockEventRegistryWithLoyalty {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -4826,6 +4845,7 @@ impl MockEventRegistryWithExcessiveLoyaltyDiscount {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -5039,6 +5059,7 @@ impl MockEventRegistryCustomFee {
                         current_sold: 0,
                         is_refundable: false,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -5169,6 +5190,7 @@ impl MockEventRegistryHighPrice {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -5277,6 +5299,7 @@ impl MockEventRegistryRefundDeadline {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -6042,6 +6065,7 @@ impl MockEventRegistryForReferral {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -6122,6 +6146,7 @@ impl MockEventRegistryFullLoyaltyDiscount {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers

--- a/contract/contracts/ticket_payment/src/test_e2e.rs
+++ b/contract/contracts/ticket_payment/src/test_e2e.rs
@@ -78,6 +78,7 @@ impl MockRegistryE2E {
                         current_sold: 0,
                         is_refundable: true,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -191,6 +192,7 @@ impl MockRegistryCancelledE2E {
                         current_sold: 0,
                         is_refundable: false,
                         auction_config: soroban_sdk::vec![&env], // not normally refundable, but cancelled overrides
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -288,6 +290,7 @@ impl MockRegistryWithGoal {
                         current_sold: current_supply,
                         is_refundable: false,
                         auction_config: soroban_sdk::vec![&env],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers
@@ -1068,6 +1071,7 @@ impl MockRegistryAuction {
                                 min_increment: 100_0000000i128,
                             }
                         ],
+                        loyalty_multiplier: 1,
                     },
                 );
                 tiers


### PR DESCRIPTION
Closes: #390

Add a `loyalty_multiplier: u32` field to `TicketTier` so that premium tiers (e.g., VIP, Platinum) can award proportionally more loyalty points per ticket purchased.

Changes:
- types.rs: Added `loyalty_multiplier: u32` to `TicketTier`. A value of 0 is treated as 1x to prevent accidental zeroing of points.
- lib.rs: Updated `update_loyalty_score` to accept a new `loyalty_multiplier: u32` parameter. Points awarded are now `tickets_purchased × 10 × effective_multiplier` where `effective_multiplier = max(1, loyalty_multiplier)`.
- ticket_payment/contract.rs: Added `loyalty_multiplier` to the local `TicketTier` mirror and updated the `EventRegistryInterface` trait signature for `update_loyalty_score`. The `process_payment` call now passes `tier.loyalty_multiplier` when awarding points.
- test.rs / test_e2e.rs / test_free_ticket.rs (event_registry): Updated all `TicketTier` struct literals to include `loyalty_multiplier: 1` and all `update_loyalty_score` call sites to pass `&1u32`.
- test.rs / test_e2e.rs (ticket_payment): Updated all `event_registry::TicketTier` struct literals to include `loyalty_multiplier: 1`.
- Added 6 new tests in event_registry/test.rs covering: 1x baseline, 2x doubling, 3x tripling, 0-treated-as-1x, accumulation across purchases with different multipliers, and field persistence in stored events.

Why: Issue #390 requests tier-specific loyalty multipliers so that higher-value ticket tiers (VIP, Platinum) reward buyers with more loyalty points, incentivising premium purchases.

Assumptions: `loyalty_multiplier = 0` is treated as 1x (not 0x) to avoid silently zeroing out points for tiers that omit the field or set it to 0 by default.