### PR TITLE
refactor: extract BaseNav component from GuestNav and UserNav

### DIFF
--- a/apps/web/components/layout/navbar/base-nav.tsx
+++ b/apps/web/components/layout/navbar/base-nav.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { NavLink } from "./nav-link";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface NavItem {
+  href: string;
+  icon: string;
+  text: string;
+  /** Determines active highlight; evaluated against the current pathname */
+  isActive: (pathname: string) => boolean;
+}
+
+export interface BaseNavProps {
+  pathname: string;
+  isAuthenticated: boolean;
+  navItems: NavItem[];
+  /** Slot rendered to the right of the nav links (e.g. CTA button) */
+  ctaSlot: React.ReactNode;
+  /** Optional slot rendered on the far right (e.g. notifications + avatar) */
+  endSlot?: React.ReactNode;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * BaseNav — shared desktop navigation shell.
+ *
+ * Renders the Agora logo, a list of NavLink items, and two optional slots
+ * (ctaSlot for the primary CTA button, endSlot for auth controls).
+ * GuestNav and UserNav are thin wrappers that pre-fill these props.
+ */
+export function BaseNav({
+  pathname,
+  isAuthenticated,
+  navItems,
+  ctaSlot,
+  endSlot,
+}: BaseNavProps) {
+  return (
+    <div
+      className={`flex items-center w-full ${
+        isAuthenticated ? "justify-between" : "gap-[231px]"
+      }`}
+    >
+      {/* ── Logo ── */}
+      <div
+        className={
+          isAuthenticated ? "flex items-center gap-8 lg:gap-[137px]" : undefined
+        }
+      >
+        <Link href="/" className="flex items-center z-50">
+          <Image
+            src="/logo/agora logo.svg"
+            alt="Agora Logo"
+            width={100}
+            height={30}
+            className="h-auto w-auto"
+          />
+        </Link>
+
+        {/* ── Nav links + CTA ── */}
+        <div
+          className={`hidden lg:flex items-center ${
+            isAuthenticated ? "gap-[53px]" : "flex-1 gap-[170px]"
+          }`}
+        >
+          <div
+            className={`flex items-center ${
+              isAuthenticated ? "gap-6" : "gap-[25px]"
+            }`}
+          >
+            {navItems.map((item) => (
+              <NavLink
+                key={item.href + item.text}
+                href={item.href}
+                icon={item.icon}
+                text={item.text}
+                isActive={item.isActive(pathname)}
+              />
+            ))}
+          </div>
+
+          {ctaSlot}
+        </div>
+      </div>
+
+      {/* ── End slot (notifications, avatar, etc.) ── */}
+      {endSlot && (
+        <div className="hidden md:flex items-center gap-4 lg:gap-[29px]">
+          {endSlot}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/layout/navbar/guest-nav.tsx
+++ b/apps/web/components/layout/navbar/guest-nav.tsx
@@ -3,75 +3,70 @@
 import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
-import { NavLink } from "./nav-link";
+import { BaseNav, type NavItem } from "./base-nav";
+
+const GUEST_NAV_ITEMS: NavItem[] = [
+  {
+    href: "/discover",
+    icon: "/icons/earth.svg",
+    text: "Discover Events",
+    isActive: (p) => p === "/discover" || p.startsWith("/events"),
+  },
+  {
+    href: "/pricing",
+    icon: "/icons/dollar-circle.svg",
+    text: "Pricing",
+    isActive: (p) => p === "/pricing",
+  },
+  {
+    href: "/stellar",
+    icon: "/icons/stellar-xlm-logo 1.svg",
+    text: "Stellar Ecosystem",
+    isActive: (p) => p === "/stellar",
+  },
+  {
+    href: "/faqs",
+    icon: "/icons/help-circle.svg",
+    text: "FAQs",
+    isActive: (p) => p === "/faqs",
+  },
+];
+
+const guestCta = (
+  <Link href="/auth" title="Sign in to create an event">
+    <Button
+      backgroundColor="bg-white"
+      textColor="text-black"
+      shadowColor="rgba(0,0,0,1)"
+      aria-label="Create event - sign in required"
+    >
+      <Image
+        src="/icons/lock.svg"
+        alt=""
+        width={18}
+        height={18}
+        aria-hidden="true"
+      />
+      <span>Create Your Event</span>
+      <Image
+        src="/icons/arrow-up-right-01.svg"
+        alt=""
+        width={24}
+        height={24}
+        aria-hidden="true"
+        className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+      />
+    </Button>
+  </Link>
+);
 
 export function GuestNav({ pathname }: { pathname: string }) {
   return (
-    <div className="flex items-center gap-[231px] w-full">
-      <Link href="/" className="flex items-center z-50">
-        <Image
-          src="/logo/agora logo.svg"
-          alt="Agora Logo"
-          width={100}
-          height={30}
-          className="h-auto w-auto"
-        />
-      </Link>
-
-      <div className="hidden lg:flex items-center flex-1 gap-[170px]">
-        <div className="flex items-center gap-[25px]">
-          <NavLink
-            href="/discover"
-            icon="/icons/earth.svg"
-            text="Discover Events"
-            isActive={pathname === "/discover" || pathname.startsWith("/events")}
-          />
-          <NavLink
-            href="/pricing"
-            icon="/icons/dollar-circle.svg"
-            text="Pricing"
-            isActive={pathname === "/pricing"}
-          />
-          <NavLink
-            href="/stellar"
-            icon="/icons/stellar-xlm-logo 1.svg"
-            text="Stellar Ecosystem"
-            isActive={pathname === "/stellar"}
-          />
-          <NavLink
-            href="/faqs"
-            icon="/icons/help-circle.svg"
-            text="FAQs"
-            isActive={pathname === "/faqs"}
-          />
-        </div>
-
-        <Link href="/auth" title="Sign in to create an event">
-          <Button
-            backgroundColor="bg-white"
-            textColor="text-black"
-            shadowColor="rgba(0,0,0,1)"
-            aria-label="Create event - sign in required"
-          >
-            <Image
-              src="/icons/lock.svg"
-              alt=""
-              width={18}
-              height={18}
-              aria-hidden="true"
-            />
-            <span>Create Your Event</span>
-            <Image
-              src="/icons/arrow-up-right-01.svg"
-              alt=""
-              width={24}
-              height={24}
-              aria-hidden="true"
-              className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
-            />
-          </Button>
-        </Link>
-      </div>
-    </div>
+    <BaseNav
+      pathname={pathname}
+      isAuthenticated={false}
+      navItems={GUEST_NAV_ITEMS}
+      ctaSlot={guestCta}
+    />
   );
 }

--- a/apps/web/components/layout/navbar/user-nav.tsx
+++ b/apps/web/components/layout/navbar/user-nav.tsx
@@ -3,108 +3,102 @@
 import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
-import { NavLink } from "./nav-link";
+import { BaseNav, type NavItem } from "./base-nav";
+
+const USER_NAV_ITEMS: NavItem[] = [
+  {
+    href: "/",
+    icon: "/icons/home.svg",
+    text: "Home",
+    isActive: (p) => p === "/",
+  },
+  {
+    href: "/discover",
+    icon: "/icons/earth-yellow.svg",
+    text: "Discover Events",
+    isActive: (p) => p === "/discover" || p.startsWith("/events"),
+  },
+  {
+    href: "/organizers",
+    icon: "/icons/user-group.svg",
+    text: "Organizers",
+    isActive: (p) => p === "/organizers",
+  },
+  {
+    href: "/stellar",
+    icon: "/icons/stellar-xlm-logo 1.svg",
+    text: "Stellar Ecosystem",
+    isActive: (p) => p === "/stellar",
+  },
+];
+
+const userCta = (
+  <Link href="/create-event">
+    <Button
+      backgroundColor="bg-white"
+      textColor="text-black"
+      shadowColor="rgba(0,0,0,1)"
+    >
+      <span>Create Your Event</span>
+      <Image
+        src="/icons/arrow-up-right-01.svg"
+        alt="Arrow"
+        width={24}
+        height={24}
+        className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+      />
+    </Button>
+  </Link>
+);
+
+const userEndSlot = (
+  <>
+    <Link href="#">
+      <Button
+        backgroundColor="bg-white"
+        className="relative w-[55.22px] h-[53px] px-[10px] py-[10px]"
+        textColor="text-black"
+        shadowColor="rgba(0,0,0,1)"
+      >
+        <div className="size-[9px] bg-red-500 rounded-full absolute top-[4px] right-[2px]" />
+        <Image
+          src="/icons/notification.svg"
+          alt="Notifications"
+          width={24}
+          height={24}
+          className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+        />
+      </Button>
+    </Link>
+    <Link href="/profile">
+      <Button
+        backgroundColor="bg-white"
+        className="relative w-[55.22px] h-[53px] px-0! py-0"
+        textColor="text-black"
+        shadowColor="rgba(0,0,0,1)"
+      >
+        <div className="size-[49px] rounded-full">
+          <Image
+            src="/images/pfp.png"
+            alt="Profile"
+            width={49}
+            height={49}
+            className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+          />
+        </div>
+      </Button>
+    </Link>
+  </>
+);
 
 export function UserNav({ pathname }: { pathname: string }) {
   return (
-    <div className="flex items-center justify-between w-full">
-      <div className="flex items-center gap-8 lg:gap-[137px]">
-        <Link href="/" className="flex items-center z-50">
-          <Image
-            src="/logo/agora logo.svg"
-            alt="Agora Logo"
-            width={100}
-            height={30}
-            className="h-auto w-auto"
-          />
-        </Link>
-
-        <div className="hidden lg:flex items-center gap-[53px]">
-          <div className="flex items-center gap-6">
-            <NavLink
-              href="/"
-              icon="/icons/home.svg"
-              text="Home"
-              isActive={pathname === "/"}
-            />
-            <NavLink
-              href="/discover"
-              icon="/icons/earth-yellow.svg"
-              text="Discover Events"
-              isActive={
-                pathname === "/discover" || pathname.startsWith("/events")
-              }
-            />
-            <NavLink
-              href="/organizers"
-              icon="/icons/user-group.svg"
-              text="Organizers"
-              isActive={pathname === "/organizers"}
-            />
-            <NavLink
-              href="/stellar"
-              icon="/icons/stellar-xlm-logo 1.svg"
-              text="Stellar Ecosystem"
-              isActive={pathname === "/stellar"}
-            />
-          </div>
-
-          <Link href="/create-event">
-            <Button
-              backgroundColor="bg-white"
-              textColor="text-black"
-              shadowColor="rgba(0,0,0,1)"
-            >
-              <span>Create Your Event</span>
-              <Image
-                src="/icons/arrow-up-right-01.svg"
-                alt="Arrow"
-                width={24}
-                height={24}
-                className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
-              />
-            </Button>
-          </Link>
-        </div>
-      </div>
-
-      <div className="hidden md:flex items-center gap-4 lg:gap-[29px]">
-        <Link href="#">
-          <Button
-            backgroundColor="bg-white"
-            className="relative w-[55.22px] h-[53px] px-[10px] py-[10px]"
-            textColor="text-black"
-            shadowColor="rgba(0,0,0,1)"
-          >
-            <div className="size-[9px] bg-red-500 rounded-full absolute top-[4px] right-[2px]" />
-            <Image
-              src="/icons/notification.svg"
-              alt="Arrow"
-              width={24}
-              height={24}
-              className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
-            />
-          </Button>
-        </Link>
-        <Link href="/profile">
-          <Button
-            backgroundColor="bg-white"
-            className="relative w-[55.22px] h-[53px] px-0! py-0"
-            textColor="text-black"
-            shadowColor="rgba(0,0,0,1)"
-          >
-            <div className=" size-[49px] rounded-full">
-              <Image
-                src="/images/pfp.png"
-                alt="Arrow"
-                width={49}
-                height={49}
-                className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
-              />
-            </div>
-          </Button>
-        </Link>
-      </div>
-    </div>
+    <BaseNav
+      pathname={pathname}
+      isAuthenticated={true}
+      navItems={USER_NAV_ITEMS}
+      ctaSlot={userCta}
+      endSlot={userEndSlot}
+    />
   );
 }


### PR DESCRIPTION
Refactor: Combine GuestNav and UserNav into BaseNav
Eliminates duplicated markup between GuestNav and UserNav by extracting a shared BaseNav component.
Changes

Created base-nav.tsx with typed BaseNavProps and NavItem interfaces
Refactored guest-nav.tsx and user-nav.tsx into thin wrappers that pass nav items and slots as props
No changes required to navbar.tsx

Screenshots
Authenticated state:

<img width="1350" height="605" alt="screenshot_agora_autenticated_state" src="https://github.com/user-attachments/assets/4619d516-17f5-4926-bc89-5503c32e670f" />

Guest state:

<img width="1337" height="610" alt="Screenshot_agro_2" src="https://github.com/user-attachments/assets/d181d552-f14d-4c6b-9e7d-3a17122d26c1" />

#Closes #701