### PR TITLE
feat(contracts): add soulbound ticket support

### DIFF
--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -1279,16 +1279,6 @@ impl TicketPaymentContract {
 
         let registry_client = event_registry::Client::new(&env, &get_event_registry(&env));
 
-        // Allow organizer OR an authorized scanner
-        let organizer = registry_client
-            .get_organizer_address(&payment.event_id)
-            .ok_or(TicketPaymentError::EventNotFound)?;
-        let is_organizer = scanner == organizer;
-        let is_scanner = registry_client.is_scanner_authorized(&payment.event_id, &scanner);
-        if !is_organizer && !is_scanner {
-            return Err(TicketPaymentError::UnauthorizedScanner);
-        }
-
         // Check if the event has ended (prevent check-ins after end_time)
         let event_info = registry_client
             .try_get_event(&payment.event_id)
@@ -1297,13 +1287,20 @@ impl TicketPaymentContract {
             .flatten()
             .ok_or(TicketPaymentError::EventNotFound)?;
 
+        // Allow organizer OR an authorized scanner.
+        let is_organizer = scanner == event_info.organizer_address;
+        let is_scanner = registry_client.is_scanner_authorized(&payment.event_id, &scanner);
+        if !is_organizer && !is_scanner {
+            return Err(TicketPaymentError::UnauthorizedScanner);
+        }
+
         let current_time = env.ledger().timestamp();
         if event_info.end_time > 0 && current_time > event_info.end_time {
             return Err(TicketPaymentError::EventEnded);
         }
 
         payment.status = PaymentStatus::CheckedIn;
-        payment.last_checked_in_at = now;
+        payment.last_checked_in_at = current_time;
         store_payment(&env, payment.clone());
 
         #[allow(deprecated)]
@@ -1312,9 +1309,9 @@ impl TicketPaymentContract {
             TicketCheckedInEvent {
                 payment_id,
                 event_id: payment.event_id,
-                attendee,
+                attendee: payment.buyer_address,
                 scanner,
-                timestamp: now,
+                timestamp: current_time,
             },
         );
 
@@ -2453,7 +2450,11 @@ impl TicketPaymentContract {
         // Return ticket to inventory
         let event_registry_addr = get_event_registry(&env);
         let registry_client = event_registry::Client::new(&env, &event_registry_addr);
-        registry_client.decrement_inventory(&payment.event_id, &payment.ticket_tier_id);
+        registry_client.decrement_inventory(
+            &payment.event_id,
+            &payment.ticket_tier_id,
+            &payment.buyer_address,
+        );
 
         // Transfer full amount back to buyer
         let token_address = crate::storage::get_usdc_token(&env);

--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -844,6 +844,7 @@ impl TicketPaymentContract {
                 created_at,
                 confirmed_at: None,
                 refunded_amount: 0,
+                is_soulbound: false,
                 last_checked_in_at: 0,
             };
 
@@ -1722,6 +1723,10 @@ impl TicketPaymentContract {
             return Err(TicketPaymentError::InvalidPaymentStatus);
         }
 
+        if payment.is_soulbound {
+            return Err(TicketPaymentError::NonTransferable);
+        }
+
         let from = payment.buyer_address.clone();
         from.require_auth();
 
@@ -2287,6 +2292,7 @@ impl TicketPaymentContract {
             created_at: env.ledger().timestamp(),
             confirmed_at: Some(env.ledger().timestamp()),
             refunded_amount: 0,
+            is_soulbound: false,
             last_checked_in_at: 0,
         };
         store_payment(&env, payment);

--- a/contract/contracts/ticket_payment/src/error.rs
+++ b/contract/contracts/ticket_payment/src/error.rs
@@ -54,6 +54,7 @@ pub enum TicketPaymentError {
     InvalidFeePercent = 58,
     EventEnded = 59,
     NonTransferable = 60,
+    InvalidSecret = 61,
 }
 
 impl From<TicketPaymentError> for soroban_sdk::Error {
@@ -124,6 +125,7 @@ impl From<soroban_sdk::Error> for TicketPaymentError {
             58 => TicketPaymentError::InvalidFeePercent,
             59 => TicketPaymentError::EventEnded,
             60 => TicketPaymentError::NonTransferable,
+            61 => TicketPaymentError::InvalidSecret,
             _ => TicketPaymentError::ArithmeticError,
         }
     }

--- a/contract/contracts/ticket_payment/src/error.rs
+++ b/contract/contracts/ticket_payment/src/error.rs
@@ -53,6 +53,7 @@ pub enum TicketPaymentError {
     CannotRemoveLastGovernor = 57,
     InvalidFeePercent = 58,
     EventEnded = 59,
+    NonTransferable = 60,
 }
 
 impl From<TicketPaymentError> for soroban_sdk::Error {
@@ -122,6 +123,7 @@ impl From<soroban_sdk::Error> for TicketPaymentError {
             57 => TicketPaymentError::CannotRemoveLastGovernor,
             58 => TicketPaymentError::InvalidFeePercent,
             59 => TicketPaymentError::EventEnded,
+            60 => TicketPaymentError::NonTransferable,
             _ => TicketPaymentError::ArithmeticError,
         }
     }

--- a/contract/contracts/ticket_payment/src/storage.rs
+++ b/contract/contracts/ticket_payment/src/storage.rs
@@ -582,6 +582,19 @@ pub fn set_event_dispute_status(env: &Env, event_id: String, disputed: bool) {
         .set(&DataKey::DisputeStatus(event_id), &disputed);
 }
 
+pub fn is_event_cancelled_for_refund(env: &Env, event_id: &String) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::EventCancelledForRefund(event_id.clone()))
+        .unwrap_or(false)
+}
+
+pub fn set_event_cancelled_for_refund(env: &Env, event_id: &String) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::EventCancelledForRefund(event_id.clone()), &true);
+}
+
 // ── Oracle configuration ──────────────────────────────────────────────────────
 
 pub fn set_oracle_address(env: &Env, address: &Address) {

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -1676,6 +1676,7 @@ fn test_transfer_ticket_rejects_soulbound_ticket() {
         confirmed_at: Some(101),
         refunded_amount: 0,
         is_soulbound: true,
+        last_checked_in_at: 0,
     };
 
     env.as_contract(&client.address, || {
@@ -2459,6 +2460,7 @@ fn test_add_discount_hashes_and_invalid_code_rejected() {
         &1,
         &Some(wrong_preimage),
         &None,
+        &hash,
     );
 
     assert_eq!(res, Err(Ok(TicketPaymentError::InvalidDiscountCode)));
@@ -2536,6 +2538,7 @@ fn test_process_payment_with_valid_discount_code() {
         &1,
         &Some(preimage),
         &None,
+        &hash,
     );
     assert_eq!(result, String::from_str(&env, "pay_1"));
 
@@ -2573,6 +2576,7 @@ fn test_discount_code_one_time_use() {
         &1,
         &Some(Bytes::from_slice(&env, b"ONCE_ONLY")),
         &None,
+        &hash,
     );
 
     let (_secret, hash) = test_secret(&env);
@@ -2586,6 +2590,7 @@ fn test_discount_code_one_time_use() {
         &1,
         &Some(Bytes::from_slice(&env, b"ONCE_ONLY")),
         &None,
+        &hash,
     );
     assert_eq!(res, Err(Ok(TicketPaymentError::DiscountCodeUsed)));
 }
@@ -2901,6 +2906,7 @@ fn test_integration_full_platform_day() {
             &1,
             &None,
             &None,
+            &hash,
         );
     }
 
@@ -3120,7 +3126,7 @@ fn test_integration_concurrent_multi_guest_sales_no_state_corruption() {
         };
         let (_secret, hash) = test_secret(&env);
         let res = payment_client.try_process_payment(
-            &pid, &event_id, &tier_id, &buyer, &usdc_id, &amount, &1, &None, &None,
+            &pid, &event_id, &tier_id, &buyer, &usdc_id, &amount, &1, &None, &None, &hash,
         );
 
         if res.is_ok() {
@@ -6084,6 +6090,7 @@ fn test_partial_refund_multi_batch_index_persisted() {
             &1,
             &None,
             &None,
+            &hash,
         );
         client.confirm_payment(pid, &String::from_str(&env, "h"));
         buyers.push_back(buyer);
@@ -6621,6 +6628,7 @@ fn test_referral_reward_is_20_percent_of_platform_fee() {
         &1,
         &None,
         &Some(referrer.clone()),
+        &hash,
     );
 
     // platform_fee = 1000 * 5% = 50 USDC
@@ -6684,6 +6692,7 @@ fn test_referral_reward_capped_when_platform_fee_is_zero() {
         &1,
         &None,
         &Some(referrer.clone()),
+        &hash,
     );
 
     let escrow = client.get_event_escrow_balance(&String::from_str(&env, "event_1"));
@@ -6734,6 +6743,7 @@ fn test_referral_reward_does_not_exceed_platform_fee_invariant() {
         &1,
         &None,
         &Some(referrer.clone()),
+        &hash,
     );
 
     // platform_fee = 1000 * 5% = 50
@@ -6800,6 +6810,7 @@ fn setup_withdrawal_cap_test(
             &1,
             &None,
             &None,
+            &hash,
         );
     }
 
@@ -7041,6 +7052,7 @@ fn test_no_referral_reward_without_referrer() {
         &1,
         &None,
         &None, // no referrer
+        &hash,
     );
 
     // Full platform fee stays in escrow

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -523,6 +523,7 @@ fn test_confirm_payment() {
         created_at: 100,
         confirmed_at: None,
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -1625,6 +1626,7 @@ fn test_transfer_ticket_success() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -1649,6 +1651,42 @@ fn test_transfer_ticket_success() {
     let new_owner_payments = client.get_buyer_payments(&new_owner);
     assert_eq!(new_owner_payments.len(), 1);
     assert_eq!(new_owner_payments.get(0).unwrap(), payment_id);
+}
+
+#[test]
+fn test_transfer_ticket_rejects_soulbound_ticket() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test(&env);
+    let buyer = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let payment_id = String::from_str(&env, "pay_soulbound");
+
+    let payment = Payment {
+        payment_id: payment_id.clone(),
+        event_id: String::from_str(&env, "event_1"),
+        buyer_address: buyer.clone(),
+        ticket_tier_id: String::from_str(&env, "t1"),
+        amount: 1000,
+        platform_fee: 50,
+        organizer_amount: 950,
+        status: PaymentStatus::Confirmed,
+        transaction_hash: String::from_str(&env, "tx_sb"),
+        created_at: 100,
+        confirmed_at: Some(101),
+        refunded_amount: 0,
+        is_soulbound: true,
+    };
+
+    env.as_contract(&client.address, || {
+        store_payment(&env, payment);
+    });
+
+    let result = client.try_transfer_ticket(&payment_id, &new_owner, &None);
+    assert_eq!(result, Err(Ok(TicketPaymentError::NonTransferable)));
+
+    let unchanged = client.get_payment_status(&payment_id).unwrap();
+    assert_eq!(unchanged.buyer_address, buyer);
 }
 
 #[test]
@@ -1700,6 +1738,7 @@ fn test_transfer_ticket_with_fee() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -1743,6 +1782,7 @@ fn test_transfer_ticket_unauthorized() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -2108,6 +2148,7 @@ fn test_bulk_refund_success() {
                     created_at: 0,
                     confirmed_at: Some(1),
                     refunded_amount: 0,
+                    is_soulbound: false,
                     last_checked_in_at: 0,
                 },
             );
