### PR TITLE
feat: implement leaderboard API (#497) and request ID tracing (#498)

### DIFF
--- a/server/src/handlers/leaderboard.rs
+++ b/server/src/handlers/leaderboard.rs
@@ -1,0 +1,86 @@
+//! # Leaderboard Handler
+//!
+//! Provides the leaderboard endpoint that ranks organizers by tickets sold.
+//! Supports `all_time`, `monthly`, and `weekly` timeframes.
+
+use axum::{extract::{Query, State}, response::{IntoResponse, Response}};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::utils::error::AppError;
+use crate::utils::response::success;
+
+/// Supported timeframe values for the leaderboard query.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Timeframe {
+    #[default]
+    AllTime,
+    Monthly,
+    Weekly,
+}
+
+/// Query parameters accepted by the leaderboard endpoint.
+#[derive(Debug, Deserialize)]
+pub struct LeaderboardParams {
+    /// Ranking timeframe: `all_time` (default), `monthly`, or `weekly`.
+    #[serde(default)]
+    pub timeframe: Timeframe,
+}
+
+/// A single entry in the leaderboard response.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct LeaderboardEntry {
+    /// Rank position (1-based).
+    pub rank: i64,
+    /// Organizer name.
+    pub organizer_name: String,
+    /// Total tickets sold within the requested timeframe.
+    pub tickets_sold: i64,
+}
+
+/// GET `/api/v1/leaderboard` – Rank organizers by tickets sold.
+///
+/// # Query Parameters
+/// - `timeframe` (optional): `all_time` (default), `monthly`, `weekly`
+///
+/// # Response
+/// Returns a JSON array of organizers ordered by tickets sold descending,
+/// each entry including their rank and score.
+pub async fn get_leaderboard(
+    State(pool): State<PgPool>,
+    Query(params): Query<LeaderboardParams>,
+) -> Response {
+    let time_filter = match params.timeframe {
+        Timeframe::AllTime => "TRUE",
+        Timeframe::Monthly => "t.created_at >= NOW() - INTERVAL '30 days'",
+        Timeframe::Weekly => "t.created_at >= NOW() - INTERVAL '7 days'",
+    };
+
+    let query = format!(
+        r#"
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY COUNT(t.id) DESC) AS rank,
+            o.name AS organizer_name,
+            COUNT(t.id) AS tickets_sold
+        FROM organizers o
+        JOIN events e ON e.organizer_id = o.id
+        JOIN ticket_tiers tt ON tt.event_id = e.id
+        JOIN tickets t ON t.ticket_tier_id = tt.id
+        WHERE {time_filter}
+        GROUP BY o.id, o.name
+        ORDER BY tickets_sold DESC
+        "#
+    );
+
+    match sqlx::query_as::<_, LeaderboardEntry>(&query)
+        .fetch_all(&pool)
+        .await
+    {
+        Ok(entries) => success(entries, "Leaderboard retrieved successfully").into_response(),
+        Err(e) => {
+            tracing::error!("Failed to fetch leaderboard: {:?}", e);
+            AppError::DatabaseError(e).into_response()
+        }
+    }
+}

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod categories;
 pub mod events;
 pub mod health;
+pub mod leaderboard;
 pub mod qr_payload;
 pub mod ws;
 

--- a/server/src/middleware/mod.rs
+++ b/server/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod audit;
+pub mod request_id_tracing;

--- a/server/src/middleware/request_id_tracing.rs
+++ b/server/src/middleware/request_id_tracing.rs
@@ -1,0 +1,29 @@
+//! # Request ID Tracing Middleware
+//!
+//! Extracts the `x-request-id` header (set by [`SetRequestIdLayer`]) and
+//! inserts it as a field on the current tracing span so that every log line
+//! emitted while handling a request automatically carries the request ID.
+//!
+//! This satisfies issue #498: a single request ID can be used to find all
+//! logs related to a specific user action.
+
+use axum::{extract::Request, middleware::Next, response::Response};
+use tracing::Instrument;
+
+use crate::config::request_id::REQUEST_ID_HEADER;
+
+/// Axum middleware that injects `request_id` into the tracing span.
+///
+/// Must be applied **after** [`SetRequestIdLayer`] so the header is already
+/// present on the request when this middleware runs.
+pub async fn trace_request_id(request: Request, next: Next) -> Response {
+    let request_id = request
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_owned();
+
+    let span = tracing::info_span!("request", request_id = %request_id);
+    next.run(request).instrument(span).await
+}

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -29,6 +29,7 @@ use crate::config::{
     propagate_request_id_layer,
     set_request_id_layer,
 };
