### PR TITLE
fix: use Next router for auth redirects

### DIFF
--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -170,7 +170,7 @@ export default function AuthPage() {
           {/* Google Button */}
           <button
             type="button"
-            onClick={() => window.location.href = '/api/auth/google'}
+            onClick={() => router.push("/api/auth/google")}
             className="
               w-full
               bg-black
@@ -197,7 +197,7 @@ export default function AuthPage() {
           {/* Apple Button */}
           <button
             type="button"
-            onClick={() => window.location.href = '/api/auth/apple'}
+            onClick={() => router.push("/api/auth/apple")}
             className="
               w-full
               bg-black


### PR DESCRIPTION
## Summary
- replace direct `window.location.href` auth redirects with `router.push`
- keep Google and Apple sign-in destinations unchanged

## Verification
- `npm run lint -- app/auth/page.tsx` from `apps/web`
- `git diff --check`
- `rg -n "window\.location\.href|location\.href|window\.location"` returns no matches

Closes #704