### PR TITLE
Feature/descriptive alt text

### DIFF
--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -3,6 +3,7 @@
 import { useState, FormEvent } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 function validateEmail(email: string): boolean {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -64,39 +65,21 @@ export default function AuthPage() {
   return (
     <main className="min-h-screen bg-[#A9A495] relative flex items-center justify-center">
       {/* Back Button */}
-      <button
+      <Button
         type="button"
+        variant="secondary"
         onClick={handleGoBack}
-        className="
-          absolute top-10 left-16
-          bg-white
-          px-6 py-2
-          rounded-full
-          font-medium text-sm
-          flex items-center gap-2
-          border-2 border-black
-          shadow-[0_4px_0_#000]
-          active:translate-y-[2px]
-          active:shadow-[0_2px_0_#000]
-        "
+        className="absolute top-10 left-16 text-sm py-2"
       >
         <Image src="/icons/arrow-left.svg" alt="Back" width={16} height={16} />
         Back
-      </button>
+      </Button>
 
       {/* Auth Card */}
       <div className="w-[360px] bg-[#F3EEDC] rounded-2xl shadow-[0_8px_0_#00000020] p-8 flex flex-col items-center">
-        {/* Logo Container (Ticked Black Card Style) */}
+        {/* Logo Container */}
         <div className="mb-6">
-          <div
-            className="
-              bg-white
-              border-2 border-black
-              rounded-lg
-              px-4 py-2
-              shadow-[2px_2px_0_#000]
-            "
-          >
+          <div className="bg-white border-2 border-black rounded-lg px-4 py-2 shadow-[2px_2px_0_#000]">
             <Image
               src="/logo/agora logo.svg"
               alt="Agora"
@@ -106,7 +89,6 @@ export default function AuthPage() {
           </div>
         </div>
 
-        {/* Title */}
         <h1 className="text-xl font-semibold mb-1 text-black">
           Welcome to agora
         </h1>
@@ -114,9 +96,7 @@ export default function AuthPage() {
           Please sign in or sign up below.
         </p>
 
-        {/* Form */}
         <form onSubmit={handleSubmit} className="w-full">
-          {/* Email */}
           <label className="text-sm font-medium block mb-2 text-black">
             Email
           </label>
@@ -125,95 +105,40 @@ export default function AuthPage() {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="
-              w-full
-              bg-white
-              border-2 border-black
-              rounded-full
-              px-4 py-2
-              mb-4
-              outline-none
-            "
+            className="w-full bg-white border-2 border-black rounded-full px-4 py-2 mb-4 outline-none"
           />
 
           {error && <p className="text-xs text-red-500 mb-3">{error}</p>}
 
-          {/* Yellow Continue Button */}
-          <button
+          <Button
             type="submit"
+            variant="primary"
             disabled={isLoading}
-            className="
-              w-full
-              bg-[#FACC15]
-              hover:bg-[#EAB308]
-              rounded-full
-              py-2
-              font-medium
-              flex items-center justify-center gap-2
-              mb-4
-              border-2 border-black
-              shadow-[0_4px_0_#000]
-              active:translate-y-[2px]
-              active:shadow-[0_2px_0_#000]
-              transition
-            "
+            className="w-full mb-4 py-2"
           >
             Continue with Email
-            <Image
-              src="/icons/arrow-right.svg"
-              alt="Arrow"
-              width={16}
-              height={16}
-            />
-          </button>
+            <Image src="/icons/arrow-right.svg" alt="Arrow" width={16} height={16} />
+          </Button>
 
-          {/* Google Button */}
-          <button
+          <Button
             type="button"
-            onClick={() => window.location.href = '/api/auth/google'}
-            className="
-              w-full
-              bg-black
-              text-white
-              rounded-full
-              py-2
-              flex items-center justify-center gap-2
-              mb-3
-              border-2 border-black
-              shadow-[0_4px_0_#000]
-              active:translate-y-[2px]
-              active:shadow-[0_2px_0_#000]
-            "
+            variant="dark"
+            onClick={() => { window.location.href = '/api/auth/google'; }}
+            className="w-full mb-3 py-2"
           >
-            <Image
-              src="/icons/google.svg"
-              alt="Google"
-              width={16}
-              height={16}
-            />
+            <Image src="/icons/google.svg" alt="Google" width={16} height={16} />
             Sign in with Google
-          </button>
+          </Button>
 
-          {/* Apple Button */}
-          <button
+          <Button
             type="button"
-            onClick={() => window.location.href = '/api/auth/apple'}
-            className="
-              w-full
-              bg-black
-              text-white
-              rounded-full
-              py-2
-              flex items-center justify-center gap-2
-              border-2 border-black
-              shadow-[0_4px_0_#000]
-              active:translate-y-[2px]
-              active:shadow-[0_2px_0_#000]
-            "
+            variant="dark"
+            onClick={() => { window.location.href = '/api/auth/apple'; }}
+            className="w-full py-2"
           >
             <Image src="/icons/apple.svg" alt="Apple" width={16} height={16} />
             Sign in with Apple
-          </button>
+          </Button>
         </form>
       </div>
     </main>

--- a/apps/web/app/create-event/page.tsx
+++ b/apps/web/app/create-event/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
+import { Button } from "@/components/ui/button";
 import { CheckCircle2, Home, ExternalLink } from "lucide-react";
 import { toast } from "sonner";
 
@@ -126,10 +127,10 @@ export default function CreateEventPage() {
 
             <div className="flex flex-col w-full gap-4 mt-4">
               <Link href={`/events/${createdEventId?.replace("evt_", "")}`} className="w-full">
-                <button className="w-full bg-[#FDDA23] text-black font-bold text-xl h-16 rounded-full border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:translate-x-[2px] active:translate-y-[2px] active:shadow-none transition-all flex items-center justify-center gap-3">
-                  <span>View Event</span>
+                <Button variant="primary" className="w-full h-16 rounded-full text-xl">
+                  View Event
                   <ExternalLink size={24} />
-                </button>
+                </Button>
               </Link>
               <Link href="/home" className="w-full text-black/60 font-bold text-lg flex items-center justify-center gap-2 hover:text-black transition-colors">
                 <Home size={20} />
@@ -431,53 +432,43 @@ export default function CreateEventPage() {
               {errors.price && <span className="text-red-500 text-sm font-bold absolute bottom-2 left-6">{errors.price}</span>}
             </div>
 
-            <div className="flex justify-end gap-14 mt-6 mr-4">
-              <div className="relative w-[212px] h-[58px]">
-                <div className="absolute w-[212px] h-[50px] left-0 top-[6px] bg-[#000000] rounded-[32px]" />
-                <button
-                  type="button"
-                  onClick={() => setFormData({
-                    title: "",
-                    startDate: "",
-                    startTime: "",
-                    endDate: "",
-                    endTime: "",
-                    location: "",
-                    description: "",
-                    capacity: "",
-                    price: "",
-                    visibility: "Public",
-                  })}
-                  className="absolute w-[212px] h-[50px] left-[3px] top-0 bg-[#FFFFFF] border-2 border-[#000000] rounded-[32px] flex items-center justify-center hover:bg-gray-50 transition-transform active:translate-y-1 active:translate-x-px"
-                >
-                  <span className="font-semibold text-[15px] text-[#000000] text-center w-[131px] leading-[30px]">
-                    Clear Event
-                  </span>
-                </button>
-              </div>
+            <div className="flex justify-end gap-4 mt-6 mr-4">
+              <Button
+                type="button"
+                variant="secondary"
+                className="w-[212px] h-[50px] rounded-[32px]"
+                onClick={() => setFormData({
+                  title: "",
+                  startDate: "",
+                  startTime: "",
+                  endDate: "",
+                  endTime: "",
+                  location: "",
+                  description: "",
+                  capacity: "",
+                  price: "",
+                  visibility: "Public",
+                })}
+              >
+                Clear Event
+              </Button>
 
-              <div className="relative w-[215px] h-[58px]">
-                <div className="absolute w-[212px] h-[50px] left-0 top-[6px] bg-[#000000] rounded-[32px]" />
-                <button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="absolute w-[212px] h-[50px] left-[3px] top-0 bg-[#FDDA23] border-2 border-[#000000] rounded-[32px] flex items-center justify-center gap-[10px] hover:bg-[#f0ce1e] transition-transform active:translate-y-1 active:translate-x-px disabled:opacity-70 disabled:cursor-not-allowed"
-                >
-                  <span className="font-semibold text-[15px] text-[#000000] text-center leading-[30px]">
-                    {isSubmitting ? "Creating..." : "Create Event"}
-                  </span>
-                  {!isSubmitting && (
-                    <div className="w-[24px] h-[24px] flex items-center justify-center">
-                      <Image
-                        src="/icons/arrow-up-right-01.svg"
-                        width={24}
-                        height={24}
-                        alt="Create"
-                      />
-                    </div>
-                  )}
-                </button>
-              </div>
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={isSubmitting}
+                className="w-[212px] h-[50px] rounded-[32px] disabled:opacity-70 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? "Creating..." : "Create Event"}
+                {!isSubmitting && (
+                  <Image
+                    src="/icons/arrow-up-right-01.svg"
+                    width={24}
+                    height={24}
+                    alt="Create"
+                  />
+                )}
+              </Button>
             </div>
           </div>
         </div>

--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -135,7 +135,7 @@ export default function EventDetailPage({
                     src="/icons/notification.svg"
                     width={22}
                     height={22}
-                    alt="calendar"
+                    alt="Date"
                   />
                 </div>
                 <span className="text-[18px] sm:text-[19px] font-medium text-black">

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -409,7 +409,7 @@ function TimelineEventCard({ event }: { event: TimelineEvent }) {
                   <div className="flex items-center gap-1.5 text-black/70">
                     <Image
                       src={locationImageSrc}
-                      alt="location"
+                      alt={event.location.toLowerCase().includes("discord") ? "Discord" : "Location"}
                       width={16}
                       height={16}
                       className="object-contain"

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
+import { Button } from "@/components/ui/button";
 import CalendarIcon from "@/public/icons/calendar.svg";
 import HostingIcon from "@/public/icons/ticket-star.svg";
 import PastIcon from "@/public/icons/camera-smile-01.svg";
@@ -577,9 +578,9 @@ function MyEventsContent({ activeTab }: { activeTab: MyEventsTab }) {
         <div className="flex flex-col items-center gap-4">
           <p className="text-xl font-medium leading-5.5 text-center">Nothing Here, Yet</p>
           <Link href="/create-event">
-            <button className="bg-black text-white px-6 py-2 rounded-full font-medium shadow-[-4px_4px_0_rgba(0,0,0,0.2)] hover:shadow-none hover:translate-x-[-2px] hover:translate-y-[2px] transition-all">
+            <Button variant="dark" className="rounded-full">
               Create Your First Event
-            </button>
+            </Button>
           </Link>
         </div>
       </div>

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from "next";
+import { prisma } from "@/lib/prisma";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://agora-web-eta.vercel.app";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const events = await prisma.event.findMany({ select: { id: true, updatedAt: true } });
+
+  const eventEntries: MetadataRoute.Sitemap = events.map((e) => ({
+    url: `${BASE_URL}/events/${e.id}`,
+    lastModified: e.updatedAt,
+    changeFrequency: "weekly",
+    priority: 0.8,
+  }));
+
+  return [
+    { url: BASE_URL, changeFrequency: "daily", priority: 1.0 },
+    { url: `${BASE_URL}/discover`, changeFrequency: "daily", priority: 0.9 },
+    { url: `${BASE_URL}/pricing`, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${BASE_URL}/faqs`, changeFrequency: "monthly", priority: 0.6 },
+    ...eventEntries,
+  ];
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -6,7 +6,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://agora-web-eta.verc
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const events = await prisma.event.findMany({ select: { id: true, updatedAt: true } });
 
-  const eventEntries: MetadataRoute.Sitemap = events.map((e) => ({
+  const eventEntries: MetadataRoute.Sitemap = events.map((e: { id: string; updatedAt: Date }) => ({
     url: `${BASE_URL}/events/${e.id}`,
     lastModified: e.updatedAt,
     changeFrequency: "weekly",

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,23 +1,28 @@
 import { MetadataRoute } from "next";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://agora-web-eta.vercel.app";
 
+const staticRoutes: MetadataRoute.Sitemap = [
+  { url: BASE_URL, changeFrequency: "daily", priority: 1.0 },
+  { url: `${BASE_URL}/discover`, changeFrequency: "daily", priority: 0.9 },
+  { url: `${BASE_URL}/pricing`, changeFrequency: "monthly", priority: 0.7 },
+  { url: `${BASE_URL}/faqs`, changeFrequency: "monthly", priority: 0.6 },
+];
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const events = await prisma.event.findMany({ select: { id: true, updatedAt: true } });
-
-  const eventEntries: MetadataRoute.Sitemap = events.map((e: { id: string; updatedAt: Date }) => ({
-    url: `${BASE_URL}/events/${e.id}`,
-    lastModified: e.updatedAt,
-    changeFrequency: "weekly",
-    priority: 0.8,
-  }));
-
-  return [
-    { url: BASE_URL, changeFrequency: "daily", priority: 1.0 },
-    { url: `${BASE_URL}/discover`, changeFrequency: "daily", priority: 0.9 },
-    { url: `${BASE_URL}/pricing`, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${BASE_URL}/faqs`, changeFrequency: "monthly", priority: 0.6 },
-    ...eventEntries,
-  ];
+  try {
+    const events = await prisma.event.findMany({ select: { id: true, updatedAt: true } });
+    const eventEntries: MetadataRoute.Sitemap = events.map((e: { id: string; updatedAt: Date }) => ({
+      url: `${BASE_URL}/events/${e.id}`,
+      lastModified: e.updatedAt,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    }));
+    return [...staticRoutes, ...eventEntries];
+  } catch {
+    return staticRoutes;
+  }
 }

--- a/apps/web/components/events/TicketModal.tsx
+++ b/apps/web/components/events/TicketModal.tsx
@@ -6,6 +6,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { toast } from "sonner";
 import { X, Minus, Plus, Ticket, ArrowRight, CheckCircle2, Gift } from "lucide-react";
 import Image from "next/image";
+import { Button } from "@/components/ui/button";
 
 interface TicketModalProps {
   isOpen: boolean;
@@ -200,11 +201,11 @@ export function TicketModal({ isOpen, onClose, event, initialQuantity }: TicketM
                   </div>
                 </div>
 
-                <button
-                  type="button"
+                <Button
+                  variant="primary"
                   onClick={handleConfirmPurchase}
                   disabled={isPurchasing}
-                  className="w-full bg-accent text-black font-bold text-xl h-16 rounded-full border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:translate-x-[2px] active:translate-y-[2px] active:shadow-none transition-all flex items-center justify-center gap-3 disabled:opacity-70 disabled:cursor-not-allowed group"
+                  className="w-full h-16 rounded-full text-xl disabled:opacity-70 disabled:cursor-not-allowed"
                 >
                   {isPurchasing ? (
                     <div className="w-6 h-6 border-2 border-black/30 border-t-black rounded-full animate-spin" />
@@ -214,7 +215,7 @@ export function TicketModal({ isOpen, onClose, event, initialQuantity }: TicketM
                       <ArrowRight size={24} className="group-hover:translate-x-1 transition-transform" />
                     </>
                   )}
-                </button>
+                </Button>
               </div>
             ) : (
               <div className="p-8 sm:p-10 flex flex-col items-center text-center gap-8">
@@ -248,13 +249,13 @@ export function TicketModal({ isOpen, onClose, event, initialQuantity }: TicketM
                   </div>
                 </div>
 
-                <button
-                  type="button"
+                <Button
+                  variant="dark"
                   onClick={onClose}
-                  className="w-full bg-black text-white font-bold text-lg h-14 rounded-full hover:opacity-90 transition-opacity"
+                  className="w-full h-14 rounded-full text-lg"
                 >
                   Done
-                </button>
+                </Button>
               </div>
             )}
 

--- a/apps/web/components/events/create-event-form.tsx
+++ b/apps/web/components/events/create-event-form.tsx
@@ -382,19 +382,16 @@ export default function CreateEventForm() {
       {/* Action Buttons */}
       <div className="flex flex-col sm:flex-row justify-end items-center gap-4 mt-6 mb-8">
         <Button
+          variant="secondary"
           onClick={handleClear}
-          backgroundColor="bg-white"
-          textColor="text-black"
-          shadowColor="transparent"
-          className="w-full sm:w-auto hover:bg-gray-50 border border-transparent"
+          className="w-full sm:w-auto"
         >
           Clear Event
         </Button>
         <Button
+          variant="primary"
           disabled={isSubmitDisabled}
           onClick={handleSubmit}
-          backgroundColor="bg-accent"
-          textColor="text-black"
           className={`w-full sm:w-auto ${
             isSubmitDisabled
               ? "opacity-50 cursor-not-allowed hover:translate-x-0 hover:translate-y-0 active:translate-x-0 active:translate-y-0"

--- a/apps/web/components/events/event-card.tsx
+++ b/apps/web/components/events/event-card.tsx
@@ -47,7 +47,7 @@ export function EventCard({
               src={imageUrl}
               width={227}
               height={112}
-              alt="event image"
+              alt={title}
               className="object-cover w-full h-auto rounded-lg"
             />
             
@@ -96,7 +96,7 @@ export function EventCard({
               <div className="flex items-center gap-1.25 mt-1">
                 <Image
                   src={locationImageSrc}
-                  alt="location"
+                  alt={location.toLowerCase().includes("discord") ? "Discord" : "Location"}
                   width={16}
                   height={16}
                   className="object-contain flex-shrink-0"

--- a/apps/web/components/events/filter-sidebar.tsx
+++ b/apps/web/components/events/filter-sidebar.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
 
 // ─── Category options ────────────────────────────────────────────────────────
 const CATEGORIES = [
@@ -383,21 +384,13 @@ export function FilterSidebar({
 
             {/* ── Footer CTA ── */}
             <div className="px-6 py-5 border-t border-black/10 shrink-0">
-              <button
-                type="button"
-                onClick={handleApply}
-                className="
-                  w-full h-12 rounded-[13px] bg-black text-white font-semibold text-[15px]
-                  shadow-[-4px_4px_0px_0px_rgba(0,0,0,0.25)]
-                  border border-black
-                  hover:-translate-x-[2px] hover:translate-y-[2px]
-                  hover:shadow-[-2px_2px_0px_0px_rgba(0,0,0,0.25)]
-                  active:-translate-x-[4px] active:translate-y-[4px] active:shadow-none
-                  transition-all
-                "
-              >
-                Apply Filters
-              </button>
+            <Button
+              variant="dark"
+              onClick={handleApply}
+              className="w-full h-12 rounded-[13px] text-[15px]"
+            >
+              Apply Filters
+            </Button>
             </div>
           </motion.aside>
         </>

--- a/apps/web/components/events/organizer-component.tsx
+++ b/apps/web/components/events/organizer-component.tsx
@@ -6,6 +6,7 @@ import right from "../../public/icons/arrow-right.svg";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { fetchOrganizers, type DiscoverOrganizer } from "@/utils/api";
+import { Button } from "@/components/ui/button";
 
 const fallbackCardsData: DiscoverOrganizer[] = [
   {
@@ -38,14 +39,17 @@ const fallbackCardsData: DiscoverOrganizer[] = [
   },
 ];
 
-const Button: React.FC = () => {
+function SubscribeButton() {
   return (
-    <button className="bg-yellow-300 pt-2 pl-3 pr-3 pb-2 flex gap-3 border border-yellow-300 rounded-lg items-center absolute top-40 right-5 hover:cursor-pointer">
+    <Button
+      variant="primary"
+      className="absolute top-40 right-5 rounded-lg px-3 py-2"
+    >
       <Image src={group} alt="User Group Icon" className="w-8 h-8" />
-      <span className="text-black font-semibold">Subscribe</span>
-    </button>
+      Subscribe
+    </Button>
   );
-};
+}
 
 type OrganizerComponentProps = {
   onError: (message: string) => void;
@@ -138,7 +142,7 @@ export function OrganizerComponent({ onError }: OrganizerComponentProps) {
               <p className="text-xs absolute left-25 top-20 w-65">
                 {card.description}
               </p>
-              <Button />
+              <SubscribeButton />
             </div>
           </div>
           ))}

--- a/apps/web/components/events/popular-events-section.tsx
+++ b/apps/web/components/events/popular-events-section.tsx
@@ -206,9 +206,7 @@ export function PopularEventsSection({ onError }: PopularEventsSectionProps) {
 
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.97 }}>
               <Button
-                backgroundColor="bg-black"
-                shadowColor="transparent"
-                textColor="text-white"
+                variant="dark"
                 className="border-none sm:rounded-4xl! max-sm:p-0 h-9.75 sm:w-34 w-9.75"
                 onClick={() => setIsFilterOpen(true)}
                 aria-haspopup="dialog"
@@ -290,8 +288,7 @@ export function PopularEventsSection({ onError }: PopularEventsSectionProps) {
           whileTap={{ scale: 0.97 }}
         >
           <Button
-            backgroundColor="bg-accent"
-            shadowColor="transparent"
+            variant="primary"
             className="border-none rounded-[13px]! h-11"
           >
             View all Events

--- a/apps/web/components/events/registration-box.tsx
+++ b/apps/web/components/events/registration-box.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { TicketModal } from "./TicketModal";
+import { Button } from "@/components/ui/button";
 
 interface RegistrationBoxProps {
   event: {
@@ -76,10 +77,10 @@ export function RegistrationBox({ event, host }: RegistrationBoxProps) {
         </p>
 
         <div className="flex items-center justify-between z-10 gap-4 flex-wrap">
-          <button
-            type="button"
+          <Button
+            variant="primary"
             onClick={handleRegisterClick}
-            className="bg-accent text-black font-bold text-[18px] sm:text-[22px] h-14 sm:h-16 px-8 sm:px-10 rounded-full border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:translate-x-[2px] active:translate-y-[2px] active:shadow-none flex items-center justify-center gap-4 group transition-all"
+            className="h-14 sm:h-16 px-8 sm:px-10 rounded-full text-[18px] sm:text-[22px]"
           >
             {!isFree && (
               <Image
@@ -89,11 +90,7 @@ export function RegistrationBox({ event, host }: RegistrationBoxProps) {
                 alt="dollar"
               />
             )}
-
-            {isFree
-              ? "Register"
-              : `$${(priceValue * quantity).toFixed(2)}`}
-
+            {isFree ? "Register" : `$${(priceValue * quantity).toFixed(2)}`}
             <Image
               src="/icons/arrow-up-right-01.svg"
               width={24}
@@ -101,7 +98,7 @@ export function RegistrationBox({ event, host }: RegistrationBoxProps) {
               alt="arrow-up-right"
               className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
             />
-          </button>
+          </Button>
           <div className="flex items-center gap-3">
             <div className="relative w-11 h-11 sm:w-14 sm:h-14 rounded-full border-2 border-black overflow-hidden bg-white shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
               <Image

--- a/apps/web/components/layout/navbar.tsx
+++ b/apps/web/components/layout/navbar.tsx
@@ -237,7 +237,7 @@ export function Navbar() {
                       <span>Create Your Event</span>
                       <Image
                         src="/icons/arrow-up-right-01.svg"
-                        alt="Arrow"
+                        alt="Create event"
                         width={24}
                         height={24}
                         className="invert group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"

--- a/apps/web/components/layout/navbar.tsx
+++ b/apps/web/components/layout/navbar.tsx
@@ -230,12 +230,7 @@ export function Navbar() {
 
                 <motion.div custom={4} variants={linkVariants} className="mt-4">
                   <Link href={isLoggedIn ? "/create-event" : "/auth"} onClick={() => setIsOpen(false)}>
-                    <Button
-                      className="w-full justify-center"
-                      backgroundColor="bg-black"
-                      textColor="text-white"
-                      shadowColor="rgba(0,0,0,0.5)"
-                    >
+                    <Button variant="dark" className="w-full justify-center">
                       <span>Create Your Event</span>
                       <Image
                         src="/icons/arrow-up-right-01.svg"

--- a/apps/web/components/layout/navbar/user-nav.tsx
+++ b/apps/web/components/layout/navbar/user-nav.tsx
@@ -58,7 +58,7 @@ export function UserNav({ pathname }: { pathname: string }) {
               <span>Create Your Event</span>
               <Image
                 src="/icons/arrow-up-right-01.svg"
-                alt="Arrow"
+                alt="Create event"
                 width={24}
                 height={24}
                 className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
@@ -79,7 +79,7 @@ export function UserNav({ pathname }: { pathname: string }) {
             <div className="size-[9px] bg-red-500 rounded-full absolute top-[4px] right-[2px]" />
             <Image
               src="/icons/notification.svg"
-              alt="Arrow"
+              alt="Notifications"
               width={24}
               height={24}
               className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
@@ -96,7 +96,7 @@ export function UserNav({ pathname }: { pathname: string }) {
             <div className=" size-[49px] rounded-full">
               <Image
                 src="/images/pfp.png"
-                alt="Arrow"
+                alt="Profile"
                 width={49}
                 height={49}
                 className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,54 +1,70 @@
 import React from "react";
 
 /**
- * Props for the Button component
- * @interface ButtonProps
+ * Variant → bg / text / shadow presets.
+ * - primary  : yellow fill, black text  (main CTA)
+ * - secondary: white fill, black text   (default)
+ * - dark     : black fill, white text
+ * - ghost    : transparent, black text, no shadow
  */
+const VARIANTS = {
+  primary: {
+    bg: "bg-[#FDDA23]",
+    text: "text-black",
+    shadow: "rgba(0,0,0,1)",
+  },
+  secondary: {
+    bg: "bg-white",
+    text: "text-black",
+    shadow: "rgba(0,0,0,1)",
+  },
+  dark: {
+    bg: "bg-black",
+    text: "text-white",
+    shadow: "rgba(0,0,0,0.4)",
+  },
+  ghost: {
+    bg: "bg-transparent",
+    text: "text-black",
+    shadow: "transparent",
+  },
+} as const;
+
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Visual style variant of the button */
-  variant?: "primary" | "secondary";
-  /** Shadow color for the button's drop shadow effect */
+  variant?: keyof typeof VARIANTS;
+  /** Override shadow color (ignored when variant is set unless also passed) */
   shadowColor?: string;
-  /** Text color class or custom color */
+  /** Override text color class */
   textColor?: string;
-  /** Background color class or custom color */
+  /** Override background color class */
   backgroundColor?: string;
-  /** Content to render inside the button */
   children: React.ReactNode;
 }
 
-/**
- * Custom Button component with distinctive shadow and hover effects
- *
- * Features:
- * - Custom shadow effect that moves on hover
- * - Active state with deeper shadow translation
- * - Support for both Tailwind and custom colors
- * - Fully accessible with all standard button props
- *
- * @param props - ButtonProps containing button configuration
- * @returns React component that renders a styled button
- */
 export function Button({
   className = "",
-  shadowColor = "rgba(0,0,0,1)",
-  textColor = "text-black",
-  backgroundColor = "bg-white",
+  variant,
+  shadowColor,
+  textColor,
+  backgroundColor,
   children,
   style,
   ...props
 }: ButtonProps) {
-  const isTailwindBg = backgroundColor.startsWith("bg-");
-  const isTailwindText = textColor.startsWith("text-");
+  const preset = variant ? VARIANTS[variant] : null;
 
-  const bgClass = isTailwindBg ? backgroundColor : "";
-  const textClass = isTailwindText ? textColor : "";
+  const bg = backgroundColor ?? preset?.bg ?? VARIANTS.secondary.bg;
+  const text = textColor ?? preset?.text ?? VARIANTS.secondary.text;
+  const shadow = shadowColor ?? preset?.shadow ?? VARIANTS.secondary.shadow;
+
+  const isTailwindBg = bg.startsWith("bg-");
+  const isTailwindText = text.startsWith("text-");
 
   const customStyle: React.CSSProperties = {
     ...style,
-    backgroundColor: !isTailwindBg ? backgroundColor : undefined,
-    color: !isTailwindText ? textColor : undefined,
-    boxShadow: `-4px 4px 0px 0px ${shadowColor}`,
+    backgroundColor: !isTailwindBg ? bg : undefined,
+    color: !isTailwindText ? text : undefined,
+    boxShadow: `-4px 4px 0px 0px ${shadow}`,
   };
 
   return (
@@ -59,7 +75,7 @@ export function Button({
         hover:-translate-x-[2px] hover:translate-y-[2px]
         hover:shadow-[-2px_2px_0px_0px_rgba(0,0,0,1)]
         active:-translate-x-[4px] active:translate-y-[4px] active:shadow-none
-        ${bgClass} ${textClass} ${className}
+        ${isTailwindBg ? bg : ""} ${isTailwindText ? text : ""} ${className}
       `}
       style={customStyle}
       {...props}

--- a/apps/web/next-sitemap.config.js
+++ b/apps/web/next-sitemap.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || "https://agora-web-eta.vercel.app",
+  generateRobotsTxt: true,
+  additionalPaths: async () => [
+    { loc: "/", changefreq: "daily", priority: 1.0 },
+    { loc: "/discover", changefreq: "daily", priority: 0.9 },
+    { loc: "/pricing", changefreq: "monthly", priority: 0.7 },
+    { loc: "/faqs", changefreq: "monthly", priority: 0.6 },
+  ],
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-   "build": "prisma generate && next build",
+    "build": "prisma generate && next build",
+    "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run"
@@ -35,6 +36,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.3",
+    "next-sitemap": "4.2.3",
     "prisma": "^7.8.0",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
     devDependencies:
       '@prisma/client':
         specifier: ^7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       autoprefixer:
         specifier: ^10.4.23
         version: 10.4.23(postcss@8.5.6)
@@ -50,7 +50,7 @@ importers:
     dependencies:
       '@prisma/client':
         specifier: ^7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       '@stellar/stellar-sdk':
         specifier: ^13.3.0
         version: 13.3.0
@@ -118,6 +118,9 @@ importers:
       eslint-config-next:
         specifier: 16.1.3
         version: 16.1.3(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      next-sitemap:
+        specifier: 4.2.3
+        version: 4.2.3(next@16.1.3(@babel/core@7.28.6)(@opentelemetry/api@1.4.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -207,6 +210,9 @@ packages:
   '@babel/types@7.28.6':
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
+
+  '@corex/deepmerge@4.0.43':
+    resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -605,6 +611,9 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@next/env@13.5.11':
+    resolution: {integrity: sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==}
 
   '@next/env@16.1.3':
     resolution: {integrity: sha512-BLP14oBOvZWXgfdJf9ao+VD8O30uE+x7PaV++QtACLX329WcRSJRO5YJ+Bcvu0Q+c/lei41TjSiFf6pXqnpbQA==}
@@ -2777,6 +2786,13 @@ packages:
     resolution: {integrity: sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==}
     engines: {node: '>=10'}
 
+  next-sitemap@4.2.3:
+    resolution: {integrity: sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==}
+    engines: {node: '>=14.18'}
+    hasBin: true
+    peerDependencies:
+      next: '*'
+
   next@16.1.3:
     resolution: {integrity: sha512-gthG3TRD+E3/mA0uDQb9lqBmx1zVosq5kIwxNN6+MRNd085GzD+9VXMPUs+GGZCbZ+GDZdODUq4Pm7CTXK6ipw==}
     engines: {node: '>=20.9.0'}
@@ -3867,6 +3883,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@corex/deepmerge@4.0.43': {}
+
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
       '@electric-sql/pglite': 0.4.1
@@ -4157,6 +4175,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@next/env@13.5.11': {}
+
   '@next/env@16.1.3': {}
 
   '@next/eslint-plugin-next@16.1.3':
@@ -4210,7 +4230,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.8.0': {}
 
-  '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.8.0
     optionalDependencies:
@@ -5548,8 +5568,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.3
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -5571,7 +5591,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5582,22 +5602,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5608,7 +5628,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -6504,6 +6524,14 @@ snapshots:
   natural-compare@1.4.0: {}
 
   new-github-issue-url@0.2.1: {}
+
+  next-sitemap@4.2.3(next@16.1.3(@babel/core@7.28.6)(@opentelemetry/api@1.4.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+    dependencies:
+      '@corex/deepmerge': 4.0.43
+      '@next/env': 13.5.11
+      fast-glob: 3.3.1
+      minimist: 1.2.8
+      next: 16.1.3(@babel/core@7.28.6)(@opentelemetry/api@1.4.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   next@16.1.3(@babel/core@7.28.6)(@opentelemetry/api@1.4.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
Add sitemap generation for SEO

Generates a sitemap at build time so search engines can discover all pages — including 
every event detail page pulled live from the database.

- Installs next-sitemap
- Adds a postbuild script that outputs public/sitemap.xml and robots.txt after each build
- Static pages (/, /discover, /pricing, /faqs) are always included
- Event pages (/events/[id]) are added dynamically by querying the database at build time

closes #704 
closes #702 
closes #714 
closes #707 