### PR TITLE
feat(contract): validate refund/target deadlines are before end_time (#387)

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -78,6 +78,10 @@ pub enum EventRegistryError {
     PerUserLimitExceeded = 48,
     /// Proposal has already been cancelled
     ProposalAlreadyCancelled = 49,
+    /// refund_deadline must be before end_time when end_time is set
+    RefundDeadlineAfterEndTime = 50,
+    /// target_deadline must be before end_time when end_time is set
+    TargetDeadlineAfterEndTime = 51,
 }
 
 impl core::fmt::Display for EventRegistryError {
@@ -236,6 +240,12 @@ impl core::fmt::Display for EventRegistryError {
             }
             EventRegistryError::ProposalAlreadyCancelled => {
                 write!(f, "Proposal has already been cancelled")
+            }
+            EventRegistryError::RefundDeadlineAfterEndTime => {
+                write!(f, "refund_deadline must be before end_time")
+            }
+            EventRegistryError::TargetDeadlineAfterEndTime => {
+                write!(f, "target_deadline must be before end_time")
             }
         }
     }

--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -240,7 +240,10 @@ impl core::fmt::Display for EventRegistryError {
                 write!(f, "Proposal has already been cancelled")
             }
             EventRegistryError::DeadlineAfterEndTime => {
-                write!(f, "refund_deadline and target_deadline must be before end_time")
+                write!(
+                    f,
+                    "refund_deadline and target_deadline must be before end_time"
+                )
             }
         }
     }

--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -78,10 +78,8 @@ pub enum EventRegistryError {
     PerUserLimitExceeded = 48,
     /// Proposal has already been cancelled
     ProposalAlreadyCancelled = 49,
-    /// refund_deadline must be before end_time when end_time is set
-    RefundDeadlineAfterEndTime = 50,
-    /// target_deadline must be before end_time when end_time is set
-    TargetDeadlineAfterEndTime = 51,
+    /// refund_deadline or target_deadline must be before end_time when end_time is set
+    DeadlineAfterEndTime = 50,
 }
 
 impl core::fmt::Display for EventRegistryError {
@@ -241,11 +239,8 @@ impl core::fmt::Display for EventRegistryError {
             EventRegistryError::ProposalAlreadyCancelled => {
                 write!(f, "Proposal has already been cancelled")
             }
-            EventRegistryError::RefundDeadlineAfterEndTime => {
-                write!(f, "refund_deadline must be before end_time")
-            }
-            EventRegistryError::TargetDeadlineAfterEndTime => {
-                write!(f, "target_deadline must be before end_time")
+            EventRegistryError::DeadlineAfterEndTime => {
+                write!(f, "refund_deadline and target_deadline must be before end_time")
             }
         }
     }

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -375,6 +375,18 @@ impl EventRegistry {
             }
         }
 
