### PR TITLE
feat(contract): add cancellation_reason to EventInfo and cancel_event (#399)

### DIFF
--- a/contract/contracts/event_registry/src/events.rs
+++ b/contract/contracts/event_registry/src/events.rs
@@ -75,6 +75,8 @@ pub struct EventCancelledEvent {
     pub cancelled_by: Address,
     /// The ledger timestamp when the cancellation occurred.
     pub timestamp: u64,
+    /// Optional human-readable reason for the cancellation.
+    pub reason: Option<String>,
 }
 
 /// Emitted when an event is archived and its full storage is reclaimed.

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -91,9 +91,9 @@ use crate::events::{
     EventRegisteredEvent, EventStatusUpdatedEvent, EventsSuspendedEvent, FeeUpdatedEvent,
     FeedbackCidSetEvent, GlobalPromoUpdatedEvent, GoalMetEvent, InitializationEvent,
     InventoryIncrementedEvent, LoyaltyScoreUpdatedEvent, MetadataUpdatedEvent,
-    OrganizerBlacklistedEvent, OrganizerRemovedFromBlacklistEvent, RegistryUpgradedEvent,
-    ScannerAuthorizedEvent, StakerRewardsClaimedEvent, StakerRewardsDistributedEvent,
-    TokenWhitelistUpdatedEvent, ProposalCancelledEvent,
+    OrganizerBlacklistedEvent, OrganizerRemovedFromBlacklistEvent, ProposalCancelledEvent,
+    RegistryUpgradedEvent, ScannerAuthorizedEvent, StakerRewardsClaimedEvent,
+    StakerRewardsDistributedEvent, TokenWhitelistUpdatedEvent,
 };
 use crate::types::{
     BlacklistAuditEntry, EventInfo, EventReceipt, EventRegistrationArgs, EventStatus, GuestProfile,

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -412,6 +412,7 @@ impl EventRegistry {
             accepted_tokens: args.accepted_tokens,
             use_global_whitelist: args.use_global_whitelist,
             feedback_cid: None,
+            cancellation_reason: None,
         };
 
         storage::store_event(&env, event_info);
@@ -492,7 +493,11 @@ impl EventRegistry {
     }
 
     /// Cancel an event (only by organizer). This is irreversible.
-    pub fn cancel_event(env: Env, event_id: String) -> Result<(), EventRegistryError> {
+    pub fn cancel_event(
+        env: Env,
+        event_id: String,
+        reason: Option<String>,
+    ) -> Result<(), EventRegistryError> {
         match storage::get_event(&env, event_id.clone()) {
             Some(mut event_info) => {
                 // Verify organizer signature
@@ -505,6 +510,7 @@ impl EventRegistry {
                 // Update status to Cancelled and deactivate
                 event_info.status = EventStatus::Cancelled;
                 event_info.is_active = false;
+                event_info.cancellation_reason = reason.clone();
                 storage::update_event(&env, event_info.clone());
 
                 // Emit cancellation event
@@ -514,6 +520,7 @@ impl EventRegistry {
                         event_id,
                         cancelled_by: event_info.organizer_address,
                         timestamp: env.ledger().timestamp(),
+                        reason,
                     },
                 );
 

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -328,6 +328,7 @@ fn test_storage_operations() {
         accepted_tokens: soroban_sdk::Vec::new(&env),
         use_global_whitelist: true,
         feedback_cid: None,
+        cancellation_reason: None,
     };
 
     client.store_event(&event_info);
@@ -427,6 +428,7 @@ fn test_get_total_tickets_sold_uses_event_current_supply() {
         accepted_tokens: soroban_sdk::Vec::new(&env),
         use_global_whitelist: true,
         feedback_cid: None,
+        cancellation_reason: None,
     });
 
     assert_eq!(client.get_total_tickets_sold(&event_id), 9);
@@ -486,7 +488,7 @@ fn test_get_active_events_count_tracks_status_changes() {
     client.update_event_status(&event_1, &false);
     assert_eq!(client.get_active_events_count(), 2);
 
-    client.cancel_event(&event_2);
+    client.cancel_event(&event_2, &None);
     assert_eq!(client.get_active_events_count(), 1);
 
     client.update_event_status(&event_1, &true);
@@ -543,6 +545,7 @@ fn test_organizer_events_list() {
         accepted_tokens: soroban_sdk::Vec::new(&env),
         use_global_whitelist: true,
         feedback_cid: None,
+        cancellation_reason: None,
     };
 
     let event_2 = EventInfo {
@@ -580,6 +583,7 @@ fn test_organizer_events_list() {
         accepted_tokens: soroban_sdk::Vec::new(&env),
         use_global_whitelist: true,
         feedback_cid: None,
+        cancellation_reason: None,
     };
 
     let contract_id = env.register(EventRegistry, ());
@@ -644,6 +648,7 @@ fn test_get_organizer_receipts_returns_archived_receipts() {
             accepted_tokens: soroban_sdk::Vec::new(&env),
             use_global_whitelist: true,
             feedback_cid: None,
+            cancellation_reason: None,
         };
 
     let event_id_1 = String::from_str(&env, "archived_1");
@@ -2600,6 +2605,7 @@ fn test_increment_inventory_supply_overflow() {
         accepted_tokens: soroban_sdk::Vec::new(&env),
         use_global_whitelist: true,
         feedback_cid: None,
+        cancellation_reason: None,
     });
 
     let result = client.try_increment_inventory(&event_id, &tier_id, &Address::generate(&env), &1);
@@ -2676,6 +2682,7 @@ fn test_increment_inventory_tier_sold_overflow() {
         accepted_tokens: soroban_sdk::Vec::new(&env),
         use_global_whitelist: true,
         feedback_cid: None,
+        cancellation_reason: None,
     });
 
     let result = client.try_increment_inventory(&event_id, &tier_id, &Address::generate(&env), &1);
@@ -3340,11 +3347,15 @@ fn test_cancel_event_success() {
         use_global_whitelist: true,
     });
 
-    client.cancel_event(&event_id);
+    client.cancel_event(&event_id, &Some(String::from_str(&env, "Venue unavailable")));
 
     let event_info = client.get_event(&event_id).unwrap();
     assert_eq!(event_info.status, EventStatus::Cancelled);
     assert!(!event_info.is_active);
+    assert_eq!(
+        event_info.cancellation_reason,
+        Some(String::from_str(&env, "Venue unavailable"))
+    );
 }
 
 #[test]
@@ -3436,8 +3447,8 @@ fn test_cancel_already_cancelled_fails() {
         use_global_whitelist: true,
     });
 
-    client.cancel_event(&event_id);
-    let result = client.try_cancel_event(&event_id);
+    client.cancel_event(&event_id, &None);
+    let result = client.try_cancel_event(&event_id, &None);
     assert_eq!(result, Err(Ok(EventRegistryError::EventAlreadyCancelled)));
 }
 

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -3347,7 +3347,10 @@ fn test_cancel_event_success() {
         use_global_whitelist: true,
     });
 
