### PR TITLE
Add `update_payment_token` to pro_subscription contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ contract/target
 
 # Contract test snapshots
 **/test_snapshots/
+
+# PR description drafts
+pr-*.md

--- a/contract/contracts/pro_subscription/src/contract.rs
+++ b/contract/contracts/pro_subscription/src/contract.rs
@@ -365,4 +365,15 @@ impl ProSubscriptionContract {
     pub fn get_payment_token(env: Env) -> Option<Address> {
         get_payment_token(&env)
     }
+
+    /// Update the accepted payment token (admin only)
+    pub fn update_payment_token(
+        env: Env,
+        new_token: Address,
+    ) -> Result<(), ProSubscriptionError> {
+        require_admin(&env)?;
+        validate_address(&env, &new_token)?;
+        set_payment_token(&env, &new_token);
+        Ok(())
+    }
 }

--- a/contract/contracts/pro_subscription/src/test.rs
+++ b/contract/contracts/pro_subscription/src/test.rs
@@ -427,3 +427,37 @@ fn test_get_payment_token() {
     let result = client.get_payment_token();
     assert_eq!(result, Some(usdc));
 }
+
+#[test]
+fn test_update_payment_token_success() {
+    let (env, client, _admin, _platform_wallet, _usdc) = setup();
+    let new_token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    client.update_payment_token(&new_token);
+
+    assert_eq!(client.get_payment_token(), Some(new_token));
+}
+
+#[test]
+#[should_panic]
+fn test_update_payment_token_unauthorized() {
+    let (env, client, contract_id, _admin, _platform_wallet, _usdc) = setup_without_auth_mock();
+    let non_admin = Address::generate(&env);
+    let new_token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_payment_token",
+            args: (&new_token,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.update_payment_token(&new_token);
+}


### PR DESCRIPTION
# Add `update_payment_token` to pro_subscription contract

Closes #642

## Summary

The `pro_subscription` contract previously had no way to change the accepted payment token after initialization. This meant switching to a different stablecoin (e.g. a new USDC deployment or an alternative token) would require a full contract redeployment. This PR adds an admin-only `update_payment_token` function to address that.

## Changes

### `contract/contracts/pro_subscription/src/contract.rs`

Added a new public contract function:

```rust
pub fn update_payment_token(
    env: Env,
    new_token: Address,
) -> Result<(), ProSubscriptionError> {
    require_admin(&env)?;
    validate_address(&env, &new_token)?;
    set_payment_token(&env, &new_token);
    Ok(())
}
```

- Calls `require_admin` — panics if the caller is not the stored admin address.
- Calls `validate_address` — rejects the contract's own address as the token.
- Calls `set_payment_token` — persists the new token in instance storage.

### `contract/contracts/pro_subscription/src/test.rs`

Added two tests:

| Test | What it verifies |
|---|---|
| `test_update_payment_token_success` | Admin updates the token; `get_payment_token` returns the new address |
| `test_update_payment_token_unauthorized` | Non-admin caller causes an auth panic (`#[should_panic]`) |

## How to Test

```bash
cargo test -p pro-subscription
```

All pre-existing tests continue to pass alongside the two new ones.

## Acceptance Criteria

- [x] `update_payment_token` is a public contract function
- [x] Only the admin can call it (unauthorized call panics)
- [x] All existing tests pass
