### PR TITLE
#469 Add Support for Multi-token Payouts

### DIFF
--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -6,17 +6,17 @@ use crate::storage::{
     get_event_payments, get_event_registry, get_highest_bid, get_oracle_address,
     get_partial_refund_index, get_partial_refund_percentage, get_payment, get_platform_wallet,
     get_proposal, get_slippage_bps, get_total_fees_collected_by_token, get_total_governors,
-    get_ticket_payment_id, get_transfer_fee, get_usdc_token, get_withdrawal_cap,
-    has_price_switched, increment_proposal_count, is_auction_closed, is_discount_hash_used,
-    is_discount_hash_valid, is_event_disputed, is_governor, is_initialized, is_paused,
-    is_token_whitelisted, mark_discount_hash_used, remove_payment_from_buyer_index,
-    remove_token_from_whitelist, set_admin, set_auction_closed, set_bulk_refund_index,
-    set_event_dispute_status, set_event_registry, set_governor, set_highest_bid, set_initialized,
-    set_is_paused, set_oracle_address, set_partial_refund_index, set_partial_refund_percentage,
-    set_platform_wallet, set_price_switched, set_proposal, set_slippage_bps, set_total_governors,
-    set_transfer_fee, set_usdc_token, set_withdrawal_cap, store_payment, store_validation_hash,
-    subtract_from_active_escrow_by_token, subtract_from_active_escrow_total,
-    subtract_from_total_fees_collected_by_token, update_event_balance, verify_secret,
+    get_transfer_fee, get_withdrawal_cap, has_price_switched, increment_proposal_count,
+    is_auction_closed, is_discount_hash_used, is_discount_hash_valid, is_event_disputed,
+    is_governor, is_initialized, is_paused, is_token_whitelisted, mark_discount_hash_used,
+    remove_payment_from_buyer_index, remove_token_from_whitelist, set_admin, set_auction_closed,
+    set_bulk_refund_index, set_event_dispute_status, set_event_registry, set_governor,
+    set_highest_bid, set_initialized, set_is_paused, set_oracle_address, set_partial_refund_index,
+    set_partial_refund_percentage, set_platform_wallet, set_price_switched, set_proposal,
+    set_slippage_bps, set_total_governors, set_transfer_fee, set_usdc_token, set_withdrawal_cap,
+    store_payment, store_validation_hash, subtract_from_active_escrow_by_token,
+    subtract_from_active_escrow_total, subtract_from_total_fees_collected_by_token,
+    update_event_balance, verify_secret,
 };
 use crate::types::{
     DataKey, HighestBid, ParameterChange, ParameterProposal, Payment, PaymentStatus,
@@ -178,6 +178,8 @@ pub mod event_registry {
         pub tags: Option<soroban_sdk::Vec<String>>,
         pub start_time: u64,
         pub end_time: u64,
+        pub accepted_tokens: soroban_sdk::Vec<Address>,
+        pub use_global_whitelist: bool,
     }
 }
 
@@ -185,6 +187,22 @@ fn require_admin(env: &Env) -> Result<Address, TicketPaymentError> {
     let admin = get_admin(env).ok_or(TicketPaymentError::NotInitialized)?;
     admin.require_auth();
     Ok(admin)
+}
+
+fn event_accepts_token(
+    env: &Env,
+    event_info: &event_registry::EventInfo,
+    token_address: &Address,
+) -> bool {
+    if event_info.use_global_whitelist || event_info.accepted_tokens.is_empty() {
+        is_token_whitelisted(env, token_address)
+    } else {
+        event_info.accepted_tokens.contains(token_address)
+    }
+}
+
+fn get_ticket_payment_id(_env: &Env, _ticket_id: u64) -> Option<String> {
+    None
 }
 
 #[contract]
@@ -617,6 +635,10 @@ impl TicketPaymentContract {
             return Err(TicketPaymentError::EventInactive);
         }
 