-    client.cancel_event(&event_id, &Some(String::from_str(&env, "Venue unavailable")));
+    client.cancel_event(
+        &event_id,
+        &Some(String::from_str(&env, "Venue unavailable")),
+    );
 
     let event_info = client.get_event(&event_id).unwrap();
     assert_eq!(event_info.status, EventStatus::Cancelled);
@@ -3495,7 +3498,7 @@ fn test_update_status_on_cancelled_event_fails() {
         use_global_whitelist: true,
     });
 
-    client.cancel_event(&event_id);
+    client.cancel_event(&event_id, &None);
     let result = client.try_update_event_status(&event_id, &true);
     assert_eq!(result, Err(Ok(EventRegistryError::EventCancelled)));
 }
@@ -4918,7 +4921,7 @@ fn test_cancelled_status_guard() {
     });
 
     // Cancel event
-    client.cancel_event(&event_id);
+    client.cancel_event(&event_id, &None);
 
     // Try to update status - should fail
     let result = client.try_update_event_status(&event_id, &true);
@@ -6434,7 +6437,7 @@ fn test_set_feedback_cid_cancelled_event_fails() {
     setup_event_with_end_time_no_init(&env, &client, &organizer, "evt_cancelled", 500);
 
     let event_id = String::from_str(&env, "evt_cancelled");
-    client.cancel_event(&event_id);
+    client.cancel_event(&event_id, &None);
 
     let result = client.try_set_feedback_cid(
         &event_id,

--- a/contract/contracts/event_registry/src/test_e2e.rs
+++ b/contract/contracts/event_registry/src/test_e2e.rs
@@ -109,7 +109,7 @@ fn test_e2e_complete_event_lifecycle() {
     assert!(info.is_active);
 
     // Cancel (irreversible)
-    client.cancel_event(&String::from_str(&env, "evt_1"));
+    client.cancel_event(&String::from_str(&env, "evt_1"), &None);
     let info = client.get_event(&String::from_str(&env, "evt_1")).unwrap();
     assert!(!info.is_active);
     assert_eq!(info.status, EventStatus::Cancelled);
@@ -119,7 +119,7 @@ fn test_e2e_complete_event_lifecycle() {
     assert_eq!(result, Err(Ok(EventRegistryError::EventCancelled)));
 
     // Cancel again should fail
-    let result = client.try_cancel_event(&String::from_str(&env, "evt_1"));
+    let result = client.try_cancel_event(&String::from_str(&env, "evt_1"), &None);
     assert_eq!(result, Err(Ok(EventRegistryError::EventAlreadyCancelled)));
 }
 

--- a/contract/contracts/event_registry/src/types.rs
+++ b/contract/contracts/event_registry/src/types.rs
@@ -161,6 +161,8 @@ pub struct EventInfo {
     pub use_global_whitelist: bool,
     /// Optional IPFS CID for post-event feedback (only settable after end_time)
     pub feedback_cid: Option<String>,
+    /// Optional human-readable reason provided when the event was cancelled
+    pub cancellation_reason: Option<String>,
 }
 
 /// Payment information for an event


### PR DESCRIPTION
Adds a structured cancellation reason to the event registry contract so organizers can communicate *why* an event was cancelled — improving transparency for attendees and downstream integrations.

## Changes
  
  ### \`types.rs\`
  - Added \`cancellation_reason: Option<String>\` field to \`EventInfo\`
  - Initialized to \`None\` on event registration
  
  ### \`lib.rs\`
  - Updated \`cancel_event\` signature to accept \`reason: Option<String>\`
  - Stores the reason in \`event_info.cancellation_reason\` before persisting
  - Passes the reason through to \`EventCancelledEvent\`
  
  ### \`events.rs\`
  - Added \`reason: Option<String>\` field to \`EventCancelledEvent\` for on-chain observability
  
  ### \`test.rs\` / \`test_e2e.rs\`
  - Updated all \`cancel_event\` / \`try_cancel_event\` call sites to pass the new argument
  - Added \`cancellation_reason: None\` to all direct \`EventInfo\` struct constructions
  - Extended \`test_cancel_event_success\` to assert the reason is persisted correctly


Closes #399