@@ -2186,6 +2227,7 @@ fn test_bulk_refund_batching() {
                     created_at: 0,
                     confirmed_at: Some(1),
                     refunded_amount: 0,
+                    is_soulbound: false,
                     last_checked_in_at: 0,
                 },
             );
@@ -3309,6 +3351,7 @@ fn test_transfer_ticket_resale_price_within_cap() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -3353,6 +3396,7 @@ fn test_transfer_ticket_resale_price_exceeds_cap() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -3399,6 +3443,7 @@ fn test_transfer_ticket_no_sale_price_with_cap() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -3443,6 +3488,7 @@ fn test_transfer_ticket_sale_price_no_cap() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -3946,6 +3992,7 @@ fn test_claim_automatic_refund_success() {
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
 
@@ -7025,6 +7072,7 @@ fn insert_confirmed_payment(
         created_at: 100,
         confirmed_at: Some(101),
         refunded_amount: 0,
+        is_soulbound: false,
         last_checked_in_at: 0,
     };
     env.as_contract(client_address, || {

--- a/contract/contracts/ticket_payment/src/test_e2e.rs
+++ b/contract/contracts/ticket_payment/src/test_e2e.rs
@@ -1263,7 +1263,8 @@ fn test_check_in_blocked_after_event_end_time() {
 
     let series_id: Option<String> = None;
     let pass_holder: Option<Address> = None;
-    client.check_in(&pay_id, &scanner, &series_id, &pass_holder);
+    let (raw_secret, _hash) = test_secret(&env);
+    client.check_in(&pay_id, &scanner, &series_id, &pass_holder, &raw_secret);
     let payment = client.get_payment_status(&pay_id).unwrap();
     assert_eq!(payment.status, PaymentStatus::CheckedIn);
 
@@ -1277,7 +1278,8 @@ fn test_check_in_blocked_after_event_end_time() {
         li.timestamp = 1001;
     });
 
-    let result = client.try_check_in(&pay_id_2, &scanner, &series_id, &pass_holder);
+    let (raw_secret, _hash) = test_secret(&env);
+    let result = client.try_check_in(&pay_id_2, &scanner, &series_id, &pass_holder, &raw_secret);
     assert_eq!(result, Err(Ok(TicketPaymentError::EventEnded)));
 
     // Verify payment status is still Confirmed (not checked in)
@@ -1314,7 +1316,8 @@ fn test_check_in_allowed_when_no_end_time_set() {
 
     let series_id: Option<String> = None;
     let pass_holder: Option<Address> = None;
-    client.check_in(&pay_id, &scanner, &series_id, &pass_holder);
+    let (raw_secret, _hash) = test_secret(&env);
+    client.check_in(&pay_id, &scanner, &series_id, &pass_holder, &raw_secret);
     let payment = client.get_payment_status(&pay_id).unwrap();
     assert_eq!(payment.status, PaymentStatus::CheckedIn);
 }

--- a/contract/contracts/ticket_payment/src/types.rs
+++ b/contract/contracts/ticket_payment/src/types.rs
@@ -69,6 +69,7 @@ pub struct Payment {
     pub created_at: u64,
     pub confirmed_at: Option<u64>,
     pub refunded_amount: i128,
+    pub is_soulbound: bool,
     pub last_checked_in_at: u64,
 }
 

--- a/contract/contracts/ticket_payment/src/types.rs
+++ b/contract/contracts/ticket_payment/src/types.rs
@@ -123,6 +123,7 @@ pub enum DataKey {
     DailyWithdrawalAmount(Address, u64), // (token_address, day_timestamp) -> amount withdrawn
     IsPaused,                            // bool – global circuit breaker flag
     DisputeStatus(String),               // event_id -> bool
+    EventCancelledForRefund(String),     // event_id -> bool
     PartialRefundIndex(String),          // event_id -> last processed payment index
     PartialRefundPercentage(String),     // event_id -> active refund percentage in bps
     OracleAddress,                       // Address of oracle contract

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
@@ -861,6 +861,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
@@ -853,6 +853,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
@@ -108,7 +108,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -1020,6 +1023,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1325,6 +1336,51 @@
                 "durability": "persistent",
                 "val": {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "p1"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "p1"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
                 }
               }
             },

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
@@ -1012,6 +1012,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
@@ -108,7 +108,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -147,7 +150,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -1234,6 +1240,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1382,6 +1396,14 @@
                       },
                       "val": {
                         "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
                       }
                     },
                     {
@@ -1691,6 +1713,96 @@
                 "durability": "persistent",
                 "val": {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "pay_1"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "pay_1"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "pay_2"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "pay_2"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
                 }
               }
             },

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
@@ -1226,6 +1226,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1366,6 +1374,14 @@
                       },
                       "val": {
                         "string": "event_1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
                       }
                     },
                     {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
@@ -1014,6 +1014,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
@@ -109,7 +109,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -1022,6 +1025,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1327,6 +1338,51 @@
                 "durability": "persistent",
                 "val": {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "pay_1"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "pay_1"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
                 }
               }
             },

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
@@ -228,7 +228,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -267,7 +270,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -1560,6 +1566,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1708,6 +1722,14 @@
                       },
                       "val": {
                         "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
                       }
                     },
                     {
@@ -2271,6 +2293,96 @@
                 "durability": "persistent",
                 "val": {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "pay_usdc"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "pay_usdc"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "pay_xlm"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "pay_xlm"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
                 }
               }
             },

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
@@ -1552,6 +1552,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1692,6 +1700,14 @@
                       },
                       "val": {
                         "string": "event_1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
                       }
                     },
                     {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
@@ -1035,6 +1035,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
@@ -108,7 +108,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -1043,6 +1046,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1348,6 +1359,51 @@
                 "durability": "persistent",
                 "val": {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "pay_1"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "pay_1"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
                 }
               }
             },

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
@@ -108,7 +108,10 @@
                   "u32": 1
                 },
                 "void",
