### PR TITLE
feat: add the pro subscription helpers and tests

### DIFF
--- a/contract/contracts/pro_subscription/src/contract.rs
+++ b/contract/contracts/pro_subscription/src/contract.rs
@@ -248,6 +248,11 @@ impl ProSubscriptionContract {
         get_subscription(&env, &organizer)
     }
 
+    /// Get subscription expiry timestamp for an organizer
+    pub fn get_subscription_expiry(env: Env, organizer: Address) -> Option<u64> {
+        get_subscription(&env, &organizer).map(|s| s.expires_at)
+    }
+
     /// Get all active pro members
     pub fn get_pro_members(env: Env) -> soroban_sdk::Vec<Address> {
         get_pro_members_list(&env)
@@ -292,6 +297,11 @@ impl ProSubscriptionContract {
         get_admin(&env)
     }
 
+    /// Check whether the contract has been initialized
+    pub fn is_initialized(env: Env) -> bool {
+        is_initialized(&env)
+    }
+
     /// Update the admin address (admin only)
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), ProSubscriptionError> {
         require_admin(&env)?;
@@ -303,6 +313,17 @@ impl ProSubscriptionContract {
     /// Get the platform wallet address
     pub fn get_platform_wallet(env: Env) -> Option<Address> {
         get_platform_wallet(&env)
+    }
+
+    /// Update the platform wallet address (admin only)
+    pub fn update_platform_wallet(
+        env: Env,
+        new_wallet: Address,
+    ) -> Result<(), ProSubscriptionError> {
+        require_admin(&env)?;
+        validate_address(&env, &new_wallet)?;
+        set_platform_wallet(&env, &new_wallet);
+        Ok(())
     }
 
     /// Get the payment token address

--- a/contract/contracts/pro_subscription/src/lib.rs
+++ b/contract/contracts/pro_subscription/src/lib.rs
@@ -4,6 +4,8 @@ mod contract;
 mod error;
 mod events;
 mod storage;
+#[cfg(test)]
+mod test;
 mod types;
 mod validation;
 

--- a/contract/contracts/pro_subscription/src/test.rs
+++ b/contract/contracts/pro_subscription/src/test.rs
@@ -1,24 +1,101 @@
 use super::contract::ProSubscriptionContract;
 use super::types::Subscription;
 use crate::error::ProSubscriptionError;
-use soroban_sdk::testutils::{Address as _, EnvTestConfig, Events, Ledger, LedgerInfo};
-use soroban_sdk::{token, Address, Env, IntoVal, String};
+use crate::ProSubscriptionContractClient;
+use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo, MockAuth, MockAuthInvoke};
+use soroban_sdk::{token, Address, Env, IntoVal};
 
 const SECONDS_PER_MONTH: u64 = 30 * 24 * 60 * 60;
 
-fn setup() -> (Env, ProSubscriptionContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    ProSubscriptionContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
-    let contract_id = env.register(ProSubscriptionContract, ());
+    let contract_id = env.register_contract(None, ProSubscriptionContract);
     let client = ProSubscriptionContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
     let platform_wallet = Address::generate(&env);
-    let usdc = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let usdc = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
 
     client.initialize(&admin, &platform_wallet, &usdc, &1000i128);
 
     (env, client, admin, platform_wallet, usdc)
+}
+
+fn setup_without_auth_mock() -> (
+    Env,
+    ProSubscriptionContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, ProSubscriptionContract);
+    let client = ProSubscriptionContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    client.initialize(&admin, &platform_wallet, &usdc, &1000i128);
+
+    (env, client, contract_id, admin, platform_wallet, usdc)
+}
+
+#[test]
+fn test_is_initialized_before_and_after_initialize() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, ProSubscriptionContract);
+    let client = ProSubscriptionContractClient::new(&env, &contract_id);
+
+    assert!(!client.is_initialized());
+
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    client.initialize(&admin, &platform_wallet, &usdc, &1000i128);
+
+    assert!(client.is_initialized());
+}
+
+#[test]
+fn test_get_subscription_expiry_none_for_unknown_address() {
+    let (env, client, _admin, _platform_wallet, _usdc) = setup();
+    let organizer = Address::generate(&env);
+
+    assert_eq!(client.get_subscription_expiry(&organizer), None);
+}
+
+#[test]
+fn test_get_subscription_expiry_after_subscribing() {
+    let (env, client, _admin, _platform_wallet, usdc) = setup();
+    let organizer = Address::generate(&env);
+    let monthly_price = 1000i128;
+
+    token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &monthly_price);
+    token::Client::new(&env, &usdc).approve(&organizer, &client.address, &monthly_price, &99999);
+
+    client.subscribe_pro(&organizer, &1u32);
+
+    let subscription = client.get_subscription(&organizer).unwrap();
+    assert_eq!(
+        client.get_subscription_expiry(&organizer),
+        Some(subscription.expires_at)
+    );
 }
 
 #[test]
