### PR TITLE
Implement admin dashboard API for flagging events

### DIFF
--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -31,6 +31,9 @@ erDiagram
         TEXT location
         TIMESTAMPTZ start_time
         TIMESTAMPTZ end_time
+        BOOLEAN is_flagged
+        BIGINT sum_of_ratings
+        INTEGER count_of_ratings
         TIMESTAMPTZ created_at
         TIMESTAMPTZ updated_at
     }
@@ -116,6 +119,9 @@ Events created by organizers.
 | `location` | TEXT | NOT NULL | Venue or address |
 | `start_time` | TIMESTAMPTZ | NOT NULL | Event start |
 | `end_time` | TIMESTAMPTZ | nullable | Event end |
+| `is_flagged` | BOOLEAN | NOT NULL, default `FALSE` | Flagged for moderation |
+| `sum_of_ratings` | BIGINT | NOT NULL, default `0` | Accumulated total of all star ratings |
+| `count_of_ratings` | INTEGER | NOT NULL, default `0` | Total number of ratings submitted |
 | `created_at` | TIMESTAMPTZ | NOT NULL, default `NOW()` | Record creation time |
 | `updated_at` | TIMESTAMPTZ | NOT NULL, default `NOW()` | Last update time (auto-managed by trigger) |
 

--- a/server/migrations/20260428000004_add_is_flagged_to_events.sql
+++ b/server/migrations/20260428000004_add_is_flagged_to_events.sql
@@ -1,0 +1,4 @@
+-- Add is_flagged column to events table for content moderation
+
+ALTER TABLE events
+    ADD COLUMN is_flagged BOOLEAN NOT NULL DEFAULT FALSE;

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -86,6 +86,9 @@ pub async fn list_events(
     let mut where_clauses = Vec::new();
     let mut param_count = 0;
     
+    // Always exclude flagged events from public listings
+    where_clauses.push("is_flagged = FALSE".to_string());
+    
     if filters.organizer_id.is_some() {
         param_count += 1;
         where_clauses.push(format!("organizer_id = ${}", param_count));
@@ -219,7 +222,7 @@ pub async fn get_event(
     
     // Cache miss or error, fetch from database
     let event = match sqlx::query_as::<_, Event>(
-        "SELECT * FROM events WHERE id = $1"
+        "SELECT * FROM events WHERE id = $1 AND is_flagged = FALSE"
     )
     .bind(event_id)
     .fetch_optional(&state.pool)
@@ -362,6 +365,63 @@ pub async fn submit_event_rating(
     };
 
     success(response, "Rating recorded successfully").into_response()
+}
+
+/// Toggle the flagged status of an event (admin only)
+///
+/// # Endpoint
+/// POST `/api/v1/admin/events/:id/toggle-flag`
+///
+/// # Description
+/// Flips the `is_flagged` status of the specified event.
+/// This endpoint is intended for admin use to moderate content.
+pub async fn toggle_event_flag(
+    State(state): State<EventState>,
+    Path(event_id): Path<Uuid>,
+) -> Response {
+    // Fetch current flag status
+    let current_flagged = match sqlx::query_scalar::<_, bool>(
+        "SELECT is_flagged FROM events WHERE id = $1"
+    )
+    .bind(event_id)
+    .fetch_optional(&state.pool)
+    .await
+    {
+        Ok(Some(flagged)) => flagged,
+        Ok(None) => {
+            return AppError::NotFound(format!("Event with id '{}' not found", event_id))
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch event flag status: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    // Toggle the flag
+    let new_flagged = !current_flagged;
+    if let Err(e) = sqlx::query(
+        "UPDATE events SET is_flagged = $1 WHERE id = $2"
+    )
+    .bind(new_flagged)
+    .bind(event_id)
+    .execute(&state.pool)
+    .await
+    {
+        tracing::error!("Failed to update event flag: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    // Invalidate cache for this event
+    let cache_key = format!("event:detail:{}", event_id);
+    if let Err(e) = state.redis.delete(&cache_key).await {
+        tracing::warn!("Failed to invalidate cache for event {}: {:?}", event_id, e);
+    }
+
+    success(
+        serde_json::json!({ "is_flagged": new_flagged }),
+        "Event flag toggled successfully"
+    ).into_response()
 }
 
 #[cfg(test)]

--- a/server/src/models/event.rs
+++ b/server/src/models/event.rs
@@ -27,6 +27,8 @@ pub struct Event {
     pub start_time: DateTime<Utc>,
     /// Optional scheduled end time of the event (UTC). `None` if open-ended.
     pub end_time: Option<DateTime<Utc>>,
+    /// Whether the event is flagged for moderation.
+    pub is_flagged: bool,
     /// Accumulated total of all star ratings for this event.
     pub sum_of_ratings: i64,
     /// Total number of ratings submitted for this event.

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -34,7 +34,7 @@ use crate::middleware::request_id_tracing::trace_request_id;
 use crate::cache::RedisCache;
 use crate::handlers::{
     categories::{get_category, list_categories},
-    events::{get_event, list_events, submit_event_rating, EventState},
+    events::{get_event, list_events, submit_event_rating, toggle_event_flag, EventState},
     example_empty_success,
     example_not_found,
     example_validation_error,
@@ -80,10 +80,10 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
 
     // Admin sub-router — every request is recorded in audit_logs.
     let admin_routes = Router::new()
-        // Placeholder: real admin handlers are mounted here as features land.
+        .route("/events/:id/toggle-flag", post(toggle_event_flag))
         .route("/health", get(health_check))
         .route_layer(middleware::from_fn_with_state(pool.clone(), audit_layer))
-        .with_state(pool.clone());
+        .with_state(event_state.clone());
 
     // WebSocket sub-router for real-time purchase updates.
     let ws_routes = Router::new()
@@ -148,6 +148,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
 
     Router::new()
         .nest("/api/v1", api_routes)
+        .nest("/api/v1/admin", admin_routes)
         .merge(deep_link_routes)
         .layer(create_security_headers_layer())
         .layer(create_cors_layer())


### PR DESCRIPTION
- Add is_flagged boolean field to events table via migration
- Update Event model to include is_flagged field
- Filter out flagged events from public list_events and get_event endpoints
- Add protected admin endpoint to toggle event flag status
- Update database schema documentation
- Add admin routes to the router

closes #493