-                "void"
+                "void",
+                {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
+                }
               ]
             }
           },
@@ -1067,6 +1070,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "last_checked_in_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {
@@ -1372,6 +1383,51 @@
                 "durability": "persistent",
                 "val": {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ValidationHash"
+                },
+                {
+                  "string": "pay_1"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ValidationHash"
+                    },
+                    {
+                      "string": "pay_1"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "2dcdef7481b644c24ab53b76c069618f189bb5c3e14f7825b0d0f5d45a93f482"
                 }
               }
             },

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
@@ -1059,6 +1059,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "is_soulbound"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "organizer_amount"
                       },
                       "val": {


### PR DESCRIPTION
Closes #465

---

## Summary
- add soulbound support to ticket records in the payment contract
- block transfers for soulbound tickets with a dedicated `NonTransferable` error
- keep standard tickets transferable by default
- add regression coverage for both normal and soulbound transfer behavior

## What Changed
- added `is_soulbound: bool` to the ticket/payment record
- set newly created tickets to `is_soulbound: false` by default so existing purchase flows remain transferable
- updated `transfer_ticket` to return `NonTransferable` when a soulbound ticket is moved
- added a test proving soulbound tickets cannot be transferred after purchase
- refreshed affected snapshots to include the new field in stored payment data

## Acceptance Criteria
- standard tickets remain transferable
- soulbound tickets cannot be moved to a different address after purchase

## Validation
- `cargo test -p ticket-payment` ✅