+use crate::middleware::request_id_tracing::trace_request_id;
 use crate::handlers::{
     categories::{get_category, list_categories},
     events::{get_event, list_events, submit_event_rating},
@@ -36,6 +37,7 @@ use crate::handlers::{
     example_not_found,
     example_validation_error,
     health::{ health_check, health_check_blockchain, health_check_db, health_check_ready },
+    leaderboard::get_leaderboard,
     qr_payload::{generate_qr_payload, list_qr_payloads, mark_qr_used, verify_qr_payload},
     ws::{ws_purchases_handler, PurchaseBroadcaster},
 };
@@ -107,6 +109,7 @@ pub fn create_routes(pool: PgPool) -> Router {
         .route("/examples/validation-error", get(example_validation_error))
         .route("/examples/empty-success", get(example_empty_success))
         .route("/examples/not-found/:id", get(example_not_found))
+        .route("/leaderboard", get(get_leaderboard))
         .with_state(pool)
         .layer(RateLimitLayer::new(GENERAL_RATE_LIMIT, GENERAL_WINDOW));
 
@@ -118,6 +121,7 @@ pub fn create_routes(pool: PgPool) -> Router {
         .nest("/api/v1", api_routes)
         .layer(create_security_headers_layer())
         .layer(create_cors_layer())
+        .layer(middleware::from_fn(trace_request_id))
         .layer(propagate_request_id_layer())
         .layer(set_request_id_layer())
 }


### PR DESCRIPTION
## Issue #497 — Create a Leaderboard API for Organizers

### What was done
Added a new GET /api/v1/leaderboard endpoint that ranks organizers by the number of tickets sold. The endpoint supports three timeframes via a query parameter (?timeframe=all_time|monthly|weekly).

### How it was done
- Created server/src/handlers/leaderboard.rs
  - Defined LeaderboardParams (query param struct with a Timeframe enum defaulting to all_time).
  - Defined LeaderboardEntry (serializable response struct with rank, organizer_name, and tickets_sold fields, derived from sqlx::FromRow).
  - Implemented get_leaderboard handler: builds a SQL query that JOINs organizers → events → ticket_tiers → tickets, applies a WHERE clause based on the requested timeframe (TRUE for all_time, NOW()-30d for monthly, NOW()-7d for weekly), groups by organizer, and uses ROW_NUMBER() OVER (...) to assign ranks.
- Registered the module in server/src/handlers/mod.rs (pub mod leaderboard).
- Imported get_leaderboard in server/src/routes/mod.rs and mounted it on the general_routes sub-router at GET /leaderboard (resolves to GET /api/v1/leaderboard), inheriting the 120 req/min rate limit.

### Acceptance criteria met
- Returns JSON with organizer names and their rank/score (tickets_sold).
- Supports all_time, monthly, and weekly timeframes.

Closes #497

---

## Issue #498 — Implement Detailed Logging with Request IDs

### What was done
Every log line emitted while handling a request now automatically carries the x-request-id value as a structured tracing field, making it trivial to grep/filter all logs for a single user action.

### How it was done
- Created server/src/middleware/request_id_tracing.rs
  - Implemented trace_request_id, an async Axum middleware function.
  - It reads the x-request-id header (already set by the existing SetRequestIdLayer before this middleware runs), opens a new tracing::info_span! with request_id as a field, and runs the rest of the request pipeline inside that span via .instrument(span).
  - Falls back to "unknown" if the header is absent.
- Exported the new module from server/src/middleware/mod.rs.
- Wired the middleware into create_routes() in server/src/routes/mod.rs via .layer(middleware::from_fn(trace_request_id)), placed between propagate_request_id_layer() and set_request_id_layer() so the header is guaranteed to be present when trace_request_id reads it.

### Acceptance criteria met
- A single request ID can be used to find all logs related to a specific user action (every log line within a request span carries request_id).

Closes #498