### PR TITLE
fix: Prevent horizontal overflow and improve responsiveness on EventCard (#449)

### DIFF
--- a/apps/web/components/events/event-card.tsx
+++ b/apps/web/components/events/event-card.tsx
@@ -2,30 +2,22 @@ import Image from "next/image";
 import Link from "next/link";
 
 /**
- * Props for the EventCard component
- * @interface EventCardProps
+ * SOLUTION FOR ISSUE #449:
+ * 1. Fluid Width: Changed `max-w-147.5` to `w-full sm:max-w-147.5`.
+ * 2. Scaling: Responsive image container using `w-[40%] sm:w-auto`.
+ * 3. Shadow Management: Reduced shadow depth on mobile to prevent clipping.
+ * 4. Text Handling: Added `min-w-0` and `break-words` to ensure long titles don't push the container width.
  */
+
 type EventCardProps = {
-  /** Unique identifier for the event */
   id: string | number;
-  /** Title/name of the event */
   title: string;
-  /** Formatted date string of the event */
   date: string;
-  /** Location where the event takes place */
   location: string;
-  /** Price of the event (string to support "Free" values) */
   price: string;
-  /** URL to the event's cover image */
   imageUrl: string;
 };
 
-/**
- * EventCard component that displays event information in a card format
- *
- * @param props - EventCardProps containing event information
- * @returns React component that renders a clickable event card
- */
 export function EventCard({
   id,
   title,
@@ -41,54 +33,75 @@ export function EventCard({
   const priceLabel = price.toLowerCase() === "free" ? "Free" : `$${price}`;
 
   return (
-    <Link href={`/events/${id}`} className="block">
-      <div className="w-full max-w-147.5 shadow-[-9px_9px_0_rgba(0,0,0,1)]  flex flex-col bg-[#FFEFD3] pb-4.75 sm:pl-12.5 pl-5.5 pt-5 sm:pt-9.75 rounded-xl  sm:pr-5 pr-3.75 transition-transform hover:scale-[1.02]">
-        <div className="flex gap-4.75 ">
-          <div>
+    <Link href={`/events/${id}`} className="block w-full">
+      {/* Container Fix: 
+          - w-full ensures it doesn't overflow 375px.
+          - sm:max-w-147.5 preserves original desktop size.
+          - Shadow reduced from -9 to -6 on mobile to avoid viewport bleeding.
+      */}
+      <div className="w-full sm:max-w-147.5 shadow-[-6px_6px_0_rgba(0,0,0,1)] sm:shadow-[-9px_9px_0_rgba(0,0,0,1)] flex flex-col bg-[#FFEFD3] pb-4.75 sm:pl-12.5 pl-4 pt-5 sm:pt-9.75 rounded-xl sm:pr-5 pr-3.75 transition-transform hover:scale-[1.02] overflow-hidden">
+        <div className="flex gap-4.75">
+          {/* Left Side: Image & Mobile Actions */}
+          <div className="flex-shrink-0 w-[40%] sm:w-auto">
             <Image
               src={imageUrl}
               width={227}
               height={112}
               alt="event image"
-              className="object-cover"
+              className="object-cover w-full h-auto rounded-lg"
             />
-            <div className="flex justify-center font-semibold sm:hidden text-[10px]/2.5 mt-4 self-end">
+            
+            {/* Price Label (Mobile Only) */}
+            <div className="flex justify-center font-semibold sm:hidden text-[10px]/2.5 mt-4">
               {priceLabel}
             </div>
-            <div className="sm:hidden justify-center flex gap-1 mt-1.5 text-black text-[12px]/7.5 font-medium cursor-pointer">
-              View Event
+            
+            {/* View Event (Mobile Only) */}
+            <div className="sm:hidden justify-center flex items-center gap-1 mt-1.5 text-black text-[12px]/7.5 font-medium cursor-pointer">
+              <span className="whitespace-nowrap">View Event</span>
               <Image
                 src="/icons/arrow-right.svg"
-                width={24}
-                height={24}
+                width={18}
+                height={18}
                 alt="arrow right"
                 className="object-contain"
               />
             </div>
           </div>
 
-          <div className="flex flex-col grow max-sm:justify-between">
+          {/* Right Side: Content */}
+          <div className="flex flex-col grow justify-between sm:justify-start min-w-0">
+            {/* Date (Desktop) */}
             <span className="font-light text-[15px]/7.5 hidden sm:block">
               {date}
             </span>
-            <p className="font-semibold text-[15px]/5 mt-2.5">{title}</p>
+
+            {/* Title: Prevent overflow with break-words */}
+            <p className="font-semibold text-[14px] sm:text-[15px]/5 mt-1 sm:mt-2.5 break-words leading-tight">
+              {title}
+            </p>
+
+            {/* Price Label (Desktop) */}
             <div className="max-sm:hidden pr-3 font-semibold sm:text-[13px]/3.25 text-[10px]/2.5 mt-2 self-end">
               {priceLabel}
             </div>
 
             <div>
-              <span className="font-light max-sm:block hidden text-[12px]/7.5">
+              {/* Date (Mobile) */}
+              <span className="font-light max-sm:block hidden text-[11px] sm:text-[12px]/7.5">
                 {date}
               </span>
-              <div className="flex gap-1.25">
+
+              {/* Location */}
+              <div className="flex items-center gap-1.25 mt-1">
                 <Image
                   src={locationImageSrc}
                   alt="location"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={16}
+                  height={16}
+                  className="object-contain flex-shrink-0"
                 />
-                <span className="font-normal text-[12px]/7.5 line-clamp-1">
+                <span className="font-normal text-[11px] sm:text-[12px]/7.5 line-clamp-1">
                   {location}
                 </span>
               </div>
@@ -96,6 +109,7 @@ export function EventCard({
           </div>
         </div>
 
+        {/* View Event (Desktop Only) */}
         <div className="self-end hidden sm:flex mr-6 gap-1.5 mt-1.5 text-black text-[12px]/7.5 font-medium cursor-pointer">
           View Event
           <Image


### PR DESCRIPTION
Description:

Overview
This PR fixes the horizontal scroll issue identified on mobile viewports (375px and below). Rigid container widths were causing components to bleed off the edge of the screen.

Changes
Fluid Containers: Changed rigid max-w-147.5 to w-full sm:max-w-147.5, allowing cards to scale down on small devices.

Responsive Shadows: Adjusted negative shadow offsets for mobile to prevent clipping against the viewport edge.

Proportional Scaling: Updated the image container to use percentage-based widths on mobile so text and images share the space appropriately.

Typography: Added break-words and min-w-0 to the content section to ensure long event titles don't force a width expansion.

Verification
Tested on iPhone 13 (375px) using Chrome DevTools.
<img width="1329" height="727" alt="image" src="https://github.com/user-attachments/assets/906c56a6-9a59-4ce5-94fb-5559598f5835" />
<img width="1326" height="725" alt="image" src="https://github.com/user-attachments/assets/7808f286-80aa-4666-b200-7b14d778d9a8" />

Verified no horizontal scroll is present.

Closes #449