### PR TITLE
feat(contract): add is_private flag to exclude events from global cou…

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -399,6 +399,7 @@ impl EventRegistry {
             custom_fee_bps: None,
             banner_cid: args.banner_cid,
             tags: args.tags,
+            is_private: args.is_private,
         };
 
         storage::store_event(&env, event_info);
@@ -854,8 +855,11 @@ impl EventRegistry {
             );
         }
 
-        storage::update_event(&env, event_info);
-        storage::add_to_global_tickets_sold(&env, quantity_i128);
+        storage::update_event(&env, event_info.clone());
+        // Private events are excluded from the global tickets sold counter.
+        if !event_info.is_private {
+            storage::add_to_global_tickets_sold(&env, quantity_i128);
+        }
 
         env.events().publish(
             (AgoraEvent::InventoryIncremented,),
@@ -920,8 +924,11 @@ impl EventRegistry {
             .ok_or(EventRegistryError::SupplyUnderflow)?;
 
         let new_supply = event_info.current_supply;
-        storage::update_event(&env, event_info);
-        storage::subtract_from_global_tickets_sold(&env, 1);
+        storage::update_event(&env, event_info.clone());
+        // Private events are excluded from the global tickets sold counter.
+        if !event_info.is_private {
+            storage::subtract_from_global_tickets_sold(&env, 1);
+        }
 
         env.events().publish(
             (crate::events::AgoraEvent::InventoryDecremented,),

--- a/contract/contracts/event_registry/src/storage.rs
+++ b/contract/contracts/event_registry/src/storage.rs
@@ -162,11 +162,26 @@ pub fn increment_series_pass_usage(env: &Env, pass_id: String) -> Option<SeriesP
 const SHARD_SIZE: u32 = 50;
 
 fn sync_active_event_count(env: &Env, existing: Option<&EventInfo>, updated: &EventInfo) {
+    // Private events are excluded from the global active event counter.
+    if updated.is_private {
+        // If the event was previously public and is now private, undo any active count.
+        if let Some(prev) = existing {
+            if !prev.is_private && prev.is_active {
+                decrement_global_active_event_count(env);
+            }
+        }
+        return;
+    }
+
     match existing {
         Some(previous) if previous.is_active && !updated.is_active => {
             decrement_global_active_event_count(env);
         }
         Some(previous) if !previous.is_active && updated.is_active => {
+            increment_global_active_event_count(env);
+        }
+        // Transitioning from private to public: treat as a fresh active event if active.
+        Some(previous) if previous.is_private && updated.is_active => {
             increment_global_active_event_count(env);
         }
         None if updated.is_active => {
@@ -417,8 +432,10 @@ pub fn store_event(env: &Env, event_info: EventInfo) {
             .persistent()
             .set(&DataKey::OrganizerEvent(organizer, event_id), &true);
 
-        // Increment global event counter
-        increment_global_event_count(env);
+        // Increment global event counter only for public events.
+        if !event_info.is_private {
+            increment_global_event_count(env);
+        }
     }
 }
 
@@ -445,7 +462,7 @@ pub fn remove_event(env: &Env, event_id: String) {
     if let Some(event_info) = get_event(env, event_id.clone()) {
         let organizer = event_info.organizer_address;
 
-        if event_info.is_active {
+        if event_info.is_active && !event_info.is_private {
             decrement_global_active_event_count(env);
         }
 

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -58,6 +58,7 @@ fn test_register_and_get_series() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     client.register_event(&EventRegistrationArgs {
         event_id: event_id2.clone(),
@@ -75,6 +76,7 @@ fn test_register_and_get_series() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Register a series
@@ -127,6 +129,7 @@ fn test_issue_and_use_series_pass() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     let series_id = String::from_str(&env, "series_1");
     let event_ids = soroban_sdk::vec![&env, event_id.clone()];
@@ -303,6 +306,7 @@ fn test_storage_operations() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     };
 
     client.store_event(&event_info);
@@ -391,6 +395,7 @@ fn test_get_total_tickets_sold_uses_event_current_supply() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert_eq!(client.get_total_tickets_sold(&event_id), 9);
@@ -436,6 +441,7 @@ fn test_get_active_events_count_tracks_status_changes() {
             target_deadline: None,
             banner_cid: None,
             tags: None,
+            is_private: false,
         });
     }
 
@@ -494,6 +500,7 @@ fn test_organizer_events_list() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     };
 
     let event_2 = EventInfo {
@@ -524,6 +531,7 @@ fn test_organizer_events_list() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     };
 
     let contract_id = env.register(EventRegistry, ());
@@ -581,6 +589,7 @@ fn test_get_organizer_receipts_returns_archived_receipts() {
             custom_fee_bps: None,
             banner_cid: None,
             tags: None,
+            is_private: false,
         };
 
     let event_id_1 = String::from_str(&env, "archived_1");
@@ -679,6 +688,7 @@ fn test_register_event_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let payment_info = client.get_event_payment_info(&event_id);
@@ -732,6 +742,7 @@ fn test_register_event_name_trimming() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let stored = client.get_event(&event_id).unwrap();
@@ -796,6 +807,7 @@ fn test_register_event_invalid_target_deadline() {
         target_deadline: Some(now - 1),
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidTargetDeadline)));
 
@@ -816,6 +828,7 @@ fn test_register_event_invalid_target_deadline() {
         target_deadline: Some(now),
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidTargetDeadline)));
 
@@ -836,6 +849,7 @@ fn test_register_event_invalid_target_deadline() {
         target_deadline: Some(now + 100),
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let stored = client.get_event(&event_id).unwrap();
@@ -872,6 +886,7 @@ fn test_register_event_rejects_contract_as_organizer() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidAddress)));
@@ -912,6 +927,7 @@ fn test_register_event_rejects_zero_organizer_address() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidAddress)));
@@ -954,6 +970,7 @@ fn test_register_event_unlimited_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -998,6 +1015,7 @@ fn test_register_duplicate_event_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let result = client.try_register_event(&EventRegistrationArgs {
@@ -1016,6 +1034,7 @@ fn test_register_duplicate_event_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::EventAlreadyExists)));
 }