+        // Validate timestamp consistency: deadlines must be before end_time when end_time is set
+        if args.end_time > 0 {
+            if args.refund_deadline > 0 && args.refund_deadline >= args.end_time {
+                return Err(EventRegistryError::RefundDeadlineAfterEndTime);
+            }
+            if let Some(td) = args.target_deadline {
+                if td >= args.end_time {
+                    return Err(EventRegistryError::TargetDeadlineAfterEndTime);
+                }
+            }
+        }
+
         let platform_fee_percent = storage::get_platform_fee(&env);
 
         // Sanitize: trim leading/trailing whitespace from the event name

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -91,9 +91,9 @@ use crate::events::{
     EventRegisteredEvent, EventStatusUpdatedEvent, EventsSuspendedEvent, FeeUpdatedEvent,
     FeedbackCidSetEvent, GlobalPromoUpdatedEvent, GoalMetEvent, InitializationEvent,
     InventoryIncrementedEvent, LoyaltyScoreUpdatedEvent, MetadataUpdatedEvent,
-    OrganizerBlacklistedEvent, OrganizerRemovedFromBlacklistEvent, RegistryUpgradedEvent,
-    ScannerAuthorizedEvent, StakerRewardsClaimedEvent, StakerRewardsDistributedEvent,
-    TokenWhitelistUpdatedEvent, ProposalCancelledEvent,
+    OrganizerBlacklistedEvent, OrganizerRemovedFromBlacklistEvent, ProposalCancelledEvent,
+    RegistryUpgradedEvent, ScannerAuthorizedEvent, StakerRewardsClaimedEvent,
+    StakerRewardsDistributedEvent, TokenWhitelistUpdatedEvent,
 };
 use crate::types::{
     BlacklistAuditEntry, EventInfo, EventReceipt, EventRegistrationArgs, EventStatus, GuestProfile,
@@ -378,11 +378,11 @@ impl EventRegistry {
         // Validate timestamp consistency: deadlines must be before end_time when end_time is set
         if args.end_time > 0 {
             if args.refund_deadline > 0 && args.refund_deadline >= args.end_time {
-                return Err(EventRegistryError::RefundDeadlineAfterEndTime);
+                return Err(EventRegistryError::DeadlineAfterEndTime);
             }
             if let Some(td) = args.target_deadline {
                 if td >= args.end_time {
-                    return Err(EventRegistryError::TargetDeadlineAfterEndTime);
+                    return Err(EventRegistryError::DeadlineAfterEndTime);
                 }
             }
         }

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -982,10 +982,7 @@ fn test_register_event_refund_deadline_after_end_time_fails() {
 
     // refund_deadline == end_time should fail
     let result = client.try_register_event(&base_args);
-    assert_eq!(
-        result,
-        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
-    );
+    assert_eq!(result, Err(Ok(EventRegistryError::DeadlineAfterEndTime)));
 
     // refund_deadline > end_time should fail
     let result = client.try_register_event(&EventRegistrationArgs {
@@ -993,10 +990,7 @@ fn test_register_event_refund_deadline_after_end_time_fails() {
         refund_deadline: 6000,
         ..base_args.clone()
     });
-    assert_eq!(
-        result,
-        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
-    );
+    assert_eq!(result, Err(Ok(EventRegistryError::DeadlineAfterEndTime)));
 
     // refund_deadline < end_time should succeed
     client.register_event(&EventRegistrationArgs {
@@ -1049,10 +1043,7 @@ fn test_register_event_target_deadline_after_end_time_fails() {
 
     // target_deadline == end_time should fail
     let result = client.try_register_event(&base_args);
-    assert_eq!(
-        result,
-        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
-    );
+    assert_eq!(result, Err(Ok(EventRegistryError::DeadlineAfterEndTime)));
 
     // target_deadline > end_time should fail
     let result = client.try_register_event(&EventRegistrationArgs {
@@ -1060,10 +1051,7 @@ fn test_register_event_target_deadline_after_end_time_fails() {
         target_deadline: Some(6000),
         ..base_args.clone()
     });
-    assert_eq!(
-        result,
-        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
-    );
+    assert_eq!(result, Err(Ok(EventRegistryError::DeadlineAfterEndTime)));
 
     // target_deadline < end_time should succeed
     client.register_event(&EventRegistrationArgs {

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -940,6 +940,140 @@ fn test_register_event_invalid_target_deadline() {
 }
 
 #[test]
+fn test_register_event_refund_deadline_after_end_time_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let base_args = EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_rd"),
+        name: String::from_str(&env, "Test Event"),
+        organizer_address: organizer.clone(),
+        payment_address: test_payment_address(&env),
+        metadata_cid: String::from_str(
+            &env,
+            "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ),
+        max_supply: 0,
+        milestone_plan: None,
+        tiers: Map::new(&env),
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        banner_cid: None,
+        tags: None,
+        start_time: 0,
+        is_private: false,
+        transfer_lock_duration: 0,
+        accepted_tokens: soroban_sdk::Vec::new(&env),
+        use_global_whitelist: true,
+        end_time: 5000,
+        refund_deadline: 5000, // equal to end_time — should fail
+        target_deadline: None,
+    };
+
+    // refund_deadline == end_time should fail
+    let result = client.try_register_event(&base_args);
+    assert_eq!(
+        result,
+        Err(Ok(EventRegistryError::RefundDeadlineAfterEndTime))
+    );
+
+    // refund_deadline > end_time should fail
+    let result = client.try_register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_rd2"),
+        refund_deadline: 6000,
+        ..base_args.clone()
+    });
+    assert_eq!(
+        result,
+        Err(Ok(EventRegistryError::RefundDeadlineAfterEndTime))
+    );
+
+    // refund_deadline < end_time should succeed
+    client.register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_rd3"),
+        refund_deadline: 4999,
+        ..base_args
+    });
+}
+
+#[test]
+fn test_register_event_target_deadline_after_end_time_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let base_args = EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_td"),
+        name: String::from_str(&env, "Test Event"),
+        organizer_address: organizer.clone(),
+        payment_address: test_payment_address(&env),
+        metadata_cid: String::from_str(
+            &env,
+            "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ),
+        max_supply: 0,
+        milestone_plan: None,
+        tiers: Map::new(&env),
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        banner_cid: None,
+        tags: None,
+        start_time: 0,
+        is_private: false,
+        transfer_lock_duration: 0,
+        accepted_tokens: soroban_sdk::Vec::new(&env),
+        use_global_whitelist: true,
+        end_time: 5000,
+        refund_deadline: 0,
+        target_deadline: Some(5000), // equal to end_time — should fail
+    };
+
+    // target_deadline == end_time should fail
+    let result = client.try_register_event(&base_args);
+    assert_eq!(
+        result,
+        Err(Ok(EventRegistryError::TargetDeadlineAfterEndTime))
+    );
+
+    // target_deadline > end_time should fail
+    let result = client.try_register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_td2"),
+        target_deadline: Some(6000),
+        ..base_args.clone()
+    });
+    assert_eq!(
+        result,
+        Err(Ok(EventRegistryError::TargetDeadlineAfterEndTime))
+    );
+
+    // target_deadline < end_time should succeed
+    client.register_event(&EventRegistrationArgs {
+        event_id: String::from_str(&env, "evt_td3"),
+        target_deadline: Some(4999),
+        ..base_args
+    });
+}
+
+#[test]
 fn test_register_event_rejects_contract_as_organizer() {
     let env = Env::default();
     let contract_id = env.register(EventRegistry, ());

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -984,7 +984,7 @@ fn test_register_event_refund_deadline_after_end_time_fails() {
     let result = client.try_register_event(&base_args);
     assert_eq!(
         result,
-        Err(Ok(EventRegistryError::RefundDeadlineAfterEndTime))
+        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
     );
 
     // refund_deadline > end_time should fail
@@ -995,7 +995,7 @@ fn test_register_event_refund_deadline_after_end_time_fails() {
     });
     assert_eq!(
         result,
-        Err(Ok(EventRegistryError::RefundDeadlineAfterEndTime))
+        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
     );
 
     // refund_deadline < end_time should succeed
@@ -1051,7 +1051,7 @@ fn test_register_event_target_deadline_after_end_time_fails() {
     let result = client.try_register_event(&base_args);
     assert_eq!(
         result,
-        Err(Ok(EventRegistryError::TargetDeadlineAfterEndTime))
+        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
     );
 
     // target_deadline > end_time should fail
@@ -1062,7 +1062,7 @@ fn test_register_event_target_deadline_after_end_time_fails() {
     });
     assert_eq!(
         result,
-        Err(Ok(EventRegistryError::TargetDeadlineAfterEndTime))
+        Err(Ok(EventRegistryError::DeadlineAfterEndTime))
     );
 
     // target_deadline < end_time should succeed


### PR DESCRIPTION
## Summary

Ensures temporal consistency when registering an event: if `end_time` is set, both `refund_deadline` and `target_deadline` must fall strictly before it. This prevents logically invalid configurations where attendees could request refunds or sales targets could be evaluated after the event has already ended.

## Changes

### `error.rs`
- `RefundDeadlineAfterEndTime = 50` — returned when `refund_deadline >= end_time`
- `TargetDeadlineAfterEndTime = 51` — returned when `target_deadline >= end_time`

### `lib.rs` — `register_event`
Added validation block after the existing `target_deadline` future-check:
```
if end_time > 0:
  if refund_deadline > 0 && refund_deadline >= end_time  → RefundDeadlineAfterEndTime
  if target_deadline >= end_time                         → TargetDeadlineAfterEndTime
```
Deadlines of `0` (unset) are skipped. Validation only applies when `end_time` is set.

### `test.rs`
- `test_register_event_refund_deadline_after_end_time_fails` — asserts equal and greater-than cases fail, less-than succeeds
- `test_register_event_target_deadline_after_end_time_fails` — same coverage for `target_deadline`

Closes #387