### PR TITLE
refactor(ticket-payment): extract DataKey to keys.rs and add withdrawal cap + referral tests

### DIFF
--- a/contract/contracts/event_registry/test_snapshots/test/test_complete_event_lifecycle.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_complete_event_lifecycle.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -318,6 +330,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -460,6 +478,14 @@
                       },
                       "val": {
                         "u32": 600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_event_inactive_error.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_event_inactive_error.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -315,6 +327,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -457,6 +475,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_get_event_payment_info.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_get_event_payment_info.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -293,6 +305,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -435,6 +453,14 @@
                       },
                       "val": {
                         "u32": 750
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_inactive_event.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_inactive_event.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -408,6 +420,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -550,6 +568,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_max_supply_exceeded.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_max_supply_exceeded.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -443,6 +455,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -585,6 +603,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_persists_across_reads.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_persists_across_reads.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -527,6 +539,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -669,6 +687,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_success.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -443,6 +455,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -585,6 +603,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_unlimited_supply.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_increment_inventory_unlimited_supply.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -666,6 +678,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -808,6 +826,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_multiple_tiers_inventory.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_multiple_tiers_inventory.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -543,6 +555,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -685,6 +703,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_organizer_events_list.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_organizer_events_list.1.json
@@ -39,6 +39,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -185,6 +191,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "refund_deadline"
                       },
                       "val": {
@@ -300,6 +314,12 @@
                     {
                       "key": {
                         "symbol": "cancellation_reason"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "category_ids"
                       },
                       "val": "void"
                     },
@@ -447,6 +467,14 @@
                       },
                       "val": {
                         "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {
@@ -675,6 +703,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -817,6 +851,14 @@
                       },
                       "val": {
                         "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {
@@ -967,6 +1009,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -1109,6 +1157,14 @@
                       },
                       "val": {
                         "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_duplicate_event_fails.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_duplicate_event_fails.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -293,6 +305,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -435,6 +453,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_event_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_event_success.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -368,6 +380,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -510,6 +528,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_register_event_unlimited_supply.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_register_event_unlimited_supply.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -293,6 +305,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -435,6 +453,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_storage_operations.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_storage_operations.1.json
@@ -40,6 +40,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -182,6 +188,14 @@
                       },
                       "val": {
                         "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {
@@ -386,6 +400,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -528,6 +548,14 @@
                       },
                       "val": {
                         "u32": 5
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_tier_not_found.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_tier_not_found.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -386,6 +398,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -528,6 +546,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_tier_supply_exceeded.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_tier_supply_exceeded.1.json
@@ -53,6 +53,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -126,6 +132,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -470,6 +482,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -612,6 +630,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_event_status.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_event_status.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -315,6 +327,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -457,6 +475,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_invalid_cid.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_invalid_cid.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -295,6 +307,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -437,6 +455,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_success.1.json
+++ b/contract/contracts/event_registry/test_snapshots/test/test_update_metadata_success.1.json
@@ -34,6 +34,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "end_time"
                       },
                       "val": {
@@ -107,6 +113,12 @@
                       "val": {
                         "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -315,6 +327,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "category_ids"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "created_at"
                       },
                       "val": {
@@ -457,6 +475,14 @@
                       },
                       "val": {
                         "u32": 500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_rate_bps"
+                      },
+                      "val": {
+                        "u32": 0
                       }
                     },
                     {

--- a/contract/contracts/ticket_payment/src/keys.rs
+++ b/contract/contracts/ticket_payment/src/keys.rs
@@ -1,0 +1,61 @@
+use soroban_sdk::{contracttype, Address, BytesN, String};
+
+use crate::types::PaymentStatus;
+
+#[contracttype]
+pub enum DataKey {
+    Payment(String), // payment_id -> Payment
+    /// Individual entry for an event payment (Persistent)
+    EventPayment(String, String),
+    /// Sharded mapping of event_id to payment_ids (Persistent)
+    EventPaymentShard(String, u32),
+    /// Total number of payments for an event (Persistent)
+    EventPaymentCount(String),
+    /// Individual entry for a buyer payment (Persistent)
+    BuyerPayment(Address, String),
+    /// Sharded mapping of buyer_address to payment_ids (Persistent)
+    BuyerPaymentShard(Address, u32),
+    /// Total number of payments for a buyer (Persistent)
+    BuyerPaymentCount(Address),
+    Admin,                               // Contract administrator address
+    UsdcToken,                           // USDC token address
+    PlatformWallet,                      // Platform wallet address
+    EventRegistry,                       // Event Registry contract address
+    ProSubscriptionContract,             // Pro Subscription contract address
+    Initialized,                         // Initialization flag
+    TokenWhitelist(Address),             // token_address -> bool
+    Balances(String),                    // event_id -> EventBalance (escrow tracking)
+    TransferFee(String),                 // event_id -> transfer_fee_bps (u32)
+    BulkRefundIndex(String),             // event_id -> last processed payment index
+    PriceSwitched(String, String),       // (event_id, tier_id) -> bool
+    TotalVolumeProcessed,                // protocol-wide gross volume from all ticket sales
+    TotalFeesCollected(Address),         // cumulative platform fees collected by token
+    ActiveEscrowTotal,                   // protocol-wide active escrow across all tokens
+    ActiveEscrowByToken(Address),        // active escrow amount per token
+    DiscountCodeHash(BytesN<32>),        // sha256_hash -> bool (registered)
+    DiscountCodeUsed(BytesN<32>),        // sha256_hash -> bool (spent)
+    DiscountCode(String, String),        // (event_id, code) -> DiscountData
+    WithdrawalCap(Address),              // token_address -> max amount per day
+    DailyWithdrawalAmount(Address, u64), // (token_address, day_timestamp) -> amount withdrawn
+    IsPaused,                            // bool – global circuit breaker flag
+    DisputeStatus(String),               // event_id -> bool
+    EventCancelledForRefund(String),     // event_id -> bool
+    PartialRefundIndex(String),          // event_id -> last processed payment index
+    PartialRefundPercentage(String),     // event_id -> active refund percentage in bps
+    OracleAddress,                       // Address of oracle contract
+    SlippageBps,                         // u32 — slippage tolerance in bps (default 200 = 2%)
+    HighestBid(String, String),          // (event_id, tier_id) -> HighestBid
+    AuctionClosed(String, String),       // (event_id, tier_id) -> bool
+    Governor(Address),                   // Address -> bool (is authorized governor)
+    TotalGovernors,                      // u32
+    Proposal(u64),                       // id -> ParameterProposal
+    ProposalCount,                       // u64
+    /// Status index for payments: (event_id, status) -> Vec<payment_id>
+    EventPaymentStatus(String, PaymentStatus),
+    /// Individual entry for status index: (event_id, status, payment_id) -> bool
+    EventPaymentStatusEntry(String, PaymentStatus, String),
+    /// SHA-256 hash of the ticket secret: payment_id -> BytesN<32>
+    ValidationHash(String),
+    /// Per-event affiliate commission rate: (event_id, affiliate_addr) -> rate_bps (u32)
+    AffiliateRate(String, Address),
+}

--- a/contract/contracts/ticket_payment/src/lib.rs
+++ b/contract/contracts/ticket_payment/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod contract;
 pub mod error;
 pub mod events;
+pub mod keys;
 pub mod storage;
 pub mod types;
 

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -8500,3 +8500,322 @@ fn test_transfer_no_lock_always_allowed() {
         "transfer with no lock must succeed immediately"
     );
 }
