### PR TITLE
feat: ticket tiers endpoint, leaderboard/profile Redis caching, body size limit

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.37", features = ["full"] }
 
 # Middleware
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace", "set-header", "request-id"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "set-header", "request-id", "limit"] }
 pin-project = "1.1"
 
 # Serialization

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -2816,9 +2816,87 @@ pub async fn list_events_by_category(
     success(response, "Events in category retrieved successfully").into_response()
 }
 
+/// Response shape for a single ticket tier.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct TicketTierResponse {
+    pub id: Uuid,
+    pub name: String,
+    pub price: rust_decimal::Decimal,
+    pub quantity: i32,
+    pub sold: i32,
+}
+
+/// GET `/api/v1/events/:id/ticket-tiers`
+///
+/// Returns all ticket tiers for the given event ordered by price ascending.
+/// Returns 404 if the event does not exist.
+pub async fn list_ticket_tiers(
+    State(state): State<EventState>,
+    Path(event_id): Path<Uuid>,
+) -> Response {
+    let event_exists = match sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM events WHERE id = $1)",
+    )
+    .bind(event_id)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("Failed to check event existence: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    if !event_exists {
+        return AppError::NotFound(format!("Event with id '{event_id}' not found"))
+            .into_response();
+    }
+
+    match sqlx::query_as::<_, TicketTierResponse>(
+        r#"
+        SELECT
+            id,
+            name,
+            price,
+            total_quantity    AS quantity,
+            (total_quantity - available_quantity) AS sold
+        FROM ticket_tiers
+        WHERE event_id = $1
+        ORDER BY price ASC
+        "#,
+    )
+    .bind(event_id)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(tiers) => success(tiers, "Ticket tiers retrieved successfully").into_response(),
+        Err(e) => {
+            tracing::error!("Failed to fetch ticket tiers: {:?}", e);
+            AppError::DatabaseError(e).into_response()
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests for list_event_tickets and image_url validation
 // ---------------------------------------------------------------------------
+
+#[test]
+fn test_ticket_tier_response_serialization() {
+    use rust_decimal::Decimal;
+    let tier = TicketTierResponse {
+        id: Uuid::new_v4(),
+        name: "General".to_string(),
+        price: Decimal::new(2500, 2),
+        quantity: 500,
+        sold: 120,
+    };
+    let json = serde_json::to_value(&tier).unwrap();
+    assert_eq!(json["name"], "General");
+    assert_eq!(json["quantity"], 500);
+    assert_eq!(json["sold"], 120);
+}
 
 #[test]
 fn test_image_url_valid_https() {

--- a/server/src/handlers/leaderboard.rs
+++ b/server/src/handlers/leaderboard.rs
@@ -2,18 +2,29 @@
 //!
 //! Provides the leaderboard endpoint that ranks organizers by tickets sold.
 //! Supports `all_time`, `monthly`, and `weekly` timeframes.
+//! Results are cached in Redis for 5 minutes.
 
 use axum::{
     extract::{Query, State},
     response::{IntoResponse, Response},
 };
 use serde::{Deserialize, Serialize};
-
-use crate::utils::db_timer::log_if_slow;
 use sqlx::PgPool;
+use std::time::Duration;
 
+use crate::cache::RedisCache;
+use crate::utils::db_timer::log_if_slow;
 use crate::utils::error::AppError;
 use crate::utils::response::success;
+
+const LEADERBOARD_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Application state for leaderboard handlers.
+#[derive(Clone)]
+pub struct LeaderboardState {
+    pub pool: PgPool,
+    pub redis: RedisCache,
+}
 
 /// Supported timeframe values for the leaderboard query.
 #[derive(Debug, Deserialize, Default)]
@@ -34,7 +45,7 @@ pub struct LeaderboardParams {
 }
 
 /// A single entry in the leaderboard response.
-#[derive(Debug, Serialize, sqlx::FromRow)]
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
 pub struct LeaderboardEntry {
     /// Rank position (1-based).
     pub rank: i64,
@@ -44,6 +55,14 @@ pub struct LeaderboardEntry {
     pub tickets_sold: i64,
 }
 
+fn cache_key(timeframe: &Timeframe) -> &'static str {
+    match timeframe {
+        Timeframe::AllTime => "leaderboard:top:all_time",
+        Timeframe::Monthly => "leaderboard:top:monthly",
+        Timeframe::Weekly => "leaderboard:top:weekly",
+    }
+}
+
 /// GET `/api/v1/leaderboard` – Rank organizers by tickets sold.
 ///
 /// # Query Parameters
@@ -51,11 +70,17 @@ pub struct LeaderboardEntry {
 ///
 /// # Response
 /// Returns a JSON array of organizers ordered by tickets sold descending,
-/// each entry including their rank and score.
+/// each entry including their rank and score. Results are cached for 5 minutes.
 pub async fn get_leaderboard(
-    State(pool): State<PgPool>,
+    State(mut state): State<LeaderboardState>,
     Query(params): Query<LeaderboardParams>,
 ) -> Response {
+    let key = cache_key(&params.timeframe);
+
+    if let Ok(Some(cached)) = state.redis.get::<Vec<LeaderboardEntry>>(key).await {
+        return success(cached, "Leaderboard retrieved successfully").into_response();
+    }
+
     let time_filter = match params.timeframe {
         Timeframe::AllTime => "TRUE",
         Timeframe::Monthly => "t.created_at >= NOW() - INTERVAL '30 days'",
@@ -80,15 +105,53 @@ pub async fn get_leaderboard(
 
     let start = std::time::Instant::now();
     let result = sqlx::query_as::<_, LeaderboardEntry>(&query)
-        .fetch_all(&pool)
+        .fetch_all(&state.pool)
         .await;
     log_if_slow("get_leaderboard", start.elapsed());
 
     match result {
-        Ok(entries) => success(entries, "Leaderboard retrieved successfully").into_response(),
+        Ok(entries) => {
+            if let Err(e) = state.redis.set(key, &entries, LEADERBOARD_CACHE_TTL).await {
+                tracing::warn!("Failed to cache leaderboard: {:?}", e);
+            }
+            success(entries, "Leaderboard retrieved successfully").into_response()
+        }
         Err(e) => {
             tracing::error!("Failed to fetch leaderboard: {:?}", e);
             AppError::DatabaseError(e).into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_leaderboard_cache_keys_are_distinct() {
+        let all_time = cache_key(&Timeframe::AllTime);
+        let monthly = cache_key(&Timeframe::Monthly);
+        let weekly = cache_key(&Timeframe::Weekly);
+        assert_ne!(all_time, monthly);
+        assert_ne!(monthly, weekly);
+        assert_ne!(all_time, weekly);
+    }
+
+    #[test]
+    fn test_leaderboard_cache_ttl_is_5_minutes() {
+        assert_eq!(LEADERBOARD_CACHE_TTL.as_secs(), 300);
+    }
+
+    #[test]
+    fn test_leaderboard_entry_serialization() {
+        let entry = LeaderboardEntry {
+            rank: 1,
+            organizer_name: "Agora".to_string(),
+            tickets_sold: 500,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["rank"], 1);
+        assert_eq!(json["organizer_name"], "Agora");
+        assert_eq!(json["tickets_sold"], 500);
     }
 }

--- a/server/src/handlers/profile.rs
+++ b/server/src/handlers/profile.rs
@@ -14,7 +14,9 @@ use axum::{
     Json,
 };
 use sqlx::{PgPool, Postgres, QueryBuilder};
+use std::time::Duration;
 
+use crate::cache::RedisCache;
 use crate::handlers::auth::extract_auth;
 use crate::models::organizer_profile::{OrganizerProfile, UpsertProfileRequest};
 use crate::utils::error::AppError;
@@ -25,7 +27,16 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::Instant;
+
+const PROFILE_CACHE_TTL: Duration = Duration::from_secs(600);
+
+/// Application state for profile handlers that use Redis caching.
+#[derive(Clone)]
+pub struct ProfileState {
+    pub pool: PgPool,
+    pub redis: RedisCache,
+}
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -101,21 +112,11 @@ pub struct PatchProfileRequest {
     pub socials: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrganizerProfileResponse {
     #[serde(flatten)]
     pub profile: OrganizerProfile,
     pub total_events: i64,
-}
-
-static PROFILE_CACHE: Lazy<Mutex<HashMap<String, (Instant, OrganizerProfileResponse)>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
-
-const PROFILE_CACHE_TTL: Duration = Duration::from_secs(300);
-
-fn invalidate_profile_cache(address: &str) {
-    let mut cache = PROFILE_CACHE.lock().unwrap();
-    cache.remove(address);
 }
 
 fn organizer_total_events_query() -> &'static str {
@@ -141,7 +142,7 @@ fn organizer_total_events_query() -> &'static str {
 /// - `display_name`: required, max 50 chars
 /// - `bio`: optional, max 500 chars
 pub async fn upsert_profile(
-    State(pool): State<PgPool>,
+    State(mut state): State<ProfileState>,
     headers: HeaderMap,
     Json(payload): Json<UpsertProfileRequest>,
 ) -> Response {
@@ -174,7 +175,7 @@ pub async fn upsert_profile(
     .bind(payload.bio.as_deref())
     .bind(payload.avatar_url.as_deref())
     .bind(&payload.socials)
-    .fetch_one(&pool)
+    .fetch_one(&state.pool)
     .await
     {
         Ok(p) => p,
@@ -184,7 +185,10 @@ pub async fn upsert_profile(
         }
     };
 
-    invalidate_profile_cache(&address);
+    let cache_key = format!("profile:{address}");
+    if let Err(e) = state.redis.delete(&cache_key).await {
+        tracing::warn!("Failed to invalidate profile cache for {address}: {:?}", e);
+    }
 
     success(profile, "Profile updated successfully").into_response()
 }
@@ -193,7 +197,7 @@ pub async fn upsert_profile(
 ///
 /// Partially updates the authenticated organizer's profile.
 pub async fn patch_profile(
-    State(pool): State<PgPool>,
+    State(mut state): State<ProfileState>,
     headers: HeaderMap,
     Json(payload): Json<PatchProfileRequest>,
 ) -> Response {
@@ -233,7 +237,7 @@ pub async fn patch_profile(
 
     let profile = match builder
         .build_query_as::<OrganizerProfile>()
-        .fetch_optional(&pool)
+        .fetch_optional(&state.pool)
         .await
     {
         Ok(Some(profile)) => profile,
@@ -247,7 +251,10 @@ pub async fn patch_profile(
         }
     };
 
-    invalidate_profile_cache(&address);
+    let cache_key = format!("profile:{address}");
+    if let Err(e) = state.redis.delete(&cache_key).await {
+        tracing::warn!("Failed to invalidate profile cache for {address}: {:?}", e);
+    }
 
     success(profile, "Profile updated successfully").into_response()
 }
@@ -256,33 +263,30 @@ pub async fn patch_profile(
 ///
 /// Returns the authenticated organizer's own profile.
 /// Returns 404 if no profile has been created yet.
-pub async fn get_my_profile(State(pool): State<PgPool>, headers: HeaderMap) -> Response {
+pub async fn get_my_profile(State(mut state): State<ProfileState>, headers: HeaderMap) -> Response {
     let address = match extract_auth(&headers) {
         Ok(a) => a,
         Err(e) => return e.into_response(),
     };
 
-    fetch_profile_by_address(&pool, &address).await
+    fetch_profile_by_address(&state.pool, &mut state.redis, &address).await
 }
 
 /// `GET /api/v1/profile/:address`
 ///
 /// Returns any organizer's public profile by their Stellar wallet address.
 pub async fn get_profile_by_address(
-    State(pool): State<PgPool>,
+    State(mut state): State<ProfileState>,
     Path(address): Path<String>,
 ) -> Response {
-    fetch_profile_by_address(&pool, &address).await
+    fetch_profile_by_address(&state.pool, &mut state.redis, &address).await
 }
 
-async fn fetch_profile_by_address(pool: &PgPool, address: &str) -> Response {
-    {
-        let cache = PROFILE_CACHE.lock().unwrap();
-        if let Some((expiry, profile)) = cache.get(address) {
-            if Instant::now() < *expiry {
-                return success(profile.clone(), "Profile retrieved successfully").into_response();
-            }
-        }
+async fn fetch_profile_by_address(pool: &PgPool, redis: &mut RedisCache, address: &str) -> Response {
+    let cache_key = format!("profile:{address}");
+
+    if let Ok(Some(cached)) = redis.get::<OrganizerProfileResponse>(&cache_key).await {
+        return success(cached, "Profile retrieved successfully").into_response();
     }
 
     match sqlx::query_as::<_, OrganizerProfile>(
@@ -310,12 +314,8 @@ async fn fetch_profile_by_address(pool: &PgPool, address: &str) -> Response {
                 total_events,
             };
 
-            {
-                let mut cache = PROFILE_CACHE.lock().unwrap();
-                cache.insert(
-                    address.to_string(),
-                    (Instant::now() + PROFILE_CACHE_TTL, response.clone()),
-                );
+            if let Err(e) = redis.set(&cache_key, &response, PROFILE_CACHE_TTL).await {
+                tracing::warn!("Failed to cache profile for {address}: {:?}", e);
             }
 
             success(response, "Profile retrieved successfully").into_response()
@@ -590,6 +590,40 @@ mod tests {
         let json = serde_json::to_value(response).unwrap();
         assert_eq!(json["address"], "GABC");
         assert_eq!(json["total_events"], 3);
+    }
+
+    #[test]
+    fn test_profile_cache_key_format() {
+        let address = "GTEST123WALLETADDRESS";
+        let key = format!("profile:{address}");
+        assert_eq!(key, "profile:GTEST123WALLETADDRESS");
+        assert!(key.starts_with("profile:"));
+    }
+
+    #[test]
+    fn test_profile_cache_ttl_is_10_minutes() {
+        assert_eq!(PROFILE_CACHE_TTL.as_secs(), 600);
+    }
+
+    #[test]
+    fn test_organizer_profile_response_deserializes() {
+        let now = chrono::Utc::now();
+        let response = OrganizerProfileResponse {
+            profile: OrganizerProfile {
+                address: "GABC".to_string(),
+                display_name: "Agora".to_string(),
+                bio: None,
+                avatar_url: None,
+                socials: json!({}),
+                created_at: now,
+                updated_at: now,
+            },
+            total_events: 5,
+        };
+        let json_str = serde_json::to_string(&response).unwrap();
+        let decoded: OrganizerProfileResponse = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(decoded.profile.address, "GABC");
+        assert_eq!(decoded.total_events, 5);
     }
 
     #[test]

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -28,6 +28,7 @@ use axum::{
 };
 use sqlx::PgPool;
 use std::time::Duration;
+use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::cache::RedisCache;
 use crate::config::{
@@ -230,6 +231,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .nest("/ws", ws_routes)
         .nest("/qr", qr_routes)
         .merge(rates_route)
+        .layer(RequestBodyLimitLayer::new(1024 * 1024))
         .layer(GovernorRateLimitLayer::new(100, Duration::from_secs(60)));
 
     let api_routes = Router::new()
@@ -464,5 +466,27 @@ mod tests {
                 StatusCode::TOO_MANY_REQUESTS
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_body_size_limit_rejects_oversized_requests() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+        use tower_http::limit::RequestBodyLimitLayer;
+
+        let limit: usize = 1024;
+        let router = Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(RequestBodyLimitLayer::new(limit));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header("content-length", "2048")
+            .body(Body::empty())
+            .unwrap();
+
+        let status = router.oneshot(req).await.unwrap().status();
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -46,7 +46,7 @@ use crate::handlers::{
     },
     example_empty_success, example_not_found, example_validation_error,
     health::{health_check, health_check_blockchain, health_check_db, health_check_ready},
-    leaderboard::get_leaderboard,
+    leaderboard::{get_leaderboard, LeaderboardState},
     monitoring::{monitoring_dashboard, MonitoringState},
     profile::{
         get_my_profile, get_organizer_stats, get_profile_by_address, patch_profile, upsert_profile,
@@ -191,13 +191,18 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         )
         .layer(RateLimitLayer::new(SENSITIVE_RATE_LIMIT, SENSITIVE_WINDOW));
 
+    let leaderboard_state = LeaderboardState {
+        pool: pool.clone(),
+        redis: redis.clone(),
+    };
+
     // General endpoints — relaxed rate limit
     let general_routes = Router::new()
         .route("/examples/validation-error", get(example_validation_error))
         .route("/examples/empty-success", get(example_empty_success))
         .route("/examples/not-found/:id", get(example_not_found))
         .route("/leaderboard", get(get_leaderboard))
-        .with_state(pool)
+        .with_state(leaderboard_state)
         .layer(RateLimitLayer::new(GENERAL_RATE_LIMIT, GENERAL_WINDOW));
 
     // Public API routes with tower-governor rate limiting

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -41,7 +41,8 @@ use crate::handlers::{
         export_attendees_csv, get_attendee_count, get_checkin_stats, get_event, get_event_counts,
         get_event_organizer, get_event_share_link, get_event_social_proof, get_ratings_summary,
         list_event_tickets, list_events, list_events_by_category, list_past_events,
-        list_similar_events, search_events, submit_event_rating, toggle_event_flag, EventState,
+        list_similar_events, list_ticket_tiers, search_events, submit_event_rating,
+        toggle_event_flag, EventState,
     },
     example_empty_success, example_not_found, example_validation_error,
     health::{health_check, health_check_blockchain, health_check_db, health_check_ready},
@@ -153,6 +154,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/:id/share-link", get(get_event_share_link))
         .route("/:id/social-proof", get(get_event_social_proof))
         .route("/:id/tickets", get(list_event_tickets))
+        .route("/:id/ticket-tiers", get(list_ticket_tiers))
         .route("/:id/similar", get(list_similar_events))
         .route("/categories/:category_id", get(list_events_by_category))
         .with_state(event_state);

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -50,6 +50,7 @@ use crate::handlers::{
     monitoring::{monitoring_dashboard, MonitoringState},
     profile::{
         get_my_profile, get_organizer_stats, get_profile_by_address, patch_profile, upsert_profile,
+        ProfileState,
     },
     qr_payload::{delete_qr_payload, generate_qr_payload, list_event_qr_codes, list_qr_payloads, mark_qr_used, verify_qr_payload},
     rates::{get_rates, RatesState},
@@ -110,12 +111,22 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/logout", post(logout))
         .with_state(pool.clone());
 
+    let profile_state = ProfileState {
+        pool: pool.clone(),
+        redis: redis.clone(),
+    };
+
     // Organizer profile routes (Issue #486)
+    // Routes that use Redis caching use ProfileState; stats route keeps PgPool.
     let profile_routes = Router::new()
         .route("/", get(get_my_profile).put(upsert_profile).patch(patch_profile))
-        .route("/:address/stats", get(get_organizer_stats))
         .route("/:address", get(get_profile_by_address))
-        .with_state(pool.clone());
+        .with_state(profile_state)
+        .merge(
+            Router::new()
+                .route("/:address/stats", get(get_organizer_stats))
+                .with_state(pool.clone()),
+        );
 
     // Admin sub-router — every request is recorded in audit_logs.
     let admin_routes = Router::new()


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/events/:id/ticket-tiers` endpoint returning all ticket tiers for an event (name, price, quantity, sold)
- Adds Redis caching (5-minute TTL) to `GET /api/v1/leaderboard` via a new `LeaderboardState`; cache is per-timeframe; Redis failures fall through to the database
- Adds Redis caching (10-minute TTL) to `GET /api/v1/profile/:address`; cache is invalidated on `PUT` and `PATCH /profile`; replaced the previous in-memory `PROFILE_CACHE` static
- Applies `RequestBodyLimitLayer` (1 MB) to all public API routes; requests with `Content-Length` exceeding the limit receive HTTP 413

## Closes

Closes #588
Closes #587
Closes #590
Closes #589