@@ -44,7 +121,7 @@ fn test_renew_active_subscription() {
     token::Client::new(&env, &usdc).approve(&organizer, &client.address, &monthly_price, &99999);
 
     // Renew before expiry; should extend from current expiry
-    client.renew_subscription(&organizer, &1u32).unwrap();
+    client.renew_subscription(&organizer, &1u32);
 
     let sub_after: Subscription = client.get_subscription(&organizer).unwrap();
     let expected_second_expiry = start + SECONDS_PER_MONTH * 2;
@@ -84,7 +161,7 @@ fn test_renew_expired_subscription() {
     token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &(monthly_price));
     token::Client::new(&env, &usdc).approve(&organizer, &client.address, &monthly_price, &99999);
 
-    client.renew_subscription(&organizer, &1u32).unwrap();
+    client.renew_subscription(&organizer, &1u32);
 
     let renewed: Subscription = client.get_subscription(&organizer).unwrap();
     let expected = env.ledger().timestamp() + SECONDS_PER_MONTH;
@@ -97,8 +174,8 @@ fn test_renew_expired_subscription() {
 fn test_renew_subscription_not_found() {
     let (env, client, _admin, _platform_wallet, _usdc) = setup();
     let never = Address::generate(&env);
-    let res = client.renew_subscription(&never, &1u32);
-    assert!(matches!(res, Err(ProSubscriptionError::SubscriptionNotFound)));
+    let res = client.try_renew_subscription(&never, &1u32);
+    assert_eq!(res, Err(Ok(ProSubscriptionError::SubscriptionNotFound)));
 }
 
 #[test]
@@ -106,8 +183,8 @@ fn test_subscribe_zero_months_error() {
     let (env, client, _admin, _platform_wallet, usdc) = setup();
     let organizer = Address::generate(&env);
     // No need to mint/approve — contract should reject months == 0 early
-    let res = client.subscribe_pro(&organizer, &0u32);
-    assert!(matches!(res, Err(ProSubscriptionError::InvalidPrice)));
+    let res = client.try_subscribe_pro(&organizer, &0u32);
+    assert_eq!(res, Err(Ok(ProSubscriptionError::InvalidPrice)));
     // ensure no subscription was created
     assert!(client.get_subscription(&organizer).is_none());
     let _ = usdc; // keep unused warning away
@@ -125,8 +202,11 @@ fn test_subscribe_already_active_error() {
     // Attempt to subscribe again while active
     token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &monthly_price);
     token::Client::new(&env, &usdc).approve(&organizer, &client.address, &monthly_price, &99999);
-    let res = client.subscribe_pro(&organizer, &1u32);
-    assert!(matches!(res, Err(ProSubscriptionError::SubscriptionAlreadyActive)));
+    let res = client.try_subscribe_pro(&organizer, &1u32);
+    assert_eq!(
+        res,
+        Err(Ok(ProSubscriptionError::SubscriptionAlreadyActive))
+    );
 }
 
 #[test]
@@ -143,7 +223,7 @@ fn test_cancel_subscription_removes_member_and_decrements_total() {
     assert_eq!(client.get_total_pro_subscriptions(), 1u32);
 
     // Cancel subscription (admin auth is mocked)
-    client.cancel_subscription(&organizer).unwrap();
+    client.cancel_subscription(&organizer);
 
     // Subscription should be inactive
     let sub = client.get_subscription(&organizer).unwrap();
@@ -157,13 +237,13 @@ fn test_cancel_subscription_removes_member_and_decrements_total() {
 
 #[test]
 fn test_update_pro_price_success() {
-    let (env, client, _admin, _platform_wallet, _usdc) = setup();
+    let (_env, client, _admin, _platform_wallet, _usdc) = setup();
 
     let initial_price = 1000i128;
     assert_eq!(client.get_pro_monthly_price(), initial_price);
 
     let new_price = 2000i128;
-    client.update_pro_price(&new_price).unwrap();
+    client.update_pro_price(&new_price);
 
     assert_eq!(client.get_pro_monthly_price(), new_price);
 }
@@ -172,35 +252,26 @@ fn test_update_pro_price_success() {
 fn test_update_pro_price_zero() {
     let (_env, client, _admin, _platform_wallet, _usdc) = setup();
 
-    let res = client.update_pro_price(&0i128);
-    assert!(matches!(res, Err(ProSubscriptionError::InvalidPrice)));
+    let res = client.try_update_pro_price(&0i128);
+    assert_eq!(res, Err(Ok(ProSubscriptionError::InvalidPrice)));
 }
 
 #[test]
 fn test_update_pro_price_negative() {
     let (_env, client, _admin, _platform_wallet, _usdc) = setup();
 
-    let res = client.update_pro_price(&-1i128);
-    assert!(matches!(res, Err(ProSubscriptionError::InvalidPrice)));
+    let res = client.try_update_pro_price(&-1i128);
+    assert_eq!(res, Err(Ok(ProSubscriptionError::InvalidPrice)));
 }
 
 #[test]
 fn test_update_pro_price_unauthorized() {
     let (env, client, _admin, _platform_wallet, _usdc) = setup();
 
-    // Create a non-admin address
-    let non_admin = Address::generate(&env);
-
     // Clear all mocked auths to force a real auth check
     env.mock_all_auths();
 
-    // Attempt to call from non-admin should fail
-    let res = client.update_pro_price(&2000i128);
-    // The contract should panic with an auth error when the non-admin calls it
-    // We test this indirectly by checking that with the wrong auth context it fails
-    // In this test, since we're mocking all auths, we need to be careful
-    // Let's just ensure the function requires auth
-    let _ = res;
+    client.update_pro_price(&2000i128);
 }
 
 #[test]
@@ -209,6 +280,45 @@ fn test_get_platform_wallet() {
 
     let result = client.get_platform_wallet();
     assert_eq!(result, Some(platform_wallet));
+}
+
+#[test]
+fn test_update_platform_wallet_success() {
+    let (env, client, _admin, _platform_wallet, _usdc) = setup();
+    let new_wallet = Address::generate(&env);
+
+    client.update_platform_wallet(&new_wallet);
+
+    assert_eq!(client.get_platform_wallet(), Some(new_wallet));
+}
+
+#[test]
+#[should_panic]
+fn test_update_platform_wallet_unauthorized() {
+    let (env, client, contract_id, _admin, _platform_wallet, _usdc) = setup_without_auth_mock();
+    let non_admin = Address::generate(&env);
+    let new_wallet = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_platform_wallet",
+            args: (&new_wallet,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.update_platform_wallet(&new_wallet);
+}
+
+#[test]
+fn test_update_platform_wallet_self_address() {
+    let (_env, client, _admin, _platform_wallet, _usdc) = setup();
+
+    let res = client.try_update_platform_wallet(&client.address);
+
+    assert_eq!(res, Err(Ok(ProSubscriptionError::InvalidAddress)));
 }
 
 #[test]

--- a/contract/contracts/pro_subscription/src/validation.rs
+++ b/contract/contracts/pro_subscription/src/validation.rs
@@ -3,7 +3,10 @@ use soroban_sdk::Env;
 use crate::error::ProSubscriptionError;
 
 /// Validates that an address is not the contract itself
-pub fn validate_address(env: &Env, addr: &soroban_sdk::Address) -> Result<(), ProSubscriptionError> {
+pub fn validate_address(
+    env: &Env,
+    addr: &soroban_sdk::Address,
+) -> Result<(), ProSubscriptionError> {
     if addr == &env.current_contract_address() {
         return Err(ProSubscriptionError::InvalidAddress);
     }


### PR DESCRIPTION
## Summary
- Added `get_subscription_expiry` view function.
- Added `is_initialized` view function.
- Added admin-only `update_platform_wallet` function.
- Added tests for subscription expiry, initialization state, and platform wallet updates.

Closes #638
Closes #639
Closes #641

## Checklist
- [x] Returns `None` for unknown subscription expiry.
- [x] Returns correct expiry timestamp after subscription.
- [x] Returns `false` before initialization and `true` after initialization.
- [x] Allows admin to update platform wallet.
- [x] Rejects contract self-address as platform wallet.
- [x] Unauthorized platform wallet update panics on auth.
- [x] Tests pass.
- [x] Clippy passes.