### PR TITLE
feat(server): add Soroban RPC blockchain connectivity health check

### DIFF
--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -198,6 +198,7 @@ Once the backend is running, confirm the system is healthy with these endpoints:
 
 ```bash
 curl http://localhost:3001/api/v1/health
+curl http://localhost:3001/api/v1/health/blockchain
 curl http://localhost:3001/api/v1/health/db
 curl http://localhost:3001/api/v1/health/ready
 ```
@@ -205,6 +206,7 @@ curl http://localhost:3001/api/v1/health/ready
 What to expect:
 
 - `/api/v1/health`: API process is up
+- `/api/v1/health/blockchain`: Soroban RPC endpoint is reachable
 - `/api/v1/health/db`: database connection is working
 - `/api/v1/health/ready`: service is ready to serve requests
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -136,6 +136,35 @@ Database connectivity check.
 }
 ```
 
+#### GET /health/blockchain
+
+Soroban RPC connectivity check.
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "status": "ok",
+    "blockchain": "soroban",
+    "soroban_rpc": "https://soroban-testnet.stellar.org",
+    "timestamp": "2024-01-15T10:30:00Z"
+  },
+  "message": "Soroban RPC is reachable"
+}
+```
+
+**Error Response (503):**
+```json
+{
+  "success": false,
+  "error": {
+    "code": "EXTERNAL_SERVICE_ERROR",
+    "message": "Soroban RPC health check failed"
+  }
+}
+```
+
 #### GET /health/ready
 
 Readiness check for both API and Database.