@@ -1053,6 +1072,7 @@ fn test_register_event_invalid_metadata_cid_formats() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(
         short_result,
@@ -1079,6 +1099,7 @@ fn test_register_event_invalid_metadata_cid_formats() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(
         wrong_prefix_result,
@@ -1105,6 +1126,7 @@ fn test_register_event_invalid_metadata_cid_formats() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(
         oversized_result,
@@ -1149,6 +1171,7 @@ fn test_get_event_payment_info() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let info = client.get_event_payment_info(&event_id);
@@ -1193,6 +1216,7 @@ fn test_update_event_status() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     client.update_event_status(&event_id, &false);
 
@@ -1236,6 +1260,7 @@ fn test_event_inactive_error() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     client.update_event_status(&event_id, &false);
 
@@ -1280,6 +1305,7 @@ fn test_complete_event_lifecycle() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let payment_info = client.get_event_payment_info(&event_id);
@@ -1336,6 +1362,7 @@ fn test_update_metadata_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let new_metadata_cid = String::from_str(
@@ -1385,6 +1412,7 @@ fn test_update_metadata_invalid_cid() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let wrong_char_cid = String::from_str(
@@ -1480,6 +1508,7 @@ fn test_set_custom_event_fee() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Default fee
@@ -1536,6 +1565,7 @@ fn test_set_custom_event_fee_exceeds_max() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Try to set custom fee exceeding 10000 bps (100%)
@@ -1606,6 +1636,7 @@ fn test_increment_inventory_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.increment_inventory(&event_id, &tier_id, &1);
@@ -1678,6 +1709,7 @@ fn test_increment_inventory_max_supply_exceeded() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.increment_inventory(&event_id, &tier_id, &1);
@@ -1745,6 +1777,7 @@ fn test_increment_inventory_bulk_exceeds_max_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Fill one slot, then attempt a bulk call that overshoots max_supply in one shot
@@ -1812,6 +1845,7 @@ fn test_increment_inventory_unlimited_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     for _ in 0..10 {
@@ -1897,6 +1931,7 @@ fn test_increment_inventory_inactive_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.update_event_status(&event_id, &false);
@@ -1957,6 +1992,7 @@ fn test_increment_inventory_persists_across_reads() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     for _ in 0..5 {
@@ -2034,6 +2070,7 @@ fn test_tier_limit_exceeds_max_supply() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(
         result,
@@ -2094,6 +2131,7 @@ fn test_tier_not_found() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let wrong_tier_id = String::from_str(&env, "nonexistent");
@@ -2155,6 +2193,7 @@ fn test_tier_supply_exceeded() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.increment_inventory(&event_id, &tier_id, &1);
@@ -2232,6 +2271,7 @@ fn test_multiple_tiers_inventory() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.increment_inventory(&event_id, &general_id, &1);
@@ -2310,6 +2350,7 @@ fn test_increment_inventory_supply_overflow() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let result = client.try_increment_inventory(&event_id, &tier_id, &1);
@@ -2377,6 +2418,7 @@ fn test_increment_inventory_tier_sold_overflow() {
         custom_fee_bps: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let result = client.try_increment_inventory(&event_id, &tier_id, &1);
@@ -2422,6 +2464,7 @@ fn test_update_event_status_noop_skips_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let _ = env.events().all();
@@ -2499,6 +2542,7 @@ fn test_blacklist_prevents_event_registration() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert_eq!(result, Err(Ok(EventRegistryError::OrganizerBlacklisted)));
@@ -2544,6 +2588,7 @@ fn test_update_metadata_noop_skips_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let _ = env.events().all();
@@ -2628,6 +2673,7 @@ fn test_blacklist_suspends_active_events() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2754,6 +2800,7 @@ fn test_register_event_with_resale_cap() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2798,6 +2845,7 @@ fn test_register_event_resale_cap_zero() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2842,6 +2890,7 @@ fn test_register_event_resale_cap_none() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let event_info = client.get_event(&event_id).unwrap();
@@ -2886,6 +2935,7 @@ fn test_postpone_event_sets_grace_period() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Set ledger time and grace period end in the future
@@ -2937,6 +2987,7 @@ fn test_register_event_resale_cap_invalid() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidResaleCapBps)));
 }
@@ -2977,6 +3028,7 @@ fn test_cancel_event_success() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.cancel_event(&event_id);
@@ -3020,6 +3072,7 @@ fn test_archive_event_rejects_active_event() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     let result = client.try_archive_event(&event_id);
@@ -3061,6 +3114,7 @@ fn test_cancel_already_cancelled_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.cancel_event(&event_id);
@@ -3103,6 +3157,7 @@ fn test_update_status_on_cancelled_event_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     client.cancel_event(&event_id);
@@ -3747,6 +3802,7 @@ fn test_register_event_with_banner_cid() {
         target_deadline: None,
         banner_cid: banner_cid.clone(),
         tags: None,
+        is_private: false,
     });
 
     let event = client.get_event(&event_id).unwrap();
@@ -3797,6 +3853,7 @@ fn test_goal_met_event_fires_only_once() {
         target_deadline: None,
         banner_cid: banner_cid.clone(),
         tags: None,
+        is_private: false,
     });
 
     let event = client.get_event(&event_id).unwrap();
@@ -3854,6 +3911,7 @@ fn test_register_event_without_banner_cid() {
         target_deadline: Some(1000),
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Drain setup events
@@ -3921,6 +3979,7 @@ fn test_series_pass_issued_at_timestamp() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Register a series
@@ -3998,6 +4057,7 @@ fn base_args(
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     }
 }
 
@@ -4335,6 +4395,7 @@ fn test_cancelled_status_guard() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     // Cancel event
@@ -4468,6 +4529,7 @@ fn test_register_event_restocking_fee_exceeds_tier_price_fails() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert_eq!(
@@ -4523,6 +4585,7 @@ fn test_register_event_restocking_fee_equal_to_tier_price_succeeds() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert!(result.is_ok());
@@ -4574,6 +4637,7 @@ fn test_register_event_restocking_fee_zero_always_valid() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert!(result.is_ok());
@@ -4625,6 +4689,7 @@ fn test_register_event_restocking_fee_overflow_returns_invalid_fee_calculation()
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
 
     assert_eq!(
@@ -4707,6 +4772,7 @@ fn test_register_event_tier_limit_overflow() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::SupplyOverflow)));
 }
@@ -4761,6 +4827,7 @@ fn test_register_event_invalid_tier_limit_negative() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidQuantity)));
 }
