### PR TITLE
feat(contracts): support multi-tier ticket inventory

### DIFF
--- a/contract/contracts/event_registry/README.md
+++ b/contract/contracts/event_registry/README.md
@@ -215,7 +215,7 @@ The contract returns `EventRegistryError` enum variants for various failure cond
 - `OrganizerBlacklisted` - Organizer is blacklisted
 - `InvalidFeePercent` - Fee exceeds 100%
 - `MaxSupplyExceeded` - Ticket limit reached
-- `TierSupplyExceeded` - Tier limit reached
+- `TierSoldOut` - Tier limit reached
 - `EventInactive` - Event is not active
 - And many more...
 

--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -19,7 +19,7 @@ pub enum EventRegistryError {
     UnauthorizedCaller = 12,
     TierLimitExceedsMaxSupply = 13,
     TierNotFound = 14,
-    TierSupplyExceeded = 15,
+    TierSoldOut = 15,
     SupplyUnderflow = 16,
     InvalidQuantity = 17,
     OrganizerBlacklisted = 18,
@@ -119,7 +119,7 @@ impl core::fmt::Display for EventRegistryError {
                     "The specified ticket tier ID does not exist for this event"
                 )
             }
-            EventRegistryError::TierSupplyExceeded => {
+            EventRegistryError::TierSoldOut => {
                 write!(
                     f,
                     "The requested ticket tier has sold out and cannot accept more registrations"

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -863,7 +863,7 @@ impl EventRegistry {
     /// * `EventNotFound` - If no event with the given ID exists.
     /// * `EventInactive` - If the event is not currently active.
     /// * `TierNotFound` - If the tier does not exist.
-    /// * `TierSupplyExceeded` - If the tier's limit has been reached.
+    /// * `TierSoldOut` - If the tier's limit has been reached.
     /// * `MaxSupplyExceeded` - If the event's max supply has been reached (when max_supply > 0).
     /// * `SupplyOverflow` - If incrementing would cause an i128 overflow.
     /// * `PerUserLimitExceeded` - If the user has exceeded the per-user limit for this tier.
@@ -914,7 +914,7 @@ impl EventRegistry {
             .ok_or(EventRegistryError::SupplyOverflow)?;
 
         if new_tier_sold > tier.tier_limit {
-            return Err(EventRegistryError::TierSupplyExceeded);
+            return Err(EventRegistryError::TierSoldOut);
         }
 
         // Check per-user limit

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -2560,7 +2560,7 @@ fn test_tier_supply_exceeded() {
     client.increment_inventory(&event_id, &tier_id, &Address::generate(&env), &1);
 
     let result = client.try_increment_inventory(&event_id, &tier_id, &Address::generate(&env), &1);
-    assert_eq!(result, Err(Ok(EventRegistryError::TierSupplyExceeded)));
+    assert_eq!(result, Err(Ok(EventRegistryError::TierSoldOut)));
 }
 
 #[test]
@@ -2654,6 +2654,124 @@ fn test_multiple_tiers_inventory() {
 
     let vip_tier = event_info.tiers.get(vip_id).unwrap();
     assert_eq!(vip_tier.current_sold, 1);
+}
+
+#[test]
+fn test_three_tiers_inventory_is_isolated_and_sold_out_tier_errors() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let payment_addr = test_payment_address(&env);
+    let platform_wallet = Address::generate(&env);
+    let ticket_payment = Address::generate(&env);
+
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+    client.set_ticket_payment_contract(&ticket_payment);
+
+    let event_id = String::from_str(&env, "three_tier_event");
+    let metadata_cid = String::from_str(
+        &env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+
+    let general_id = String::from_str(&env, "general");
+    let vip_id = String::from_str(&env, "vip");
+    let early_bird_id = String::from_str(&env, "early_bird");
+
+    let mut tiers = Map::new(&env);
+    tiers.set(
+        general_id.clone(),
+        TicketTier {
+            name: String::from_str(&env, "General"),
+            price: 5000000,
+            tier_limit: 50,
+            current_sold: 0,
+            is_refundable: true,
+            auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
+            max_per_user: 0,
+        },
+    );
+    tiers.set(
+        vip_id.clone(),
+        TicketTier {
+            name: String::from_str(&env, "VIP"),
+            price: 10000000,
+            tier_limit: 20,
+            current_sold: 0,
+            is_refundable: true,
+            auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
+            max_per_user: 0,
+        },
+    );
+    tiers.set(
+        early_bird_id.clone(),
+        TicketTier {
+            name: String::from_str(&env, "Early Bird"),
+            price: 3000000,
+            tier_limit: 1,
+            current_sold: 0,
+            is_refundable: true,
+            auction_config: soroban_sdk::vec![&env],
+            loyalty_multiplier: 1,
+            max_per_user: 0,
+        },
+    );
+
+    client.register_event(&EventRegistrationArgs {
+        event_id: event_id.clone(),
+        name: String::from_str(&env, "Tiered Event"),
+        organizer_address: organizer,
+        payment_address: payment_addr,
+        metadata_cid,
+        max_supply: 71,
+        milestone_plan: None,
+        tiers,
+        refund_deadline: 0,
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+        banner_cid: None,
+        tags: None,
+        start_time: 0,
+        is_private: false,
+        end_time: 0,
+        transfer_lock_duration: 0,
+        accepted_tokens: soroban_sdk::Vec::new(&env),
+        use_global_whitelist: true,
+    });
+
+    client.increment_inventory(&event_id, &general_id, &Address::generate(&env), &2);
+    client.increment_inventory(&event_id, &vip_id, &Address::generate(&env), &1);
+    client.increment_inventory(&event_id, &early_bird_id, &Address::generate(&env), &1);
+
+    let sold_out_attempt = client.try_increment_inventory(
+        &event_id,
+        &early_bird_id,
+        &Address::generate(&env),
+        &1,
+    );
+    assert_eq!(sold_out_attempt, Err(Ok(EventRegistryError::TierSoldOut)));
+
+    let event_info = client.get_event(&event_id).unwrap();
+    assert_eq!(event_info.current_supply, 4);
+
+    let general_tier = event_info.tiers.get(general_id).unwrap();
+    assert_eq!(general_tier.current_sold, 2);
+
+    let vip_tier = event_info.tiers.get(vip_id).unwrap();
+    assert_eq!(vip_tier.current_sold, 1);
+
+    let early_bird_tier = event_info.tiers.get(early_bird_id).unwrap();
+    assert_eq!(early_bird_tier.current_sold, 1);
 }
 
 #[test]
@@ -5114,7 +5232,7 @@ fn test_tier_not_found_error_message() {
 
 #[test]
 fn test_tier_supply_exceeded_error_message() {
-    let buf = fmt_to_str(EventRegistryError::TierSupplyExceeded);
+    let buf = fmt_to_str(EventRegistryError::TierSoldOut);
     assert!(
         buf_starts_with(
             &buf,

--- a/contract/contracts/event_registry/src/test_e2e.rs
+++ b/contract/contracts/event_registry/src/test_e2e.rs
@@ -246,14 +246,14 @@ fn test_e2e_tier_supply_limits() {
         );
     }
 
-    // 4th fails with TierSupplyExceeded
+    // 4th fails with TierSoldOut
     let result = client.try_increment_inventory(
         &String::from_str(&env, "evt_tier"),
         &String::from_str(&env, "tier_1"),
         &Address::generate(&env),
         &1,
     );
-    assert_eq!(result, Err(Ok(EventRegistryError::TierSupplyExceeded)));
+    assert_eq!(result, Err(Ok(EventRegistryError::TierSoldOut)));
 }
 
 // ---------------------------------------------------------------------------

--- a/contract/contracts/event_registry/src/test_free_ticket.rs
+++ b/contract/contracts/event_registry/src/test_free_ticket.rs
@@ -213,7 +213,7 @@ fn test_free_ticket_respects_tier_limit() {
 
     // Third ticket must be rejected
     let result = client.try_increment_inventory(&event_id, &tier_id, &Address::generate(&env), &1);
-    assert_eq!(result, Err(Ok(EventRegistryError::TierSupplyExceeded)));
+    assert_eq!(result, Err(Ok(EventRegistryError::TierSoldOut)));
 }
 
 /// max_supply cap is enforced for free tickets when set.

--- a/contract/contracts/event_registry/test_max_per_user.rs
+++ b/contract/contracts/event_registry/test_max_per_user.rs
@@ -163,7 +163,7 @@ fn test_unlimited_per_user_limit() {
     
     // But not beyond the tier limit
     let result = client.try_increment_inventory(&event_id, &vip_tier, &user1, 1);
-    assert_eq!(result, Err(Ok(event_registry::error::EventRegistryError::TierSupplyExceeded)));
+    assert_eq!(result, Err(Ok(event_registry::error::EventRegistryError::TierSoldOut)));
 }
 
 #[test]

--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -104,8 +104,14 @@ pub mod event_registry {
         fn get_event_payment_info(env: Env, event_id: String) -> PaymentInfo;
         fn get_event(env: Env, event_id: String) -> Option<EventInfo>;
         fn get_organizer_address(env: Env, event_id: String) -> Option<Address>;
-        fn increment_inventory(env: Env, event_id: String, tier_id: String, quantity: u32);
-        fn decrement_inventory(env: Env, event_id: String, tier_id: String);
+        fn increment_inventory(
+            env: Env,
+            event_id: String,
+            tier_id: String,
+            user: Address,
+            quantity: u32,
+        );
+        fn decrement_inventory(env: Env, event_id: String, tier_id: String, user: Address);
         fn get_global_promo_bps(env: Env) -> u32;
         fn get_promo_expiry(env: Env) -> u64;
         fn is_scanner_authorized(env: Env, event_id: String, scanner: Address) -> bool;
@@ -785,7 +791,12 @@ impl TicketPaymentContract {
         }
 
         // 6. Increment inventory after successful payment
-        registry_client.increment_inventory(&event_id, &ticket_tier_id, &quantity);
+        registry_client.increment_inventory(
+            &event_id,
+            &ticket_tier_id,
+            &buyer_address,
+            &quantity,
+        );
 
         // 7. Create payment records for each individual ticket
         let quantity_i128 = quantity as i128;
@@ -1043,7 +1054,11 @@ impl TicketPaymentContract {
             .ok_or(TicketPaymentError::ArithmeticError)?;
 
         // Return ticket to inventory (increments available inventory)
-        registry_client.decrement_inventory(&payment.event_id, &payment.ticket_tier_id);
+        registry_client.decrement_inventory(
+            &payment.event_id,
+            &payment.ticket_tier_id,
+            &payment.buyer_address,
+        );
 
         let old_status = payment.status.clone();
         payment.status = PaymentStatus::Refunded;
@@ -2227,7 +2242,12 @@ impl TicketPaymentContract {
         add_to_total_fees_collected_by_token(&env, token_address.clone(), total_platform_fee);
 
         // Increment inventory
-        registry_client.increment_inventory(&event_id, &ticket_tier_id, &1);
+        registry_client.increment_inventory(
+            &event_id,
+            &ticket_tier_id,
+            &bidder_address,
+            &1,
+        );
 
         // Record the payment
         let empty_tx_hash = String::from_str(&env, "");

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -67,7 +67,7 @@ impl MockCancelledRegistry {
             end_time: 0,
         })
     }
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
 }
 
 // Mock Event Registry Contract
@@ -141,8 +141,15 @@ impl MockEventRegistry {
         None
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -215,7 +222,14 @@ impl MockEventRegistry2 {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -290,8 +304,15 @@ impl MockAuctionEventRegistry {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -314,7 +335,14 @@ impl MockEventRegistryNotFound {
         None
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -1047,7 +1075,13 @@ impl MockEventRegistryMaxSupply {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
         panic!("MaxSupplyExceeded");
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -1162,7 +1196,13 @@ impl MockEventRegistryWithInventory {
         })
     }
 
-    pub fn increment_inventory(env: Env, _event_id: String, _tier_id: String, quantity: u32) {
+    pub fn increment_inventory(
+        env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        quantity: u32,
+    ) {
         let key = Symbol::new(&env, "supply");
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
         env.storage()
@@ -1389,7 +1429,13 @@ impl MockEventRegistryWithMilestones {
         })
     }
 
-    pub fn increment_inventory(env: Env, _event_id: String, _tier_id: String, quantity: u32) {
+    pub fn increment_inventory(
+        env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        quantity: u32,
+    ) {
         let key = Symbol::new(&env, "supply");
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
         env.storage()
@@ -1730,8 +1776,15 @@ impl MockEventRegistryEarlyBird {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -2224,8 +2277,15 @@ impl MockEventRegistryWithOrganizer {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -2578,7 +2638,13 @@ impl MockPlatformRegistryE2E {
             .get(&MockPlatformDataKey::Event(event_id))
     }
 
-    pub fn increment_inventory(env: Env, event_id: String, tier_id: String, quantity: u32) {
+    pub fn increment_inventory(
+        env: Env,
+        event_id: String,
+        tier_id: String,
+        _user: Address,
+        quantity: u32,
+    ) {
         let mut event = env
             .storage()
             .persistent()
@@ -2609,7 +2675,7 @@ impl MockPlatformRegistryE2E {
             .set(&MockPlatformDataKey::Event(event_id), &event);
     }
 
-    pub fn decrement_inventory(env: Env, event_id: String, tier_id: String) {
+    pub fn decrement_inventory(env: Env, event_id: String, tier_id: String, _user: Address) {
         let mut event = env
             .storage()
             .persistent()
@@ -3015,8 +3081,15 @@ impl MockEventRegistryRefund {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -3091,8 +3164,15 @@ impl MockEventRegistryWithResaleCap {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -3363,8 +3443,15 @@ impl MockRegistryZeroCap {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -3982,8 +4069,15 @@ impl MockEventRegistryUsdPriced {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -4678,7 +4772,14 @@ impl MockEventRegistryWithFailingLoyaltyUpdate {
             end_time: 0,
         })
     }
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -4809,7 +4910,14 @@ impl MockEventRegistryWithLoyalty {
             end_time: 0,
         })
     }
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -4894,7 +5002,14 @@ impl MockEventRegistryWithExcessiveLoyaltyDiscount {
             end_time: 0,
         })
     }
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -5112,7 +5227,14 @@ impl MockEventRegistryCustomFee {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -5244,8 +5366,15 @@ impl MockEventRegistryHighPrice {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -5355,8 +5484,15 @@ impl MockEventRegistryRefundDeadline {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -5922,8 +6058,15 @@ impl MockEventRegistryForDust {
             .set(&Symbol::new(&env, "payment_addr"), &payment_addr);
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -6124,7 +6267,14 @@ impl MockEventRegistryForReferral {
             end_time: 0,
         })
     }
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }
@@ -6207,7 +6357,14 @@ impl MockEventRegistryFullLoyaltyDiscount {
             end_time: 0,
         })
     }
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }

--- a/contract/contracts/ticket_payment/src/test_e2e.rs
+++ b/contract/contracts/ticket_payment/src/test_e2e.rs
@@ -99,7 +99,13 @@ impl MockRegistryE2E {
         })
     }
 
-    pub fn increment_inventory(env: Env, _event_id: String, _tier_id: String, quantity: u32) {
+    pub fn increment_inventory(
+        env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        quantity: u32,
+    ) {
         let key = Symbol::new(&env, "supply");
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
         env.storage()
@@ -107,7 +113,7 @@ impl MockRegistryE2E {
             .set(&key, &(current + quantity as i128));
     }
 
-    pub fn decrement_inventory(env: Env, _event_id: String, _tier_id: String) {
+    pub fn decrement_inventory(env: Env, _event_id: String, _tier_id: String, _user: Address) {
         let key = Symbol::new(&env, "supply");
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
         if current > 0 {
@@ -220,7 +226,7 @@ impl MockRegistryCancelledE2E {
         })
     }
 
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
 
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
@@ -320,7 +326,13 @@ impl MockRegistryWithGoal {
         })
     }
 
-    pub fn increment_inventory(env: Env, event_id: String, _tier_id: String, quantity: u32) {
+    pub fn increment_inventory(
+        env: Env,
+        event_id: String,
+        _tier_id: String,
+        _user: Address,
+        quantity: u32,
+    ) {
         let key = (Symbol::new(&env, "supply"), event_id);
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
         env.storage()
@@ -328,7 +340,7 @@ impl MockRegistryWithGoal {
             .set(&key, &(current + quantity as i128));
     }
 
-    pub fn decrement_inventory(env: Env, event_id: String, _tier_id: String) {
+    pub fn decrement_inventory(env: Env, event_id: String, _tier_id: String, _user: Address) {
         let key = (Symbol::new(&env, "supply"), event_id);
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
         if current > 0 {
@@ -1103,8 +1115,15 @@ impl MockRegistryAuction {
         })
     }
 
-    pub fn increment_inventory(_env: Env, _event_id: String, _tier_id: String, _quantity: u32) {}
-    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String) {}
+    pub fn increment_inventory(
+        _env: Env,
+        _event_id: String,
+        _tier_id: String,
+        _user: Address,
+        _quantity: u32,
+    ) {
+    }
+    pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
     pub fn get_global_promo_bps(_env: Env) -> u32 {
         0
     }


### PR DESCRIPTION
Closes #458

---

## Summary
- align `ticket_payment` with the current `event_registry` inventory API by passing the buyer address into inventory updates
- rename the registry sold-out error from `TierSupplyExceeded` to `TierSoldOut`
- add acceptance coverage for a 3-tier event to prove sold counts stay isolated per tier
- refresh affected ticket-payment snapshots after the interface change

## What Changed
- updated the `ticket_payment` registry client signatures and inventory call sites for purchase, refund, and auction-close flows
- updated ticket-payment test doubles to expose the same inventory interface as the live registry
- updated registry docs/tests/error handling to use `TierSoldOut`
- added a regression test covering:
  - creating an event with 3 tiers
  - buying tickets in one tier without affecting the others
  - returning `TierSoldOut` when a tier is exhausted

## Validation
- `cargo test -p ticket-payment` ✅
- `cargo check -p event-registry --lib` ✅
- `cargo test -p event-registry` ⚠️ `rustc` crashed locally with a compiler memory/stack overrun while compiling the large registry test crate
