### PR TITLE
feat(frontend): implement real email and oauth sign-in flow #424

### DIFF
--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, FormEvent } from "react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 function validateEmail(email: string): boolean {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -12,8 +13,9 @@ export default function AuthPage() {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
     if (!email) {
@@ -29,9 +31,24 @@ export default function AuthPage() {
     setError("");
     setIsLoading(true);
 
-    setTimeout(() => {
+    try {
+      const res = await fetch('/api/auth/email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Authentication failed');
+      }
+
+      router.push('/home');
+    } catch (err: any) {
+      setError(err.message || 'Something went wrong');
+    } finally {
       setIsLoading(false);
-    }, 1200);
+    }
   };
 
   return (
@@ -142,6 +159,7 @@ export default function AuthPage() {
           {/* Google Button */}
           <button
             type="button"
+            onClick={() => window.location.href = '/api/auth/google'}
             className="
               w-full
               bg-black
@@ -168,6 +186,7 @@ export default function AuthPage() {
           {/* Apple Button */}
           <button
             type="button"
+            onClick={() => window.location.href = '/api/auth/apple'}
             className="
               w-full
               bg-black


### PR DESCRIPTION
## Description
Resolves #424
Depends on #423 

This PR wires up the `/auth` page in the Next.js app to replace the basic loading spinner simulation with an actual connection against our new authentication API. 

### Changes Made:
- Refactored [apps/web/app/auth/page.tsx](cci:7://file:///home/edohwares/Desktop/Room/drips/agora/apps/web/app/auth/page.tsx:0:0-0:0) utilizing `useRouter` from `next/navigation`.
- Replaced the delayed `setTimeout` loading simulation with a real server-side `POST` fetch call directed to the newly created `/api/auth/email`.
- Added a `try/catch` handler to gracefully capture payload and server-side errors, rendering them reliably within the UI's pre-built local `setError()` hook.
- Added programmatic redirect functionality to successfully push authenticated sessions pointing back to `/home`.
- Wired the placeholder Google and Apple OAuth icons with raw `window.location.href` to bounce dynamically against `/api/auth/google` and `/api/auth/apple` flow routers! 

### Testing:
- Passed an arbitrarily malformed email address and verified the error propagates correctly to the UI.
- Passed correct payload structures and verified loading spinners disable cleanly while properly rejecting bad authentication configurations from the server.
- Verified `/home` routing successfully kicks in upon receiving a confirmed `res.ok` status back from the backend endpoint.
- Clicked Apple and Google buttons to verify redirects properly reach the API entry points.

Closes #424 