@@ -4814,6 +4881,7 @@ fn test_register_event_milestone_overflow() {
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     assert_eq!(result, Err(Ok(EventRegistryError::SupplyOverflow)));
 }
@@ -4852,6 +4920,7 @@ fn tags_base_args(env: &Env, event_id: &str, organizer: &Address) -> EventRegist
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     }
 }
 
@@ -5044,4 +5113,222 @@ fn test_version_fn_returns_1() {
     let contract_id = env.register(EventRegistry, ());
     let client = EventRegistryClient::new(&env, &contract_id);
     assert_eq!(client.version(), 1u32);
+}
+
+// ── Private Event Support Tests ───────────────────────────────────────────────
+
+fn setup_private_test(env: &Env) -> (EventRegistryClient<'static>, Address, Address, Address) {
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let organizer = Address::generate(env);
+    let platform_wallet = Address::generate(env);
+    let usdc_token = Address::generate(env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+    let ticket_payment = Address::generate(env);
+    client.set_ticket_payment_contract(&ticket_payment);
+    (client, admin, organizer, ticket_payment)
+}
+
+fn register_event_with_privacy(
+    env: &Env,
+    client: &EventRegistryClient,
+    organizer: &Address,
+    event_id: &str,
+    is_private: bool,
+) {
+    let metadata_cid = String::from_str(
+        env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+    let mut tiers = Map::new(env);
+    tiers.set(
+        String::from_str(env, "tier_1"),
+        crate::types::TicketTier {
+            name: String::from_str(env, "General"),
+            price: 1000,
+            tier_limit: 100,
+            current_sold: 0,
+            is_refundable: false,
+            auction_config: soroban_sdk::vec![env],
+        },
+    );
+    client.register_event(&EventRegistrationArgs {
+        event_id: String::from_str(env, event_id),
+        name: String::from_str(env, "Test Event"),
+        organizer_address: organizer.clone(),
+        payment_address: test_payment_address(env),
+        metadata_cid,
+        max_supply: 100,
+        milestone_plan: None,
+        tiers,
+        refund_deadline: 0,
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+        banner_cid: None,
+        tags: None,
+        is_private,
+    });
+}
+
+/// A public event increments the global managed events counter.
+#[test]
+fn test_public_event_increments_managed_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, _) = setup_private_test(&env);
+
+    assert_eq!(client.get_managed_events_count(), 0);
+    register_event_with_privacy(&env, &client, &organizer, "pub_evt", false);
+    assert_eq!(client.get_managed_events_count(), 1);
+}
+
+/// A private event does NOT increment the global managed events counter.
+#[test]
+fn test_private_event_excluded_from_managed_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, _) = setup_private_test(&env);
+
+    assert_eq!(client.get_managed_events_count(), 0);
+    register_event_with_privacy(&env, &client, &organizer, "priv_evt", true);
+    assert_eq!(client.get_managed_events_count(), 0);
+}
+
+/// A public event increments the global active events counter.
+#[test]
+fn test_public_event_increments_active_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, _) = setup_private_test(&env);
+
+    assert_eq!(client.get_active_events_count(), 0);
+    register_event_with_privacy(&env, &client, &organizer, "pub_evt", false);
+    assert_eq!(client.get_active_events_count(), 1);
+}
+
+/// A private event does NOT increment the global active events counter.
+#[test]
+fn test_private_event_excluded_from_active_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, _) = setup_private_test(&env);
+
+    assert_eq!(client.get_active_events_count(), 0);
+    register_event_with_privacy(&env, &client, &organizer, "priv_evt", true);
+    assert_eq!(client.get_active_events_count(), 0);
+}
+
+/// Mixed registration: only public events count toward global counters.
+#[test]
+fn test_mixed_public_private_events_counters() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, _) = setup_private_test(&env);
+
+    register_event_with_privacy(&env, &client, &organizer, "pub_1", false);
+    register_event_with_privacy(&env, &client, &organizer, "priv_1", true);
+    register_event_with_privacy(&env, &client, &organizer, "pub_2", false);
+    register_event_with_privacy(&env, &client, &organizer, "priv_2", true);
+
+    // 2 public events counted, 2 private excluded
+    assert_eq!(client.get_managed_events_count(), 2);
+    assert_eq!(client.get_active_events_count(), 2);
+}
+
+/// Tickets sold for a public event are included in the global counter.
+#[test]
+fn test_public_event_tickets_counted_globally() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, ticket_payment) = setup_private_test(&env);
+
+    register_event_with_privacy(&env, &client, &organizer, "pub_evt", false);
+
+    assert_eq!(client.get_global_tickets_sold(), 0);
+    client.increment_inventory(
+        &String::from_str(&env, "pub_evt"),
+        &String::from_str(&env, "tier_1"),
+        &2u32,
+    );
+    assert_eq!(client.get_global_tickets_sold(), 2);
+
+    // Decrement (refund) also updates the counter
+    client.decrement_inventory(
+        &String::from_str(&env, "pub_evt"),
+        &String::from_str(&env, "tier_1"),
+    );
+    assert_eq!(client.get_global_tickets_sold(), 1);
+    let _ = ticket_payment; // suppress unused warning
+}
+
+/// Tickets sold for a private event are NOT included in the global counter.
+#[test]
+fn test_private_event_tickets_excluded_from_global_counter() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, ticket_payment) = setup_private_test(&env);
+
+    register_event_with_privacy(&env, &client, &organizer, "priv_evt", true);
+
+    assert_eq!(client.get_global_tickets_sold(), 0);
+    client.increment_inventory(
+        &String::from_str(&env, "priv_evt"),
+        &String::from_str(&env, "tier_1"),
+        &5u32,
+    );
+    // Global counter must remain 0 for private events
+    assert_eq!(client.get_global_tickets_sold(), 0);
+
+    // Decrement (refund) also must not affect the global counter
+    client.decrement_inventory(
+        &String::from_str(&env, "priv_evt"),
+        &String::from_str(&env, "tier_1"),
+    );
+    assert_eq!(client.get_global_tickets_sold(), 0);
+    let _ = ticket_payment;
+}
+
+/// is_private flag is stored and retrievable via get_event.
+#[test]
+fn test_is_private_flag_stored_on_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, _) = setup_private_test(&env);
+
+    register_event_with_privacy(&env, &client, &organizer, "priv_evt", true);
+    register_event_with_privacy(&env, &client, &organizer, "pub_evt", false);
+
+    let priv_event = client
+        .get_event(&String::from_str(&env, "priv_evt"))
+        .unwrap();
+    let pub_event = client
+        .get_event(&String::from_str(&env, "pub_evt"))
+        .unwrap();
+
+    assert!(priv_event.is_private);
+    assert!(!pub_event.is_private);
+}
+
+/// Deactivating a private event does not affect the active events counter.
+#[test]
+fn test_private_event_status_change_does_not_affect_active_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, organizer, _) = setup_private_test(&env);
+
+    register_event_with_privacy(&env, &client, &organizer, "pub_evt", false);
+    register_event_with_privacy(&env, &client, &organizer, "priv_evt", true);
+
+    assert_eq!(client.get_active_events_count(), 1);
+
+    // Deactivate the private event — counter must stay at 1
+    client.update_event_status(&String::from_str(&env, "priv_evt"), &false);
+    assert_eq!(client.get_active_events_count(), 1);
+
+    // Re-activate the private event — counter must stay at 1
+    client.update_event_status(&String::from_str(&env, "priv_evt"), &true);
+    assert_eq!(client.get_active_events_count(), 1);
 }

