### PR TITLE
feat: implement event pausing mechanism with pause/resume functionality

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -80,6 +80,10 @@ pub enum EventRegistryError {
     ProposalAlreadyCancelled = 49,
     /// refund_deadline or target_deadline must be before end_time when end_time is set
     DeadlineAfterEndTime = 50,
+    /// Event is currently paused and does not accept tickets sales
+    EventPaused = 51,
+    /// Event is already in the requested state (pause/resume)
+    NoStateChange = 52,
 }
 
 impl core::fmt::Display for EventRegistryError {
@@ -244,6 +248,12 @@ impl core::fmt::Display for EventRegistryError {
                     f,
                     "refund_deadline and target_deadline must be before end_time"
                 )
+            }
+            EventRegistryError::EventPaused => {
+                write!(f, "Event is currently paused and does not accept ticket sales")
+            }
+            EventRegistryError::NoStateChange => {
+                write!(f, "Event is already in the requested state")
             }
         }
     }

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -1284,6 +1284,103 @@ impl EventRegistry {
         storage::is_scanner_authorized(&env, event_id, &scanner)
     }
 
+    // ── Event Pause Management ─────────────────────────────────────────────────
+
+    /// Pauses an event, preventing new ticket sales. Only callable by the organizer.
+    ///
+    /// Organizers can temporarily halt ticket sales due to venue issues or capacity reassessment.
+    /// While paused, the TicketPayment contract will reject new purchase requests.
+    /// All other event data remains intact and unchanged.
+    ///
+    /// # Arguments
+    /// * `event_id` - The event ID to pause
+    ///
+    /// # Errors
+    /// * `EventNotFound` - If no event with the given ID exists
+    /// * `Unauthorized` - If the caller is not the event organizer
+    /// * `NoStateChange` - If the event is already paused
+    pub fn pause_event(env: Env, event_id: String) -> Result<(), EventRegistryError> {
+        let event_info =
+            storage::get_event(&env, event_id.clone()).ok_or(EventRegistryError::EventNotFound)?;
+
+        // Verify organizer authorization
+        event_info.organizer_address.require_auth();
+
+        // Check if already paused
+        if storage::is_event_paused(&env, &event_id) {
+            return Err(EventRegistryError::NoStateChange);
+        }
+
+        // Set the pause flag
+        storage::set_event_paused(&env, &event_id, true);
+
+        env.events().publish(
+            (AgoraEvent::EventStatusUpdated,),
+            EventStatusUpdatedEvent {
+                event_id,
+                is_active: event_info.is_active,
+                updated_by: event_info.organizer_address,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Resumes a paused event, allowing ticket sales to resume. Only callable by the organizer.
+    ///
+    /// Reactivates ticket sales for a previously paused event.
+    /// The event must be currently paused to call this function.
+    ///
+    /// # Arguments
+    /// * `event_id` - The event ID to resume
+    ///
+    /// # Errors
+    /// * `EventNotFound` - If no event with the given ID exists
+    /// * `Unauthorized` - If the caller is not the event organizer
+    /// * `NoStateChange` - If the event is not currently paused
+    pub fn resume_event(env: Env, event_id: String) -> Result<(), EventRegistryError> {
+        let event_info =
+            storage::get_event(&env, event_id.clone()).ok_or(EventRegistryError::EventNotFound)?;
+
+        // Verify organizer authorization
+        event_info.organizer_address.require_auth();
+
+        // Check if not paused
+        if !storage::is_event_paused(&env, &event_id) {
+            return Err(EventRegistryError::NoStateChange);
+        }
+
+        // Clear the pause flag
+        storage::set_event_paused(&env, &event_id, false);
+
+        env.events().publish(
+            (AgoraEvent::EventStatusUpdated,),
+            EventStatusUpdatedEvent {
+                event_id,
+                is_active: event_info.is_active,
+                updated_by: event_info.organizer_address,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Returns whether an event is currently paused.
+    ///
+    /// Read-only function for external contract consumption. Can be queried by the
+    /// TicketPayment contract to determine if ticket sales should be blocked.
+    ///
+    /// # Arguments
+    /// * `event_id` - The event ID to check
+    ///
+    /// # Returns
+    /// `true` if the event is paused; `false` otherwise (including if the event doesn't exist).
+    pub fn is_event_paused(env: Env, event_id: String) -> bool {
+        storage::is_event_paused(&env, &event_id)
+    }
+
     // ── Loyalty & Staking ──────────────────────────────────────────────────────
 
     /// Configures staking parameters. Only callable by the admin.

--- a/contract/contracts/event_registry/src/storage.rs
+++ b/contract/contracts/event_registry/src/storage.rs
@@ -1099,3 +1099,22 @@ pub fn subtract_from_user_ticket_count(
         current.saturating_sub(quantity),
     );
 }
+
+// ── Event Pause Storage ────────────────────────────────────────────────────────
+
+/// Returns whether an event is paused. Returns false if the pause status is not set (i.e., event is not paused).
+/// Storage key: DataKey::EventPaused(event_id). Storage type: Persistent
+pub fn is_event_paused(env: &Env, event_id: &String) -> bool {
+    env.storage()
+        .persistent()
+        .get::<_, bool>(&DataKey::EventPaused(event_id.clone()))
+        .unwrap_or(false)
+}
+
+/// Sets the pause status for an event.
+/// Storage key: DataKey::EventPaused(event_id). Storage type: Persistent
+pub fn set_event_paused(env: &Env, event_id: &String, is_paused: bool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::EventPaused(event_id.clone()), &is_paused);
+}

--- a/contract/contracts/event_registry/src/types.rs
+++ b/contract/contracts/event_registry/src/types.rs
@@ -412,4 +412,6 @@ pub enum DataKey {
     GlobalTicketsSold,
     /// Mapping of (event_id, tier_id, user_address) to ticket count for per-user limits (Persistent)
     UserTicketCount(String, String, Address),
+    /// Mapping of event_id to pause status (bool) – whether the event is paused (Persistent)
+    EventPaused(String),
 }


### PR DESCRIPTION
Closes #454 

PR Summary
Implemented the event pausing mechanism for the event_registry Soroban contract.

What changed
[types.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [DataKey::EventPaused(String)](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to track paused state per event.
[storage.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [is_event_paused(env, event_id)](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [set_event_paused(env, event_id, is_paused)](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) storage helpers using persistent storage.
[error.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [EventPaused = 51](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added [NoStateChange = 52](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added display strings for both new error variants.
[lib.rs](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [pause_event(env, event_id)](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [resume_event(env, event_id)](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) contract entry points.
Added [is_event_paused(env, event_id)](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) read-only contract function.
Organizer auth is enforced via [event_info.organizer_address.require_auth()](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Functions return [NoStateChange](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when the event is already in the requested paused/resumed state.
Existing event validity is checked and [EventNotFound](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is returned if missing.
Notes
This implementation stores pause state separately from [EventInfo](vscode-file://vscode-app/snap/code/234/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as requested.
I could not execute Rust tests locally because cargo/rustc is not installed in the current environment.