+
+// ── Withdrawal Cap Tests ──────────────────────────────────────────────────────
+
+/// Helper: process a payment and settle the platform fees so that
+/// `total_fees_collected` is funded and `withdraw_platform_fees` can be called.
+fn fund_fees_for_cap_tests(
+    env: &Env,
+    client: &TicketPaymentContractClient,
+    usdc_id: &Address,
+    num_payments: u32,
+) {
+    let buyer = Address::generate(env);
+    let amount = 1000_0000000i128; // 1000 USDC per ticket
+    let total = amount * num_payments as i128;
+
+    token::StellarAssetClient::new(env, usdc_id).mint(&buyer, &total);
+    token::Client::new(env, usdc_id).approve(&buyer, &client.address, &total, &99999);
+
+    for i in 0..num_payments {
+        let pid = match i {
+            0 => String::from_str(env, "cap_p0"),
+            1 => String::from_str(env, "cap_p1"),
+            2 => String::from_str(env, "cap_p2"),
+            3 => String::from_str(env, "cap_p3"),
+            _ => String::from_str(env, "cap_px"),
+        };
+        let (_secret, hash) = test_secret(env);
+        client.process_payment(
+            &pid,
+            &String::from_str(env, "event_1"),
+            &String::from_str(env, "tier_1"),
+            &buyer,
+            &None::<Address>,
+            usdc_id,
+            &amount,
+            &1u32,
+            &crate::types::PurchaseOptions {
+                code_preimage: None,
+                referrer: None,
+                discount_code: None,
+            },
+            &hash,
+        );
+    }
+}
+
+/// A daily withdrawal cap of 100 USDC must block a 150 USDC withdrawal even
+/// when 200 USDC of fees are available.
+#[test]
+fn test_withdrawal_cap_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, usdc_id, _platform_wallet, _) = setup_test(&env);
+
+    // Process 2 payments of 1000 USDC each → 2 × 50 USDC = 100 USDC in fees.
+    // We need > 100 USDC available, so process 4 payments → 200 USDC in fees.
+    fund_fees_for_cap_tests(&env, &client, &usdc_id, 4);
+
+    let total_fees = client.get_total_fees_collected(&usdc_id);
+    assert!(
+        total_fees >= 200_0000000i128,
+        "expected at least 200 USDC in fees, got {}",
+        total_fees
+    );
+
+    // Set a daily cap of 100 USDC.
+    let cap = 100_0000000i128;
+    client.set_withdrawal_cap(&usdc_id, &cap);
+
+    // Attempting to withdraw 150 USDC must fail with WithdrawalCapExceeded.
+    let result = client.try_withdraw_platform_fees(&150_0000000i128, &usdc_id);
+    assert_eq!(
+        result,
+        Err(Ok(TicketPaymentError::WithdrawalCapExceeded)),
+        "withdrawal of 150 USDC should be blocked by a 100 USDC daily cap"
+    );
+}
+
+/// After exhausting the daily cap, advancing the ledger by more than 86400 seconds
+/// resets the day counter and a second withdrawal must succeed.
+#[test]
+fn test_withdrawal_cap_resets_after_24h() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, usdc_id, platform_wallet, _) = setup_test(&env);
+
+    // Fund enough fees for two full-cap withdrawals.
+    fund_fees_for_cap_tests(&env, &client, &usdc_id, 4);
+
+    let cap = 50_0000000i128; // 50 USDC cap per day
+    client.set_withdrawal_cap(&usdc_id, &cap);
+
+    // First withdrawal — exactly at the cap.
+    client.withdraw_platform_fees(&cap, &usdc_id);
+    let balance_after_first = token::Client::new(&env, &usdc_id).balance(&platform_wallet);
+    assert_eq!(balance_after_first, cap);
+
+    // Second withdrawal on the same day must fail.
+    let same_day_result = client.try_withdraw_platform_fees(&1_0000000i128, &usdc_id);
+    assert_eq!(
+        same_day_result,
+        Err(Ok(TicketPaymentError::WithdrawalCapExceeded)),
+        "same-day withdrawal after cap exhaustion must fail"
+    );
+
+    // Advance ledger by 86401 seconds (past the 24-hour boundary).
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86401);
+
+    // Second withdrawal on the new day must succeed.
+    client.withdraw_platform_fees(&cap, &usdc_id);
+    let balance_after_second = token::Client::new(&env, &usdc_id).balance(&platform_wallet);
+    assert_eq!(
+        balance_after_second,
+        cap * 2,
+        "second withdrawal on a new day should succeed"
+    );
+}
+
+/// A withdrawal cap of 0 means unlimited — large withdrawals must not be blocked.
+#[test]
+fn test_withdrawal_cap_zero_means_unlimited() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, usdc_id, platform_wallet, _) = setup_test(&env);
+
+    // Fund 4 payments → 200 USDC in fees.
+    fund_fees_for_cap_tests(&env, &client, &usdc_id, 4);
+
+    let total_fees = client.get_total_fees_collected(&usdc_id);
+    assert!(total_fees > 0);
+
+    // Explicitly set cap to 0 (unlimited).
+    client.set_withdrawal_cap(&usdc_id, &0i128);
+
+    // Withdraw the entire accumulated fee in one shot — must succeed.
+    client.withdraw_platform_fees(&total_fees, &usdc_id);
+
+    let platform_balance = token::Client::new(&env, &usdc_id).balance(&platform_wallet);
+    assert_eq!(
+        platform_balance, total_fees,
+        "cap=0 must allow withdrawing the full fee balance"
+    );
+}
+
+// ── Referral Tests ────────────────────────────────────────────────────────────
+
+/// process_payment with a referrer must transfer the correct commission to the referrer.
+///
+/// price = 1000 USDC, fee_bps = 500 (5%) → platform_fee = 50 USDC
+/// default affiliate rate = 2000 bps (20%) → reward = 50 × 20% = 10 USDC
+#[test]
+fn test_process_payment_with_referral() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TicketPaymentContract, ());
+    let client = TicketPaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let platform_wallet = Address::generate(&env);
+    let registry_id = env.register(MockEventRegistryForReferral, ());
+    client.initialize(&admin, &usdc_id, &platform_wallet, &registry_id);
+
+    let buyer = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let price = 1000_0000000i128;
+
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &price);
+    token::Client::new(&env, &usdc_id).approve(&buyer, &client.address, &price, &99999);
+
+    let (_secret, hash) = test_secret(&env);
+    client.process_payment(
+        &String::from_str(&env, "pay_ref_new"),
+        &String::from_str(&env, "event_1"),
+        &String::from_str(&env, "tier_1"),
+        &buyer,
+        &None::<Address>,
+        &usdc_id,
+        &price,
+        &1u32,
+        &crate::types::PurchaseOptions {
+            code_preimage: None,
+            referrer: Some(referrer.clone()),
+            discount_code: None,
+        },
+        &hash,
+    );
+
+    // platform_fee = 1000 × 5% = 50 USDC
+    // reward = 50 × 20% = 10 USDC  (default 2000 bps affiliate rate)
+    let expected_reward = 10_0000000i128;
+    let referrer_balance = token::Client::new(&env, &usdc_id).balance(&referrer);
+    assert_eq!(
+        referrer_balance, expected_reward,
+        "referrer must receive 10 USDC commission"
+    );
+
+    // The payment record must store the referral amount and referrer address.
+    let payment = client
+        .get_payment_status(&String::from_str(&env, "pay_ref_new"))
+        .unwrap();
+    assert_eq!(payment.referral_amount, expected_reward);
+    assert_eq!(payment.referrer, Some(referrer));
+}
+
+/// Passing the buyer's own address as the referrer must return SelfReferralNotAllowed.
+#[test]
+fn test_process_payment_self_referral_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TicketPaymentContract, ());
+    let client = TicketPaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let platform_wallet = Address::generate(&env);
+    let registry_id = env.register(MockEventRegistryForReferral, ());
+    client.initialize(&admin, &usdc_id, &platform_wallet, &registry_id);
+
+    let buyer = Address::generate(&env);
+    let price = 1000_0000000i128;
+
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &price);
+    token::Client::new(&env, &usdc_id).approve(&buyer, &client.address, &price, &99999);
+
+    let (_secret, hash) = test_secret(&env);
+    // Pass buyer as their own referrer.
+    let result = client.try_process_payment(
+        &String::from_str(&env, "pay_self_ref"),
+        &String::from_str(&env, "event_1"),
+        &String::from_str(&env, "tier_1"),
+        &buyer,
+        &None::<Address>,
+        &usdc_id,
+        &price,
+        &1u32,
+        &crate::types::PurchaseOptions {
+            code_preimage: None,
+            referrer: Some(buyer.clone()), // self-referral
+            discount_code: None,
+        },
+        &hash,
+    );
+
+    assert_eq!(
+        result,
+        Err(Ok(TicketPaymentError::SelfReferralNotAllowed)),
+        "self-referral must be rejected"
+    );
+}
+
+/// When no referrer is provided, no commission must be paid out and the
+/// payment record must store referral_amount = 0.
+#[test]
+fn test_referral_commission_zero_when_no_referrer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TicketPaymentContract, ());
+    let client = TicketPaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let platform_wallet = Address::generate(&env);
+    let registry_id = env.register(MockEventRegistryForReferral, ());
+    client.initialize(&admin, &usdc_id, &platform_wallet, &registry_id);
+
+    let buyer = Address::generate(&env);
+    let price = 1000_0000000i128;
+
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &price);
+    token::Client::new(&env, &usdc_id).approve(&buyer, &client.address, &price, &99999);
+
+    let payment_id = String::from_str(&env, "pay_no_ref");
+    let (_secret, hash) = test_secret(&env);
+    client.process_payment(
+        &payment_id,
+        &String::from_str(&env, "event_1"),
+        &String::from_str(&env, "tier_1"),
+        &buyer,
+        &None::<Address>,
+        &usdc_id,
+        &price,
+        &1u32,
+        &crate::types::PurchaseOptions {
+            code_preimage: None,
+            referrer: None, // no referrer
+            discount_code: None,
+        },
+        &hash,
+    );
+
+    // The full platform fee must stay in escrow — no commission was paid out.
+    let escrow = client.get_event_escrow_balance(&String::from_str(&env, "event_1"));
+    let expected_platform_fee = (price * 500) / 10000; // 5% = 50 USDC
+    assert_eq!(
+        escrow.platform_fee, expected_platform_fee,
+        "full platform fee must remain in escrow when there is no referrer"
+    );
+
+    // Payment record must record zero referral amount and no referrer.
+    let payment = client.get_payment_status(&payment_id).unwrap();
+    assert_eq!(
+        payment.referral_amount, 0,
+        "referral_amount must be 0 when no referrer is provided"
+    );
+    assert_eq!(
+        payment.referrer, None,
+        "referrer field must be None when no referrer is provided"
+    );
+}