--- a/contract/contracts/event_registry/src/test_e2e.rs
+++ b/contract/contracts/event_registry/src/test_e2e.rs
@@ -49,6 +49,7 @@ fn make_event_args(
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     }
 }
 

--- a/contract/contracts/event_registry/src/test_free_ticket.rs
+++ b/contract/contracts/event_registry/src/test_free_ticket.rs
@@ -84,6 +84,7 @@ fn register_free_event(
         target_deadline: None,
         banner_cid: None,
         tags: None,
+        is_private: false,
     });
     id
 }

--- a/contract/contracts/event_registry/src/types.rs
+++ b/contract/contracts/event_registry/src/types.rs
@@ -139,6 +139,10 @@ pub struct EventInfo {
     pub banner_cid: Option<String>,
     /// Optional categorical tags for the event (e.g., "Music", "Tech")
     pub tags: Option<Vec<String>>,
+    /// Whether the event is private and should be excluded from global public counters.
+    /// Private events do not appear in managed event counts, active event counts,
+    /// or global tickets sold totals.
+    pub is_private: bool,
 }
 
 /// Payment information for an event
@@ -180,6 +184,8 @@ pub struct EventRegistrationArgs {
     pub banner_cid: Option<String>,
     /// Optional categorical tags for the event (e.g., "Music", "Tech")
     pub tags: Option<Vec<String>>,
+    /// Whether the event is private and should be excluded from global public counters.
+    pub is_private: bool,
 }
 
 /// Audit log entry for blacklist actions

