### PR TITLE
feat: add GET /api/v1/events/:id/is-sold-out endpoint

### DIFF
--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -725,7 +725,11 @@ mod tests {
 
     #[test]
     fn test_sold_out_status_when_minted_equals_total() {
-        let status = SoldOutStatus { is_sold_out: 500 >= 500, minted: 500, total: 500 };
+        let status = SoldOutStatus {
+            is_sold_out: 500 >= 500,
+            minted: 500,
+            total: 500,
+        };
         assert!(status.is_sold_out);
         assert_eq!(status.minted, 500);
         assert_eq!(status.total, 500);
@@ -733,14 +737,22 @@ mod tests {
 
     #[test]
     fn test_sold_out_status_when_not_sold_out() {
-        let status = SoldOutStatus { is_sold_out: 100 >= 500, minted: 100, total: 500 };
+        let status = SoldOutStatus {
+            is_sold_out: 100 >= 500,
+            minted: 100,
+            total: 500,
+        };
         assert!(!status.is_sold_out);
     }
 
     #[test]
     fn test_sold_out_status_when_minted_exceeds_total() {
         // Edge case: minted > total (e.g. after a refund reversal)
-        let status = SoldOutStatus { is_sold_out: 501 >= 500, minted: 501, total: 500 };
+        let status = SoldOutStatus {
+            is_sold_out: 501 >= 500,
+            minted: 501,
+            total: 500,
+        };
         assert!(status.is_sold_out);
     }
 }
@@ -774,7 +786,9 @@ pub async fn get_sold_out_status(
     let cache_key = format!("event:sold_out:{}", event_id);
 
     match state.redis.get::<SoldOutStatus>(&cache_key).await {
-        Ok(Some(status)) => return success(status, "Sold-out status retrieved (cached)").into_response(),
+        Ok(Some(status)) => {
+            return success(status, "Sold-out status retrieved (cached)").into_response()
+        }
         Ok(None) => {}
         Err(e) => tracing::warn!("Redis error for sold-out cache: {:?}", e),
     }
@@ -804,8 +818,16 @@ pub async fn get_sold_out_status(
         total,
     };
 
-    if let Err(e) = state.redis.set(&cache_key, &status, SOLD_OUT_CACHE_TTL).await {
-        tracing::warn!("Failed to cache sold-out status for event {}: {:?}", event_id, e);
+    if let Err(e) = state
+        .redis
+        .set(&cache_key, &status, SOLD_OUT_CACHE_TTL)
+        .await
+    {
+        tracing::warn!(
+            "Failed to cache sold-out status for event {}: {:?}",
+            event_id,
+            e
+        );
     }
 
     success(status, "Sold-out status retrieved").into_response()
@@ -834,7 +856,11 @@ pub async fn get_checkin_stats(
             let checked_in = r.checked_in.unwrap_or(0);
             let total_sold = r.total_sold.unwrap_or(0);
             success(
-                CheckInStats { checked_in, total_sold, remaining: total_sold - checked_in },
+                CheckInStats {
+                    checked_in,
+                    total_sold,
+                    remaining: total_sold - checked_in,
+                },
                 "Check-in stats retrieved",
             )
             .into_response()

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 //! # Event Handlers
 //!
 //! This module provides HTTP handlers for event-related operations including

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -723,6 +723,27 @@ mod tests {
         assert!(filters.organizer_id.is_some());
         assert_eq!(filters.location.unwrap(), "New York");
     }
+
+    #[test]
+    fn test_sold_out_status_when_minted_equals_total() {
+        let status = SoldOutStatus { is_sold_out: 500 >= 500, minted: 500, total: 500 };
+        assert!(status.is_sold_out);
+        assert_eq!(status.minted, 500);
+        assert_eq!(status.total, 500);
+    }
+
+    #[test]
+    fn test_sold_out_status_when_not_sold_out() {
+        let status = SoldOutStatus { is_sold_out: 100 >= 500, minted: 100, total: 500 };
+        assert!(!status.is_sold_out);
+    }
+
+    #[test]
+    fn test_sold_out_status_when_minted_exceeds_total() {
+        // Edge case: minted > total (e.g. after a refund reversal)
+        let status = SoldOutStatus { is_sold_out: 501 >= 500, minted: 501, total: 500 };
+        assert!(status.is_sold_out);
+    }
 }
 
 #[derive(Serialize)]
@@ -730,6 +751,65 @@ pub struct CheckInStats {
     pub checked_in: i64,
     pub total_sold: i64,
     pub remaining: i64,
+}
+
+/// Cache TTL for sold-out status (60 seconds)
+const SOLD_OUT_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Response body for the is-sold-out endpoint
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SoldOutStatus {
+    pub is_sold_out: bool,
+    pub minted: i32,
+    pub total: i32,
+}
+
+/// GET /api/v1/events/:id/is-sold-out
+///
+/// Returns whether an event is sold out by comparing `minted_tickets` to
+/// `total_tickets`. Result is cached in Redis for 60 seconds.
+pub async fn get_sold_out_status(
+    State(mut state): State<EventState>,
+    Path(event_id): Path<Uuid>,
+) -> Response {
+    let cache_key = format!("event:sold_out:{}", event_id);
+
+    match state.redis.get::<SoldOutStatus>(&cache_key).await {
+        Ok(Some(status)) => return success(status, "Sold-out status retrieved (cached)").into_response(),
+        Ok(None) => {}
+        Err(e) => tracing::warn!("Redis error for sold-out cache: {:?}", e),
+    }
+
+    let row = match sqlx::query_as::<_, (i32, i32)>(
+        "SELECT minted_tickets, total_tickets FROM events WHERE id = $1",
+    )
+    .bind(event_id)
+    .fetch_optional(&state.pool)
+    .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return AppError::NotFound(format!("Event with id '{}' not found", event_id))
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch event sold-out status: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let (minted, total) = row;
+    let status = SoldOutStatus {
+        is_sold_out: minted >= total,
+        minted,
+        total,
+    };
+
+    if let Err(e) = state.redis.set(&cache_key, &status, SOLD_OUT_CACHE_TTL).await {
+        tracing::warn!("Failed to cache sold-out status for event {}: {:?}", event_id, e);
+    }
+
+    success(status, "Sold-out status retrieved").into_response()
 }
 
 /// GET /api/v1/events/:id/check-in-stats

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -2,7 +2,6 @@ pub mod auth;
 pub mod categories;
 pub mod events;
 pub mod health;
-<<<<<<< HEAD
 pub mod leaderboard;
 pub mod monitoring;
 pub mod profile;

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -35,7 +35,6 @@ use crate::config::{
     set_request_id_layer, Config,
 };
 use crate::handlers::{
-<<<<<<< HEAD
     auth::{logout, request_nonce, verify_signature},
     categories::{get_category, list_categories},
     events::{

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -39,8 +39,8 @@ use crate::handlers::{
     auth::{logout, request_nonce, verify_signature},
     categories::{get_category, list_categories},
     events::{
-        get_checkin_stats, get_event, list_events, search_events, submit_event_rating,
-        toggle_event_flag, EventState,
+        get_checkin_stats, get_event, get_sold_out_status, list_events, search_events,
+        submit_event_rating, toggle_event_flag, EventState,
     },
     example_empty_success, example_not_found, example_validation_error,
     health::{health_check, health_check_blockchain, health_check_db, health_check_ready},
@@ -136,6 +136,7 @@ pub async fn create_routes(pool: PgPool, _config: Config, redis: RedisCache) -> 
         .route("/:id", get(get_event))
         .route("/:id/rate", post(submit_event_rating))
         .route("/:id/check-in-stats", get(get_checkin_stats))
+        .route("/:id/is-sold-out", get(get_sold_out_status))
         .with_state(event_state);
 
     // Category routes


### PR DESCRIPTION
## Summary

Adds a dedicated lightweight endpoint to check whether an event is sold out.

## Changes

- **Handler** (): New `get_sold_out_status` handler that queries `minted_tickets` and `total_tickets` from the `events` table, computes `is_sold_out = minted >= total`, and caches the result in Redis for 60 seconds.
- **Route** (`server/src/routes/mod.rs`): Registered `GET /:id/is-sold-out` in the event routes.
- **Tests**: Three unit tests covering sold-out (equal), not sold-out, and over-minted edge cases.

## Response Shape

```json
{ "success": true, "data": { "is_sold_out": true, "minted": 500, "total": 500 } }
```

## Acceptance Criteria

- [x] Returns `is_sold_out: true` when `minted_tickets >= total_tickets`
- [x] Returns 404 for a non-existent event
- [x] Response is cached for 60 seconds
- [x] All existing tests pass

Closes #624