--- a/contract/contracts/ticket_payment/src/types.rs
+++ b/contract/contracts/ticket_payment/src/types.rs
@@ -1,7 +1,10 @@
-use soroban_sdk::{contracttype, Address, BytesN, String};
+use soroban_sdk::{contracttype, Address, String};
 
 pub const TRANSFER_FEE_BPS: u32 = 100;
 pub const MAX_BPS: u32 = 10000;
+
+// Re-export DataKey from the dedicated keys module so all existing imports continue to work.
+pub use crate::keys::DataKey;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -120,62 +123,4 @@ pub struct HighestBid {
     pub bidder: Address,
     pub token_address: Address,
     pub amount: i128,
-}
-
-#[contracttype]
-pub enum DataKey {
-    Payment(String), // payment_id -> Payment
-    /// Individual entry for an event payment (Persistent)
-    EventPayment(String, String),
-    /// Sharded mapping of event_id to payment_ids (Persistent)
-    EventPaymentShard(String, u32),
-    /// Total number of payments for an event (Persistent)
-    EventPaymentCount(String),
-    /// Individual entry for a buyer payment (Persistent)
-    BuyerPayment(Address, String),
-    /// Sharded mapping of buyer_address to payment_ids (Persistent)
-    BuyerPaymentShard(Address, u32),
-    /// Total number of payments for a buyer (Persistent)
-    BuyerPaymentCount(Address),
-    Admin,                               // Contract administrator address
-    UsdcToken,                           // USDC token address
-    PlatformWallet,                      // Platform wallet address
-    EventRegistry,                       // Event Registry contract address
-    ProSubscriptionContract,             // Pro Subscription contract address
-    Initialized,                         // Initialization flag
-    TokenWhitelist(Address),             // token_address -> bool
-    Balances(String),                    // event_id -> EventBalance (escrow tracking)
-    TransferFee(String),                 // event_id -> transfer_fee_bps (u32)
-    BulkRefundIndex(String),             // event_id -> last processed payment index
-    PriceSwitched(String, String),       // (event_id, tier_id) -> bool
-    TotalVolumeProcessed,                // protocol-wide gross volume from all ticket sales
-    TotalFeesCollected(Address),         // cumulative platform fees collected by token
-    ActiveEscrowTotal,                   // protocol-wide active escrow across all tokens
-    ActiveEscrowByToken(Address),        // active escrow amount per token
-    DiscountCodeHash(BytesN<32>),        // sha256_hash -> bool (registered)
-    DiscountCodeUsed(BytesN<32>),        // sha256_hash -> bool (spent)
-    DiscountCode(String, String),        // (event_id, code) -> DiscountData
-    WithdrawalCap(Address),              // token_address -> max amount per day
-    DailyWithdrawalAmount(Address, u64), // (token_address, day_timestamp) -> amount withdrawn
-    IsPaused,                            // bool – global circuit breaker flag
-    DisputeStatus(String),               // event_id -> bool
-    EventCancelledForRefund(String),     // event_id -> bool
-    PartialRefundIndex(String),          // event_id -> last processed payment index
-    PartialRefundPercentage(String),     // event_id -> active refund percentage in bps
-    OracleAddress,                       // Address of oracle contract
-    SlippageBps,                         // u32 — slippage tolerance in bps (default 200 = 2%)
-    HighestBid(String, String),          // (event_id, tier_id) -> HighestBid
-    AuctionClosed(String, String),       // (event_id, tier_id) -> bool
-    Governor(Address),                   // Address -> bool (is authorized governor)
-    TotalGovernors,                      // u32
-    Proposal(u64),                       // id -> ParameterProposal
-    ProposalCount,                       // u64
-    /// Status index for payments: (event_id, status) -> Vec<payment_id>
-    EventPaymentStatus(String, PaymentStatus),
-    /// Individual entry for status index: (event_id, status, payment_id) -> bool
-    EventPaymentStatusEntry(String, PaymentStatus, String),
-    /// SHA-256 hash of the ticket secret: payment_id -> BytesN<32>
-    ValidationHash(String),
-    /// Per-event affiliate commission rate: (event_id, affiliate_addr) -> rate_bps (u32)
-    AffiliateRate(String, Address),
 }

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_confirm_payment.1.json
@@ -878,6 +878,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -891,6 +899,20 @@
                       "val": {
                         "i128": "5"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_fee_calculation_variants.1.json
@@ -98,6 +98,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
+                "void",
                 {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 },
@@ -1059,6 +1060,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1072,6 +1081,20 @@
                       "val": {
                         "i128": "2500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_inventory_increment_on_successful_payment.1.json
@@ -98,6 +98,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
+                "void",
                 {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 },
@@ -160,6 +161,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
+                "void",
                 {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 },
@@ -1296,6 +1298,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1309,6 +1319,20 @@
                       "val": {
                         "i128": "500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -1464,6 +1488,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1477,6 +1509,20 @@
                       "val": {
                         "i128": "500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_success.1.json
@@ -99,6 +99,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
+                "void",
                 {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 },
@@ -1061,6 +1062,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1074,6 +1083,20 @@
                       "val": {
                         "i128": "500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_process_payment_with_multiple_tokens.1.json
@@ -218,6 +218,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
                 },
+                "void",
                 {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 },
@@ -280,6 +281,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
                 },
+                "void",
                 {
                   "address": "CD3FXVGYSLQFFTW3UH6WFF2OKZH7VERGZJZAMJHTGHBWO4F6URWEJL23"
                 },
@@ -1622,6 +1624,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1635,6 +1645,20 @@
                       "val": {
                         "i128": "500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {
@@ -1790,6 +1814,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1803,6 +1835,20 @@
                       "val": {
                         "i128": "500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_organizer_funds.1.json
@@ -98,6 +98,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
+                "void",
                 {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 },
@@ -1082,6 +1083,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1095,6 +1104,20 @@
                       "val": {
                         "i128": "500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
+++ b/contract/contracts/ticket_payment/test_snapshots/test/test_withdraw_platform_fees.1.json
@@ -98,6 +98,7 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
+                "void",
                 {
                   "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 },
@@ -1106,6 +1107,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "owner_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "payment_id"
                       },
                       "val": {
@@ -1119,6 +1128,20 @@
                       "val": {
                         "i128": "500000000"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referral_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "referrer"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {


### PR DESCRIPTION


What changed

DataKey enum extracted to dedicated module

The DataKey enum (40+ variants spanning payments, escrow, fees, governance, auctions, and more) was moved out of types.rs into a new keys.rs file. types.rs now re-exports it via pub use crate::keys::DataKey so all existing imports in storage.rs, contract.rs, and tests are unaffected. lib.rs declares the new mod keys module.

6 new test cases in test.rs

Withdrawal cap:

test_withdrawal_cap_enforced — sets a 100 USDC daily cap, funds 200 USDC in fees, asserts WithdrawalCapExceeded on a 150 USDC withdrawal
test_withdrawal_cap_resets_after_24h — exhausts the cap, advances the ledger by 86401 seconds, asserts the second withdrawal succeeds on the new day
test_withdrawal_cap_zero_means_unlimited — sets cap to 0, asserts the full fee balance can be withdrawn in one call
Referral:

test_process_payment_with_referral — verifies the referrer receives the correct 10 USDC commission (20% of the 5% platform fee) and the payment record stores the right referral_amount and referrer
test_process_payment_self_referral_rejected — passes the buyer as their own referrer, asserts SelfReferralNotAllowed
test_referral_commission_zero_when_no_referrer — processes a payment with no referrer, asserts the full platform fee stays in escrow and referral_amount == 0


closes #672
closes #674
closes #675
closes #676