--- a/server/.env.example
+++ b/server/.env.example
@@ -24,3 +24,8 @@ RUST_LOG=info
 # Example: http://localhost:3000,https://agora.example.com
 # Default: http://localhost:3000,http://localhost:5173
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
+# Soroban RPC health probe URL
+# Used by GET /api/v1/health/blockchain to check blockchain connectivity
+# Default: https://soroban-testnet.stellar.org
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -10,16 +10,17 @@ dependencies = [
  "chrono",
  "dotenvy",
  "pin-project",
+ "reqwest",
  "rust_decimal",
  "serde",
  "serde_json",
  "serde_yaml",
  "sqlx",
  "temp-env",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -617,8 +618,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -628,9 +631,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -783,6 +788,23 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -791,14 +813,22 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -948,6 +978,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1078,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1347,6 +1399,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1578,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1712,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1813,7 +2013,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "sqlformat",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1899,7 +2099,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "uuid",
  "whoami",
@@ -1940,7 +2140,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "uuid",
  "whoami",
@@ -2021,6 +2221,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2068,7 +2271,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2076,6 +2288,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2142,6 +2365,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2254,6 +2487,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,6 +2636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2650,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2432,6 +2696,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,6 +2739,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2782,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2577,6 +2893,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -2610,6 +2935,22 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -2618,7 +2959,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.53.1",
  "windows_i686_msvc 0.53.1",
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
@@ -2630,6 +2971,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2645,6 +2992,12 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
@@ -2657,9 +3010,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2675,6 +3040,12 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
@@ -2684,6 +3055,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2699,6 +3076,12 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
@@ -2708,6 +3091,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,6 +18,7 @@ pin-project = "1.1"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Env handling (recommended)
 dotenvy = "0.15"

--- a/server/README.md
+++ b/server/README.md
@@ -40,6 +40,7 @@ These variables are read from `.env` at startup:
 | `RUST_ENV` | No | `development` | Enables production-specific behavior such as HSTS when set to `production` |
 | `RUST_LOG` | No | `info` | Log level for `tracing` output |
 | `CORS_ALLOWED_ORIGINS` | No | `http://localhost:3000,http://localhost:5173` | Comma-separated allowlist for browser clients |
+| `SOROBAN_RPC_URL` | No | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint used by blockchain connectivity health checks |
 
 Example values are already provided in [`server/.env.example`](/c:/Users/User/Desktop/agora/server/.env.example).
 
@@ -101,6 +102,12 @@ Try the health endpoint:
 
 ```bash
 curl http://localhost:3001/api/v1/health
+```
+
+Try the blockchain health endpoint:
+
+```bash
+curl http://localhost:3001/api/v1/health/blockchain
 ```
 
 ## Architecture Overview
@@ -172,6 +179,7 @@ bash ./test_health_endpoints.sh
 If you are using Git Bash on Windows, run the same command there. The script checks:
 
 - `GET /api/v1/health`
+- `GET /api/v1/health/blockchain`
 - `GET /api/v1/health/db`
 - `GET /api/v1/health/ready`
 

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -18,6 +18,7 @@
 //! - `RUST_ENV` (optional, default: development) - Environment mode
 //! - `CORS_ALLOWED_ORIGINS` (optional, default: localhost URLs) - CORS origins
 //! - `RUST_LOG` (optional, default: info) - Logging level
+//! - `SOROBAN_RPC_URL` (optional, default: Stellar testnet RPC) - Blockchain health probe URL
 
 use std::env;
 
@@ -48,6 +49,9 @@ pub struct Config {
 
     /// Logging configuration (RUST_LOG).
     pub rust_log: String,
+
+    /// Soroban RPC URL for blockchain connectivity checks.
+    pub soroban_rpc_url: String,
 }
 
 impl Config {
@@ -77,6 +81,8 @@ impl Config {
             .unwrap_or_else(|_| "http://localhost:3000,http://localhost:5173".to_string());
 
         let rust_log = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+        let soroban_rpc_url =
+            env::var("SOROBAN_RPC_URL").unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string());
 
         Ok(Self {
             database_url,
@@ -84,6 +90,7 @@ impl Config {
             rust_env,
             cors_allowed_origins,
             rust_log,
+            soroban_rpc_url,
         })
     }
 

--- a/server/src/handlers/health.rs
+++ b/server/src/handlers/health.rs
@@ -1,7 +1,9 @@
 use axum::{extract::State, response::IntoResponse, response::Response};
 use chrono::Utc;
 use serde::Serialize;
+use serde_json::json;
 use sqlx::PgPool;
+use std::time::Duration;
 
 use crate::utils::error::AppError;
 use crate::utils::response::success;
@@ -24,6 +26,14 @@ struct HealthReadyResponse {
     status: &'static str,
     api: &'static str,
     database: &'static str,
+}
+
+#[derive(Serialize)]
+struct HealthBlockchainResponse {
+    status: &'static str,
+    blockchain: &'static str,
+    soroban_rpc: String,
+    timestamp: String,
 }
 
 /// GET /health – Combined check for API and Database.
@@ -90,6 +100,56 @@ pub async fn health_check_ready(State(pool): State<PgPool>) -> Response {
     } else {
         AppError::ExternalServiceError("Service is not ready: database is unreachable".to_string())
             .into_response()
+    }
+}
+
+/// GET /health/blockchain – Soroban RPC connectivity check.
+///
+/// Returns 200 when the configured Soroban RPC endpoint is reachable.
+/// On failure the response uses [`AppError`] for a consistent error schema.
+pub async fn health_check_blockchain() -> Response {
+    let soroban_rpc_url =
+        std::env::var("SOROBAN_RPC_URL").unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string());
+
+    let client = match reqwest::Client::builder().timeout(Duration::from_secs(5)).build() {
+        Ok(client) => client,
+        Err(error) => {
+            return AppError::ExternalServiceError(format!(
+                "Failed to initialize Soroban RPC probe client: {error}"
+            ))
+            .into_response();
+        }
+    };
+
+    let response = client
+        .post(&soroban_rpc_url)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": "health-check",
+            "method": "getHealth",
+        }))
+        .send()
+        .await;
+
+    match response {
+        Ok(resp) if resp.status().is_success() => {
+            let payload = HealthBlockchainResponse {
+                status: "ok",
+                blockchain: "soroban",
+                soroban_rpc: soroban_rpc_url,
+                timestamp: Utc::now().to_rfc3339(),
+            };
+            success(payload, "Soroban RPC is reachable").into_response()
+        }
+        Ok(resp) => AppError::ExternalServiceError(format!(
+            "Soroban RPC health check failed with HTTP status {}",
+            resp.status()
+        ))
+        .into_response(),
+        Err(error) => AppError::ExternalServiceError(format!(
+            "Soroban RPC health check failed: {error}"
+        ))
+        .into_response(),
     }
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -40,6 +40,7 @@ async fn main() {
     tracing::info!("Configuration: RUST_ENV={}", config.rust_env);
     tracing::info!("Configuration: RUST_LOG={}", config.rust_log);
     tracing::info!("Configuration: CORS_ALLOWED_ORIGINS={}", config.cors_allowed_origins);
+    tracing::info!("Configuration: SOROBAN_RPC_URL={}", config.soroban_rpc_url);
     // Note: DATABASE_URL is strictly excluded from logging for security reasons.
 
     let pool = PgPoolOptions::new()

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -32,7 +32,7 @@ use crate::handlers::{
     example_empty_success,
     example_not_found,
     example_validation_error,
-    health::{ health_check, health_check_db, health_check_ready },
+    health::{ health_check, health_check_blockchain, health_check_db, health_check_ready },
 };
 
 /// Creates the main application router with all routes and middleware
@@ -45,6 +45,7 @@ use crate::handlers::{
 pub fn create_routes(pool: PgPool) -> Router {
     let api_routes = Router::new()
         .route("/health", get(health_check))
+        .route("/health/blockchain", get(health_check_blockchain))
         .route("/health/db", get(health_check_db))
         .route("/health/ready", get(health_check_ready))
         .route("/examples/validation-error", get(example_validation_error))
@@ -70,6 +71,10 @@ mod tests {
         Router::new()
             .route(
                 "/api/v1/health",
+                get(|| async { "ok" })
+            )
+            .route(
+                "/api/v1/health/blockchain",
                 get(|| async { "ok" })
             )
             .route(
@@ -112,6 +117,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_health_blockchain_route_exists_under_api_v1() {
+        let router = test_router();
+        assert_ne!(
+            get_status(router, "/api/v1/health/blockchain").await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
     async fn test_health_ready_route_exists_under_api_v1() {
         let router = test_router();
         assert_ne!(get_status(router, "/api/v1/health/ready").await, StatusCode::NOT_FOUND);
@@ -148,6 +162,7 @@ mod tests {
     async fn test_old_routes_without_prefix_return_404() {
         let router = test_router();
         assert_eq!(get_status(router.clone(), "/health").await, StatusCode::NOT_FOUND);
+        assert_eq!(get_status(router.clone(), "/health/blockchain").await, StatusCode::NOT_FOUND);
         assert_eq!(get_status(router.clone(), "/health/db").await, StatusCode::NOT_FOUND);
         assert_eq!(get_status(router, "/health/ready").await, StatusCode::NOT_FOUND);
     }

--- a/server/test_health_endpoints.sh
+++ b/server/test_health_endpoints.sh
@@ -18,14 +18,21 @@ echo ""
 echo ""
 
 # Test 2: Database health check (with database running)
-echo "2. Testing GET /api/v1/health/db (Database health check - DB running)"
+echo "2. Testing GET /api/v1/health/blockchain (Soroban RPC reachability check)"
+echo "Expected: 200 OK with blockchain: soroban"
+curl -i -X GET "$BASE_URL/health/blockchain"
+echo ""
+echo ""
+
+# Test 3: Database health check (with database running)
+echo "3. Testing GET /api/v1/health/db (Database health check - DB running)"
 echo "Expected: 200 OK with database: connected"
 curl -i -X GET "$BASE_URL/health/db"
 echo ""
 echo ""
 
-# Test 3: Readiness check (with both healthy)
-echo "3. Testing GET /api/v1/health/ready (Readiness check - all healthy)"
+# Test 4: Readiness check (with both healthy)
+echo "4. Testing GET /api/v1/health/ready (Readiness check - all healthy)"
 echo "Expected: 200 OK with api: ok, database: ok"
 curl -i -X GET "$BASE_URL/health/ready"
 echo ""


### PR DESCRIPTION
Closes #400
Closes #401
Closes #402
Closes #410

## Summary
- implement issue #410 by adding a Soroban RPC reachability endpoint at GET /api/v1/health/blockchain
- probe RPC connectivity using a short-timeout JSON-RPC request (method: getHealth)
- return standardized success/error response payloads consistent with existing health handlers
- wire route registration and route-level tests for the new endpoint
- add SOROBAN_RPC_URL configuration support with a safe default for testnet
- update backend docs and health test script to include blockchain connectivity checks

## Validation
- cargo test (run in server/) passed: 70 tests passed