### PR TITLE
fix: implement proper back navigation for auth page

### DIFF
--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -53,11 +53,20 @@ export default function AuthPage() {
     }
   };
 
+  const handleGoBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  };
+
   return (
     <main className="min-h-screen bg-[#A9A495] relative flex items-center justify-center">
       {/* Back Button */}
       <button
         type="button"
+        onClick={handleGoBack}
         className="
           absolute top-10 left-16
           bg-white


### PR DESCRIPTION
Description:
This PR implements the missing navigation logic for the back button on the Auth page. 

Changes Made:
Imported `useRouter` from `next/navigation`.
Added an `onClick` handler that checks the browser's history stack.
If `window.history.length > 1`, it accurately routes the user back to their previous page (`router.back()`).
If the page is accessed directly with no history stack, it falls back to the home page (`router.push('/')`).

Testing Done: 
Verified that clicking "Back" after navigating from the home page returns the user to the home page.
Verified that opening `/auth` directly in a fresh tab and clicking "Back" safely redirects to `/` instead of doing nothing.

Closes #447