+        if !event_accepts_token(&env, &event_info, &token_address) {
+            return Err(TicketPaymentError::TokenNotWhitelisted);
+        }
+
         // Block sales if the event has been locally cancelled for refunds
         if crate::storage::is_event_cancelled_for_refund(&env, &event_id) {
             return Err(TicketPaymentError::EventCancelled);
@@ -797,12 +819,7 @@ impl TicketPaymentContract {
         }
 
         // 6. Increment inventory after successful payment
-        registry_client.increment_inventory(
-            &event_id,
-            &ticket_tier_id,
-            &buyer_address,
-            &quantity,
-        );
+        registry_client.increment_inventory(&event_id, &ticket_tier_id, &buyer_address, &quantity);
 
         // 7. Create payment records for each individual ticket
         let quantity_i128 = quantity as i128;
@@ -836,6 +853,7 @@ impl TicketPaymentContract {
                 event_id: event_id.clone(),
                 buyer_address: buyer_address.clone(),
                 ticket_tier_id: ticket_tier_id.clone(),
+                token_address: token_address.clone(),
                 amount,
                 platform_fee: platform_fee_per_ticket,
                 organizer_amount: organizer_amount_per_ticket,
@@ -976,8 +994,8 @@ impl TicketPaymentContract {
             return Err(TicketPaymentError::ContractPaused);
         }
 
-        let payment_id = get_ticket_payment_id(&env, ticket_id)
-            .ok_or(TicketPaymentError::PaymentNotFound)?;
+        let payment_id =
+            get_ticket_payment_id(&env, ticket_id).ok_or(TicketPaymentError::PaymentNotFound)?;
 
         let payment =
             get_payment(&env, payment_id.clone()).ok_or(TicketPaymentError::PaymentNotFound)?;
@@ -1137,8 +1155,7 @@ impl TicketPaymentContract {
 
         // Process token transfer
         if refund_amount > 0 {
-            let token_address = crate::storage::get_usdc_token(&env);
-            token::Client::new(&env, &token_address).transfer(
+            token::Client::new(&env, &payment.token_address).transfer(
                 &env.current_contract_address(),
                 &payment.buyer_address,
                 &refund_amount,
@@ -1162,11 +1179,7 @@ impl TicketPaymentContract {
         );
 
         subtract_from_active_escrow_total(&env, refund_amount);
-        subtract_from_active_escrow_by_token(
-            &env,
-            crate::storage::get_usdc_token(&env),
-            refund_amount,
-        );
+        subtract_from_active_escrow_by_token(&env, payment.token_address.clone(), refund_amount);
 
         // Clear escrow record if both amounts are now zero (fully refunded event)
         let updated_balance = get_event_balance(&env, payment.event_id.clone());
@@ -1835,8 +1848,7 @@ impl TicketPaymentContract {
                 .ok_or(TicketPaymentError::ArithmeticError)?;
 
             if actual_transfer_fee > 0 {
-                let token_address = crate::storage::get_usdc_token(&env);
-                let token_client = token::Client::new(&env, &token_address);
+                let token_client = token::Client::new(&env, &payment.token_address);
                 let contract_address = env.current_contract_address();
 
                 // Transfer fee from old owner to contract
@@ -1918,14 +1930,13 @@ impl TicketPaymentContract {
         let mut total_refunded = 0;
         let mut balance = get_event_balance(&env, event_id.clone());
 
-        let token_address = crate::storage::get_usdc_token(&env);
-        let token_client = token::Client::new(&env, &token_address);
         let contract_address = env.current_contract_address();
 
         for i in start_index..end_index {
             let payment_id = payment_ids.get(i).unwrap();
             if let Some(mut payment) = get_payment(&env, payment_id.clone()) {
                 if payment.status == PaymentStatus::Confirmed {
+                    let token_client = token::Client::new(&env, &payment.token_address);
                     // Refund full amount to buyer
                     token_client.transfer(
                         &contract_address,
@@ -1944,6 +1955,11 @@ impl TicketPaymentContract {
 
                     total_refunded += payment.amount;
                     processed_count += 1;
+                    subtract_from_active_escrow_by_token(
+                        &env,
+                        payment.token_address.clone(),
+                        payment.amount,
+                    );
                 }
             }
         }
@@ -1951,7 +1967,6 @@ impl TicketPaymentContract {
         if processed_count > 0 {
             crate::storage::set_event_balance(&env, event_id.clone(), balance);
             subtract_from_active_escrow_total(&env, total_refunded);
-            subtract_from_active_escrow_by_token(&env, token_address, total_refunded);
         }
 
         set_bulk_refund_index(&env, event_id.clone(), end_index);
@@ -2024,14 +2039,13 @@ impl TicketPaymentContract {
         let mut total_refunded = 0;
         let mut balance = get_event_balance(&env, event_id.clone());
 
-        let token_address = crate::storage::get_usdc_token(&env);
-        let token_client = token::Client::new(&env, &token_address);
         let contract_address = env.current_contract_address();
 
         for i in start_index..end_index {
             let payment_id = payment_ids.get(i).unwrap();
             if let Some(mut payment) = get_payment(&env, payment_id.clone()) {
                 if payment.status == PaymentStatus::Confirmed {
+                    let token_client = token::Client::new(&env, &payment.token_address);
                     let refund_amount = (payment
                         .amount
                         .checked_mul(active_pct as i128)
@@ -2052,6 +2066,11 @@ impl TicketPaymentContract {
                         balance.organizer_amount -= refund_amount;
                         total_refunded += refund_amount;
                         processed_count += 1;
+                        subtract_from_active_escrow_by_token(
+                            &env,
+                            payment.token_address.clone(),
+                            refund_amount,
+                        );
                     }
                 }
             }
@@ -2060,7 +2079,6 @@ impl TicketPaymentContract {
         if processed_count > 0 {
             crate::storage::set_event_balance(&env, event_id.clone(), balance);
             subtract_from_active_escrow_total(&env, total_refunded);
-            subtract_from_active_escrow_by_token(&env, token_address, total_refunded);
         }
 
         set_partial_refund_index(&env, event_id.clone(), end_index);
@@ -2151,6 +2169,10 @@ impl TicketPaymentContract {
             return Err(TicketPaymentError::EventInactive);
         }
 
+        if !event_accepts_token(&env, &event_info, &token_address) {
+            return Err(TicketPaymentError::TokenNotWhitelisted);
+        }
+
         let tier = event_info
             .tiers
             .get(ticket_tier_id.clone())
@@ -2204,14 +2226,19 @@ impl TicketPaymentContract {
 
         // Refund previous bidder if exists
         if let Some(prev) = previous_bidder {
-            token_client.transfer(&contract_address, &prev.bidder, &prev.amount);
+            token::Client::new(&env, &prev.token_address).transfer(
+                &contract_address,
+                &prev.bidder,
+                &prev.amount,
+            );
             subtract_from_active_escrow_total(&env, prev.amount);
-            subtract_from_active_escrow_by_token(&env, token_address.clone(), prev.amount);
+            subtract_from_active_escrow_by_token(&env, prev.token_address, prev.amount);
         }
 
         // Save new highest bid
         let new_bid = HighestBid {
             bidder: bidder_address.clone(),
+            token_address: token_address.clone(),
             amount,
         };
         set_highest_bid(&env, event_id.clone(), ticket_tier_id.clone(), new_bid);
@@ -2302,8 +2329,6 @@ impl TicketPaymentContract {
             .ok_or(TicketPaymentError::ArithmeticError)?;
 
         // Update protocol fees and event balances
-        let token_address = get_usdc_token(&env);
-
         update_event_balance(
             &env,
             event_id.clone(),
@@ -2311,15 +2336,14 @@ impl TicketPaymentContract {
             total_platform_fee,
         );
         add_to_total_volume_processed(&env, amount);
-        add_to_total_fees_collected_by_token(&env, token_address.clone(), total_platform_fee);
+        add_to_total_fees_collected_by_token(
+            &env,
+            winning_bid.token_address.clone(),
+            total_platform_fee,
+        );
 
         // Increment inventory
-        registry_client.increment_inventory(
-            &event_id,
-            &ticket_tier_id,
-            &bidder_address,
-            &1,
-        );
+        registry_client.increment_inventory(&event_id, &ticket_tier_id, &bidder_address, &1);
 
         // Record the payment
         let empty_tx_hash = String::from_str(&env, "");
@@ -2328,6 +2352,7 @@ impl TicketPaymentContract {
             event_id: event_id.clone(),
             buyer_address: bidder_address.clone(),
             ticket_tier_id: ticket_tier_id.clone(),
+            token_address: winning_bid.token_address,
             amount,
             platform_fee: total_platform_fee,
             organizer_amount: total_organizer_amount,
@@ -2504,8 +2529,7 @@ impl TicketPaymentContract {
         );
 
         // Transfer full amount back to buyer
-        let token_address = crate::storage::get_usdc_token(&env);
-        token::Client::new(&env, &token_address).transfer(
+        token::Client::new(&env, &payment.token_address).transfer(
             &env.current_contract_address(),
             &payment.buyer_address,
             &refund_amount,
@@ -2519,7 +2543,7 @@ impl TicketPaymentContract {
             -payment.platform_fee,
         );
         subtract_from_active_escrow_total(&env, refund_amount);
-        subtract_from_active_escrow_by_token(&env, token_address, refund_amount);
+        subtract_from_active_escrow_by_token(&env, payment.token_address.clone(), refund_amount);
 
         env.events().publish(
             (AgoraEvent::CancellationRefundClaimed,),

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -71,6 +71,8 @@ impl MockCancelledRegistry {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -92,6 +94,13 @@ impl MockEventRegistry {
 
     pub fn get_event(env: Env, event_id: String) -> Option<event_registry::EventInfo> {
         let _organizer_address = Address::generate(&env);
+        let accepted_token_key = Symbol::new(&env, "accepted_token");
+        let accepted_token: Option<Address> = env.storage().instance().get(&accepted_token_key);
+        let use_global_whitelist = accepted_token.is_none();
+        let mut accepted_tokens = soroban_sdk::vec![&env];
+        if let Some(token) = accepted_token {
+            accepted_tokens.push_back(token);
+        }
         // We use a fixed predictable address for some tests by mapping it in storage if needed,
         // but for general setup, a generated one is fine.
         // For testing set_transfer_fee, we'll need to know this address.
@@ -142,6 +151,8 @@ impl MockEventRegistry {
                 tags: None,
                 start_time: 0,
                 end_time: 0,
+                accepted_tokens,
+                use_global_whitelist,
             });
         }
         None
@@ -225,6 +236,8 @@ impl MockEventRegistry2 {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -307,6 +320,8 @@ impl MockAuctionEventRegistry {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -515,6 +530,7 @@ fn test_confirm_payment() {
         event_id: String::from_str(&env, "e1"),
         buyer_address: buyer,
         ticket_tier_id: String::from_str(&env, "t1"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 100,
         platform_fee: 5,
         organizer_amount: 95,
@@ -1043,6 +1059,86 @@ fn test_process_payment_with_multiple_tokens() {
     assert_eq!(payment2.amount, xlm_amount);
 }
 
+#[test]
+fn test_process_payment_respects_event_specific_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, _usdc_id, _platform_wallet, registry_id) = setup_test(&env);
+
+    let custom_token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let wrong_token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    for token in [custom_token.clone(), wrong_token.clone()] {
+        let proposal_id =
+            client.propose_parameter_change(&admin, &ParameterChange::AddTokenToWhitelist(token));
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + 172801);
+        client.execute_proposal(&admin, &proposal_id);
+    }
+
+    let accepted_token_key = Symbol::new(&env, "accepted_token");
+    env.as_contract(&registry_id, || {
+        env.storage()
+            .instance()
+            .set(&accepted_token_key, &custom_token);
+    });
+
+    let buyer = Address::generate(&env);
+    let amount = 1000_0000000i128;
+
+    token::StellarAssetClient::new(&env, &wrong_token).mint(&buyer, &amount);
+    token::Client::new(&env, &wrong_token).approve(&buyer, &client.address, &amount, &99999);
+
+    let (_secret, wrong_hash) = test_secret(&env);
+    let wrong_result = client.try_process_payment(
+        &String::from_str(&env, "pay_wrong"),
+        &String::from_str(&env, "event_1"),
+        &String::from_str(&env, "tier_1"),
+        &buyer,
+        &wrong_token,
+        &amount,
+        &1,
+        &None,
+        &None,
+        &wrong_hash,
+    );
+    assert_eq!(
+        wrong_result,
+        Err(Ok(TicketPaymentError::TokenNotWhitelisted))
+    );
+
+    token::StellarAssetClient::new(&env, &custom_token).mint(&buyer, &(amount * 2));
+    token::Client::new(&env, &custom_token).approve(&buyer, &client.address, &(amount * 2), &99999);
+
+    let (_secret, right_hash) = test_secret(&env);
+    let payment_id = client.process_payment(
+        &String::from_str(&env, "pay_custom"),
+        &String::from_str(&env, "event_1"),
+        &String::from_str(&env, "tier_1"),
+        &buyer,
+        &custom_token,
+        &amount,
+        &1,
+        &None,
+        &None,
+        &right_hash,
+    );
+
+    let stored_payment = client.get_payment_status(&payment_id).unwrap();
+    assert_eq!(stored_payment.token_address, custom_token);
+
+    client.confirm_payment(&payment_id, &String::from_str(&env, "tx_custom"));
+    client.request_guest_refund(&payment_id);
+
+    let refunded_balance = token::Client::new(&env, &custom_token).balance(&buyer);
+    assert_eq!(refunded_balance, 2 * amount);
+}
+
 // Mock Event Registry with max supply reached
 #[soroban_sdk::contract]
 pub struct MockEventRegistryMaxSupply;
@@ -1096,6 +1192,8 @@ impl MockEventRegistryMaxSupply {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -1219,6 +1317,8 @@ impl MockEventRegistryWithInventory {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -1460,6 +1560,8 @@ impl MockEventRegistryWithMilestones {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -1618,6 +1720,7 @@ fn test_transfer_ticket_success() {
         event_id: String::from_str(&env, "event_1"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "t1"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000,
         platform_fee: 50,
         organizer_amount: 950,
@@ -1667,6 +1770,7 @@ fn test_transfer_ticket_rejects_soulbound_ticket() {
         event_id: String::from_str(&env, "event_1"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "t1"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000,
         platform_fee: 50,
         organizer_amount: 950,
@@ -1731,6 +1835,7 @@ fn test_transfer_ticket_with_fee() {
         event_id: event_id.clone(),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "t1"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: ticket_amount,
         platform_fee: 50,
         organizer_amount: 950,
@@ -1775,6 +1880,7 @@ fn test_transfer_ticket_unauthorized() {
         event_id: String::from_str(&env, "event_1"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "t1"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000,
         platform_fee: 50,
         organizer_amount: 950,
@@ -1858,6 +1964,8 @@ impl MockEventRegistryEarlyBird {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -2141,6 +2249,7 @@ fn test_bulk_refund_success() {
                     event_id: event_id.clone(),
                     buyer_address: buyer,
                     ticket_tier_id: String::from_str(&env, "tier_1"),
+                    token_address: get_usdc_token(&env),
                     amount: ticket_price,
                     platform_fee: 50_0000000,
                     organizer_amount: 950_0000000,
@@ -2220,6 +2329,7 @@ fn test_bulk_refund_batching() {
                     event_id: event_id.clone(),
                     buyer_address: buyer,
                     ticket_tier_id: String::from_str(&env, "tier_1"),
+                    token_address: get_usdc_token(&env),
                     amount: ticket_price,
                     platform_fee: 50_0000000,
                     organizer_amount: 950_0000000,
@@ -2379,6 +2489,8 @@ impl MockEventRegistryWithOrganizer {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -2712,6 +2824,8 @@ impl MockPlatformRegistryE2E {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         };
 
         env.storage()
@@ -3206,6 +3320,8 @@ impl MockEventRegistryRefund {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -3289,6 +3405,8 @@ impl MockEventRegistryWithResaleCap {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -3349,6 +3467,7 @@ fn test_transfer_ticket_resale_price_within_cap() {
         event_id: String::from_str(&env, "event_capped"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "general"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000_0000000,
         platform_fee: 50_0000000,
         organizer_amount: 950_0000000,
@@ -3394,6 +3513,7 @@ fn test_transfer_ticket_resale_price_exceeds_cap() {
         event_id: String::from_str(&env, "event_capped"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "general"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000_0000000,
         platform_fee: 50_0000000,
         organizer_amount: 950_0000000,
@@ -3441,6 +3561,7 @@ fn test_transfer_ticket_no_sale_price_with_cap() {
         event_id: String::from_str(&env, "event_capped"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "general"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000_0000000,
         platform_fee: 50_0000000,
         organizer_amount: 950_0000000,
@@ -3486,6 +3607,7 @@ fn test_transfer_ticket_sale_price_no_cap() {
         event_id: String::from_str(&env, "event_1"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "tier_1"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000_0000000,
         platform_fee: 50_0000000,
         organizer_amount: 950_0000000,
@@ -3576,6 +3698,8 @@ impl MockRegistryZeroCap {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -3990,6 +4114,7 @@ fn test_claim_automatic_refund_success() {
         event_id: String::from_str(&env, "e1"),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(&env, "tier_1"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
         amount: 1000,
         platform_fee: 50,
         organizer_amount: 950,
@@ -4216,6 +4341,8 @@ impl MockEventRegistryUsdPriced {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -4936,6 +5063,8 @@ impl MockEventRegistryWithFailingLoyaltyUpdate {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
     pub fn increment_inventory(
@@ -5076,6 +5205,8 @@ impl MockEventRegistryWithLoyalty {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
     pub fn increment_inventory(
@@ -5168,6 +5299,8 @@ impl MockEventRegistryWithExcessiveLoyaltyDiscount {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
     pub fn increment_inventory(
@@ -5398,6 +5531,8 @@ impl MockEventRegistryCustomFee {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -5539,6 +5674,8 @@ impl MockEventRegistryHighPrice {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -5659,6 +5796,8 @@ impl MockEventRegistryRefundDeadline {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -6242,6 +6381,8 @@ impl MockEventRegistryForDust {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -6461,6 +6602,8 @@ impl MockEventRegistryForReferral {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
     pub fn increment_inventory(
@@ -6551,6 +6694,8 @@ impl MockEventRegistryFullLoyaltyDiscount {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
     pub fn increment_inventory(
@@ -7076,6 +7221,7 @@ fn insert_confirmed_payment(
         event_id: String::from_str(env, event_id),
         buyer_address: buyer.clone(),
         ticket_tier_id: String::from_str(env, "tier_1"),
+        token_address: env.as_contract(client_address, || get_usdc_token(env)),
         amount: 1000_0000000,
         platform_fee: 50_0000000,
         organizer_amount: 950_0000000,

--- a/contract/contracts/ticket_payment/src/test_e2e.rs
+++ b/contract/contracts/ticket_payment/src/test_e2e.rs
@@ -96,6 +96,8 @@ impl MockRegistryE2E {
             tags: None,
             start_time: 0,
             end_time: stored_end_time,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -223,6 +225,8 @@ impl MockRegistryCancelledE2E {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -323,6 +327,8 @@ impl MockRegistryWithGoal {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 
@@ -1131,6 +1137,8 @@ impl MockRegistryAuction {
             tags: None,
             start_time: 0,
             end_time: 0,
+            accepted_tokens: soroban_sdk::vec![&env],
+            use_global_whitelist: true,
         })
     }
 

--- a/contract/contracts/ticket_payment/src/types.rs
+++ b/contract/contracts/ticket_payment/src/types.rs
@@ -61,7 +61,8 @@ pub struct Payment {
     pub event_id: String,
     pub buyer_address: Address,
     pub ticket_tier_id: String,
-    pub amount: i128, // USDC amount in stroops
+    pub token_address: Address,
+    pub amount: i128, // Payment token amount in stroops
     pub platform_fee: i128,
     pub organizer_amount: i128,
     pub status: PaymentStatus,
@@ -85,6 +86,7 @@ pub struct EventBalance {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HighestBid {
     pub bidder: Address,
+    pub token_address: Address,
     pub amount: i128,
 }
 

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
@@ -28,6 +28,7 @@
     [],
     [],
     [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -917,6 +918,14 @@
                       },
                       "val": {
                         "string": "t1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                       }
                     },
                     {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
@@ -1083,6 +1083,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "transaction_hash"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
@@ -1300,6 +1300,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "transaction_hash"
                       },
                       "val": {
@@ -1456,6 +1464,14 @@
                       },
                       "val": {
                         "string": "tier_1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                       }
                     },
                     {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
@@ -1085,6 +1085,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "transaction_hash"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
@@ -1626,6 +1626,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "transaction_hash"
                       },
                       "val": {
@@ -1782,6 +1790,14 @@
                       },
                       "val": {
                         "string": "tier_1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CD3FXVGYSLQFFTW3UH6WFF2OKZH7VERGZJZAMJHTGHBWO4F6URWEJL23"
                       }
                     },
                     {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
@@ -1106,6 +1106,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "transaction_hash"
                       },
                       "val": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
@@ -1130,6 +1130,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "transaction_hash"
                       },
                       "val": {


### PR DESCRIPTION
Closes #469

---

## Summary
- enforce each event's configured payment token policy during ticket purchases and auction bids
- persist the token used for each payment and highest bid so refunds, transfer fees, and auction settlement use the same asset instead of falling back to USDC
- add coverage for event-specific token acceptance/rejection and custom-token refund flows

## Context
Some organizers may want USDC, others may want XLM or a custom token.

Description: Allow specifying the token address at event creation.

Implementation details:
- store the event payment token through the existing event token configuration surfaced to 	icket_payment
- ensure all related 	ransfer and 	ransfer_from calls use the configured token instead of the contract default

## Acceptance Criteria
- an event can be created that only accepts a specific custom token
- payments made in the wrong token are rejected

## Validation
- cargo test -p ticket-payment --lib

## Notes
- a broader cargo test run in contract/ is currently blocked by pre-existing event-registry compile errors already present in this checkout, unrelated to this branch's 	icket_payment changes