### PR TITLE
fix: return 404 for missing rating event

### DIFF
--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -502,6 +502,24 @@ pub async fn submit_event_rating(
 
     let (ticket_status, ticket_event_id) = ticket;
 
+    let event_exists =
+        match sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM events WHERE id = $1)")
+            .bind(event_id)
+            .fetch_one(&state.pool)
+            .await
+        {
+            Ok(exists) => exists,
+            Err(e) => {
+                tracing::error!("Failed to check event existence for rating: {:?}", e);
+                return AppError::DatabaseError(e).into_response();
+            }
+        };
+
+    if !event_exists {
+        return AppError::NotFound(format!("Event with id '{}' not found", event_id))
+            .into_response();
+    }
+
     if ticket_event_id != event_id {
         return AppError::Forbidden("Ticket does not belong to this event".to_string())
             .into_response();
@@ -562,10 +580,14 @@ pub async fn submit_event_rating(
     )
     .bind(event_id)
     .bind(payload.rating)
-    .fetch_one(&mut *tx)
+    .fetch_optional(&mut *tx)
     .await
     {
-        Ok(event) => event,
+        Ok(Some(event)) => event,
+        Ok(None) => {
+            return AppError::NotFound(format!("Event with id '{}' not found", event_id))
+                .into_response();
+        }
         Err(e) => {
             tracing::error!("Failed to update event rating aggregates: {:?}", e);
             return AppError::DatabaseError(e).into_response();


### PR DESCRIPTION
Fixes #571.

This updates the event rating handler so a request for a missing path event ID returns the existing `AppError::NotFound` response instead of falling through to database-error behavior.

The handler now verifies the path `event_id` after the ticket lookup and before the ticket/event ownership check. That keeps the existing ordering for invalid ratings and missing tickets, while preserving the `403` response when a real event is rated with a ticket from another event.

The aggregate update also uses `fetch_optional` and maps a no-row result to `NotFound`, so the transaction has the same behavior if the event row disappears before the `UPDATE ... RETURNING *` completes.

Verification:
- `git diff --check`

I also tried `cargo fmt --check`, `cargo check --lib`, and focused `cargo test --lib ...` commands. They currently fail before this change is checked because of unrelated existing compile/format issues in `routes/mod.rs`, `EventSocialProofResponse` Redis deserialization, and an existing `SearchParams` test initializer.