--- a/contract/contracts/event_registry/test_snapshots/test/test_complete_event_lifecycle.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_complete_event_lifecycle.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -311,6 +319,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_event_inactive_error.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_event_inactive_error.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -308,6 +316,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_get_event_payment_info.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_get_event_payment_info.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -286,6 +294,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_inactive_event.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_inactive_event.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -385,6 +393,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_max_supply_exceeded.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_max_supply_exceeded.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -414,6 +422,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_persists_across_reads.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_persists_across_reads.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -489,6 +497,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_success.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -414,6 +422,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_unlimited_supply.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_unlimited_supply.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -613,6 +621,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_multiple_tiers_inventory.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_multiple_tiers_inventory.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -495,6 +503,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_organizer_events_list.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_organizer_events_list.1.json
@@ -87,6 +87,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -286,6 +294,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false
@@ -603,6 +619,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -828,6 +852,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_duplicate_event_fails.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_duplicate_event_fails.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -286,6 +294,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_event_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_event_success.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -345,6 +353,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_event_unlimited_supply.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_event_unlimited_supply.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -286,6 +294,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_storage_operations.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_storage_operations.1.json
@@ -88,6 +88,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -367,6 +375,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_tier_not_found.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_tier_not_found.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -363,6 +371,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_tier_supply_exceeded.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_tier_supply_exceeded.1.json
@@ -53,6 +53,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -438,6 +446,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_event_status.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_event_status.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -308,6 +316,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_invalid_cid.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_invalid_cid.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -288,6 +296,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_success.1.json
@@ -34,6 +34,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_private"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "max_supply"
                       },
                       "val": {
@@ -308,6 +316,14 @@
                     {
                       "key": {
                         "symbol": "is_postponed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_private"
                       },
                       "val": {
                         "bool": false


### PR DESCRIPTION
Closes: #391 

Add an `is_private: bool` field to `EventInfo` and `EventRegistrationArgs` so that private events are excluded from the three global public counters: managed event count, active event count, and global tickets sold.

Changes:
- types.rs: Added `is_private: bool` to both `EventInfo` and `EventRegistrationArgs`. Defaults to `false` for all existing callers.
- storage.rs: Updated `store_event` to skip `increment_global_event_count` when `is_private = true`. Updated `sync_active_event_count` to skip active-count increments/decrements for private events (including the private→public transition case). Updated `remove_event` to skip the active-count decrement when the removed event is private.
- lib.rs: Updated `register_event` to propagate `args.is_private` into the stored `EventInfo`. Updated `increment_inventory` and `decrement_inventory` to skip `add/subtract_from_global_tickets_sold` when the event is private.
- test.rs / test_e2e.rs / test_free_ticket.rs: Updated all `EventRegistrationArgs` and `EventInfo` struct literals to include `is_private: false` (preserving existing behaviour). Added 9 new tests covering: public event increments managed count, private event excluded from managed count, public/private active count, mixed registration, public tickets counted globally, private tickets excluded from global counter, is_private flag stored on event, and private event status changes do not affect the active count.

Why: Issue #391 requests a private event flag so that invite-only or internal events do not inflate platform-wide public statistics.

Assumptions: `is_private` is set at registration time and is immutable thereafter (no setter function is provided, consistent with the issue description which only asks for the flag to control counter exclusion).