### PR TITLE
fix(contract): resolve issues #895, #897, #899, #901 in event-registry

### DIFF
--- a/contract/contracts/event_registry/src/events.rs
+++ b/contract/contracts/event_registry/src/events.rs
@@ -224,10 +224,34 @@ pub struct EventPostponedEvent {
     pub event_id: String,
     /// The wallet address of the event organizer.
     pub organizer_address: Address,
+    /// The new Unix timestamp when the event will start.
+    pub new_start_time: u64,
     /// The Unix timestamp when the refund grace period ends.
     pub grace_period_end: u64,
     /// The ledger timestamp when the postponement occurred.
     pub timestamp: u64,
+}
+
+/// Emitted when the staking token address is changed by an admin.
+///
+/// Published with topic `(AgoraEvent::StakingTokenUpdated,)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StakingTokenUpdatedEvent {
+    pub old_token: Option<Address>,
+    pub new_token: Address,
+    pub admin: Address,
+}
+
+/// Emitted when the minimum stake amount is changed by an admin.
+///
+/// Published with topic `(AgoraEvent::MinStakeAmountUpdated,)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MinStakeAmountUpdatedEvent {
+    pub old_amount: i128,
+    pub new_amount: i128,
+    pub admin: Address,
 }
 
 /// Emitted when a governance proposal is created by an admin.

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -5,9 +5,10 @@ use crate::events::{
     EventArchivedEvent, EventCancelledEvent, EventPostponedEvent, EventRegisteredEvent,
     EventStatusUpdatedEvent, EventsSuspendedEvent, FeeUpdatedEvent, GlobalPromoUpdatedEvent,
     GoalMetEvent, InitializationEvent, InventoryIncrementedEvent, LoyaltyScoreUpdatedEvent,
-    MetadataUpdatedEvent, OrganizerBlacklistedEvent, OrganizerRemovedFromBlacklistEvent,
-    RegistryUpgradedEvent, ScannerAuthorizedEvent, ScannerRevokedEvent, StakerRewardsClaimedEvent,
-    StakerRewardsDistributedEvent,
+    MetadataUpdatedEvent, MinStakeAmountUpdatedEvent, OrganizerBlacklistedEvent,
+    OrganizerRemovedFromBlacklistEvent, RegistryUpgradedEvent, ScannerAuthorizedEvent,
+    ScannerRevokedEvent, StakerRewardsClaimedEvent, StakerRewardsDistributedEvent,
+    StakingTokenUpdatedEvent,
 };
 use crate::types::{
     BlacklistAuditEntry, EventInfo, EventReceipt, EventRegistrationArgs, EventStatus, GuestProfile,
@@ -490,6 +491,38 @@ impl EventRegistry {
             return Err(EventRegistryError::InvalidFeePercent);
         }
 
+        // When threshold > 1 (multi-sig), a pre-approved SetPlatformFee proposal is required.
+        let config =
+            storage::get_multisig_config(&env).ok_or(EventRegistryError::NotInitialized)?;
+        if config.threshold > 1 {
+            // Find an approved, unexpired, unexecuted SetPlatformFee proposal matching new_fee_percent
+            let active = storage::get_active_proposals(&env);
+            let mut approved_proposal_id: Option<u64> = None;
+            let now = env.ledger().timestamp();
+            for pid in active.iter() {
+                if let Some(p) = storage::get_proposal(&env, pid) {
+                    if p.executed || p.cancelled || now > p.expires_at {
+                        continue;
+                    }
+                    if let types::ParameterChange::SetPlatformFee(fee) = &p.change {
+                        if *fee == new_fee_percent
+                            && p.approvals.len() >= config.threshold
+                        {
+                            approved_proposal_id = Some(pid);
+                            break;
+                        }
+                    }
+                }
+            }
+            let proposal_id =
+                approved_proposal_id.ok_or(EventRegistryError::MultisigError)?;
+            // Mark the proposal as executed
+            let mut proposal = storage::get_proposal(&env, proposal_id).unwrap();
+            proposal.executed = true;
+            storage::set_proposal(&env, &proposal);
+            storage::remove_active_proposal(&env, proposal_id);
+        }
+
         storage::set_platform_fee(&env, new_fee_percent);
 
         // Emit fee update event using contract event type
@@ -917,6 +950,7 @@ impl EventRegistry {
     pub fn postpone_event(
         env: Env,
         event_id: String,
+        new_start_time: u64,
         grace_period_end: u64,
     ) -> Result<(), EventRegistryError> {
         let mut event_info =
@@ -926,10 +960,14 @@ impl EventRegistry {
         auth::require_organizer(&env, &event_id, &event_info.organizer_address)?;
 
         let now = env.ledger().timestamp();
+        if new_start_time <= now {
+            return Err(EventRegistryError::InvalidDeadline);
+        }
         if grace_period_end <= now {
             return Err(EventRegistryError::InvalidGracePeriodEnd);
         }
 
+        event_info.start_time = new_start_time;
         event_info.is_postponed = true;
         event_info.grace_period_end = grace_period_end;
         storage::update_event(&env, event_info.clone());
@@ -939,6 +977,7 @@ impl EventRegistry {
             EventPostponedEvent {
                 event_id,
                 organizer_address: event_info.organizer_address,
+                new_start_time,
                 grace_period_end,
                 timestamp: now,
             },
@@ -1019,14 +1058,36 @@ impl EventRegistry {
         token: Address,
         min_amount: i128,
     ) -> Result<(), EventRegistryError> {
-        let _admin = auth::require_admin(&env)?;
+        let admin = auth::require_admin(&env)?;
 
         if min_amount <= 0 {
             return Err(EventRegistryError::InvalidStakeAmount);
         }
 
+        let old_token = storage::get_staking_token(&env);
+        let old_amount = storage::get_min_stake_amount(&env);
+
         storage::set_staking_token(&env, &token);
         storage::set_min_stake_amount(&env, min_amount);
+
+        env.events().publish(
+            (AgoraEvent::StakingTokenUpdated,),
+            StakingTokenUpdatedEvent {
+                old_token,
+                new_token: token,
+                admin: admin.clone(),
+            },
+        );
+
+        env.events().publish(
+            (AgoraEvent::MinStakeAmountUpdated,),
+            MinStakeAmountUpdatedEvent {
+                old_amount,
+                new_amount: min_amount,
+                admin,
+            },
+        );
+
         Ok(())
     }
 

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -498,7 +498,7 @@ fn test_postpone_event_grace_period_in_past() {
     env.ledger().with_mut(|li| li.timestamp = 1_000);
     let grace_period_end = 500u64;
 
-    let result = client.try_postpone_event(&event_id, &grace_period_end);
+    let result = client.try_postpone_event(&event_id, &1500u64, &grace_period_end);
     assert_eq!(result, Err(Ok(EventRegistryError::InvalidGracePeriodEnd)));
 }
 
@@ -544,7 +544,7 @@ fn test_postpone_cancelled_event() {
     env.ledger().with_mut(|li| li.timestamp = 1_000);
     let grace_period_end = 2_000u64;
 
-    let result = client.try_postpone_event(&event_id, &grace_period_end);
+    let result = client.try_postpone_event(&event_id, &1500u64, &grace_period_end);
     assert_eq!(result, Err(Ok(EventRegistryError::EventCancelled)));
 }
 
@@ -2481,7 +2481,7 @@ fn test_postpone_event_sets_grace_period() {
     env.ledger().with_mut(|li| li.timestamp = 1_000);
     let grace_period_end = 2_000u64;
 
-    client.postpone_event(&event_id, &grace_period_end);
+    client.postpone_event(&event_id, &1500u64, &grace_period_end);
 
     let event_info = client.get_event(&event_id).unwrap();
     assert!(event_info.is_postponed);
@@ -4280,4 +4280,194 @@ fn test_get_events_by_category_returns_correct_events() {
     assert_eq!(cat1_events.len(), 2);
     assert!(cat1_events.contains(String::from_str(&env, "event1_cat1")));
     assert!(cat1_events.contains(String::from_str(&env, "event2_cat1")));
+}
+
+// ── Issue #899: postpone_event must validate new_start_time is in the future ──
+
+#[test]
+fn test_postpone_event_past_start_time_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    let event_id = String::from_str(&env, "event_past_start");
+    let metadata_cid = String::from_str(
+        &env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+    let tiers = Map::new(&env);
+    client.register_event(&EventRegistrationArgs {
+        event_id: event_id.clone(),
+        organizer_address: organizer,
+        payment_address: Address::generate(&env),
+        metadata_cid,
+        max_supply: 100,
+        milestone_plan: None,
+        tiers,
+        refund_deadline: 0,
+        restocking_fee: 0,
+        resale_cap_bps: None,
+        min_sales_target: None,
+        target_deadline: None,
+        banner_cid: None,
+    });
+
+    env.ledger().with_mut(|li| li.timestamp = 2_000);
+    // new_start_time in the past → InvalidDeadline
+    let result = client.try_postpone_event(&event_id, &500u64, &3_000u64);
+    assert_eq!(result, Err(Ok(EventRegistryError::InvalidDeadline)));
+}
+
+// ── Issue #901: set_staking_config emits StakingTokenUpdated and MinStakeAmountUpdated ──
+
+#[test]
+fn test_set_staking_config_emits_events() {
+    use soroban_sdk::testutils::Events;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    let staking_token = Address::generate(&env);
+    client.set_staking_config(&staking_token, &1_000_000i128).unwrap();
+
+    let all_events = env.events().all();
+    // Find StakingTokenUpdated and MinStakeAmountUpdated in the emitted events
+    let staking_token_event = all_events.iter().any(|(topics, _)| {
+        topics.get(0) == Some(soroban_sdk::Val::from(crate::topics::AgoraEvent::StakingTokenUpdated))
+    });
+    let min_stake_event = all_events.iter().any(|(topics, _)| {
+        topics.get(0) == Some(soroban_sdk::Val::from(crate::topics::AgoraEvent::MinStakeAmountUpdated))
+    });
+    assert!(staking_token_event, "StakingTokenUpdated event not emitted");
+    assert!(min_stake_event, "MinStakeAmountUpdated event not emitted");
+}
+
+// ── Issue #895: set_platform_fee requires approved multisig proposal when threshold > 1 ──
+
+#[test]
+fn test_set_platform_fee_single_admin_no_proposal_needed() {
+    // threshold == 1: direct call still works
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+    // threshold is 1 after initialize → should succeed without proposal
+    client.set_platform_fee(&300);
+    assert_eq!(client.get_platform_fee(), 300);
+}
+
+#[test]
+fn test_set_platform_fee_multisig_no_proposal_fails() {
+    // threshold > 1: calling set_platform_fee without an approved proposal returns MultisigError
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin1, &platform_wallet, &500, &usdc_token);
+
+    // Add a second admin and raise threshold to 2
+    let pid = client.propose_add_admin(&admin1, &admin2, &0u64);
+    client.approve_proposal(&admin1, &pid);
+    client.execute_proposal(&admin1, &pid);
+
+    let pid2 = client.propose_set_threshold(&admin1, &2u32, &0u64);
+    client.approve_proposal(&admin1, &pid2);
+    client.approve_proposal(&admin2, &pid2);
+    client.execute_proposal(&admin1, &pid2);
+
+    // Now threshold == 2: set_platform_fee without a proposal should fail
+    let result = client.try_set_platform_fee(&300);
+    assert_eq!(result, Err(Ok(EventRegistryError::MultisigError)));
+}
+
+#[test]
+fn test_set_platform_fee_multisig_with_approved_proposal_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin1, &platform_wallet, &500, &usdc_token);
+
+    // Raise to 2-of-2 multisig
+    let pid = client.propose_add_admin(&admin1, &admin2, &0u64);
+    client.approve_proposal(&admin1, &pid);
+    client.execute_proposal(&admin1, &pid);
+    let pid2 = client.propose_set_threshold(&admin1, &2u32, &0u64);
+    client.approve_proposal(&admin1, &pid2);
+    client.approve_proposal(&admin2, &pid2);
+    client.execute_proposal(&admin1, &pid2);
+
+    // Create and fully approve a SetPlatformFee proposal
+    let fee_pid = client.propose_parameter_change(
+        &admin1,
+        &crate::types::ParameterChange::SetPlatformFee(300),
+        &0u64,
+    );
+    client.approve_proposal(&admin1, &fee_pid);
+    client.approve_proposal(&admin2, &fee_pid);
+
+    // Now set_platform_fee should succeed using the approved proposal
+    client.set_platform_fee(&300);
+    assert_eq!(client.get_platform_fee(), 300);
+}
+
+// ── Issue #897: propose_add_admin rejects duplicate admins at proposal creation ──
+
+#[test]
+fn test_propose_add_admin_duplicate_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    // Trying to propose admin (who is already an admin) should fail immediately
+    let result = client.try_propose_add_admin(&admin, &admin, &0u64);
+    assert_eq!(result, Err(Ok(EventRegistryError::AdminAlreadyExists)));
+}
+
+#[test]
+fn test_propose_add_admin_new_address_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    // Proposing a brand-new address should succeed
+    let pid = client.propose_add_admin(&admin, &new_admin, &0u64);
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert!(!proposal.executed);
+    assert_eq!(proposal.change, crate::types::ParameterChange::AddAdmin(new_admin));
 }

--- a/contract/contracts/event_registry/src/topics.rs
+++ b/contract/contracts/event_registry/src/topics.rs
@@ -65,4 +65,8 @@ pub enum AgoraEvent {
     ProposalCancelled,
     /// A user has joined the waitlist for a sold-out event.
     WaitlistJoined,
+    /// The staking token address has been updated by an admin.
+    StakingTokenUpdated,
+    /// The minimum stake amount has been updated by an admin.
+    MinStakeAmountUpdated,
 }


### PR DESCRIPTION
## Issue #899 — postpone_event does not validate new_start_time

Problem:
The postpone_event function accepted a grace_period_end timestamp but had no parameter for the new event start time, making it impossible to validate that the postponed date is actually in the future. An organizer could implicitly leave start_time unchanged or set it to a past value.

Fix:
- Added new_start_time: u64 parameter to postpone_event.
- Added validation: if new_start_time <= env.ledger().timestamp(), the function returns EventRegistryError::InvalidDeadline (reusing the existing error code to stay within the 50-variant XDR spec limit).
- The function now writes new_start_time back to event_info.start_time before persisting the event.
- EventPostponedEvent struct gained a new_start_time field so off-chain listeners can observe the rescheduled time.
- Updated all three existing test call sites (try_postpone_event) to supply the new argument.
- Added test: test_postpone_event_past_start_time_rejected — verifies that a new_start_time in the past returns InvalidDeadline.

Files changed: src/lib.rs, src/events.rs, src/test.rs

---

## Issue #901 — no event emitted when staking config changes

Problem:
set_staking_config updated the staking token address and minimum stake amount silently. Off-chain indexers (e.g. the Soroban event listener on the backend) had no way to detect that these values had changed and could not update organizer Verified status thresholds accordingly.

Fix:
- Added StakingTokenUpdatedEvent struct (fields: old_token, new_token, admin) published with topic AgoraEvent::StakingTokenUpdated.
- Added MinStakeAmountUpdatedEvent struct (fields: old_amount, new_amount, admin) published with topic AgoraEvent::MinStakeAmountUpdated.
- Both new event structs are defined in src/events.rs.
- Two new topic variants (StakingTokenUpdated, MinStakeAmountUpdated) added to the AgoraEvent enum in src/topics.rs.
- set_staking_config now reads the old values before overwriting them, then emits both events after the storage writes.
- Added test: test_set_staking_config_emits_events — verifies both event topics appear in env.events().all() after a call to set_staking_config.

Files changed: src/lib.rs, src/events.rs, src/topics.rs

---

## Issue #895 — set_platform_fee bypasses multi-sig when threshold > 1

Problem:
Any single admin could call set_platform_fee and immediately change the global fee rate, even when the multi-sig threshold was configured to require multiple approvals. This bypassed the governance safeguard for fee changes on multi-sig deployments.

Fix:
- When the multisig threshold is 1, set_platform_fee behaves exactly as before (single admin can change the fee directly).
- When threshold > 1, the function searches the active proposal list for an approved, unexpired, unexecuted SetPlatformFee(new_fee_percent) proposal that has reached the required approval count. If none exists, it returns EventRegistryError::MultisigError. If one is found, the proposal is marked as executed and removed from the active list before the fee is applied — preventing double-execution.
- This routes large fee changes through the existing propose_parameter_change / approve_proposal workflow without duplicating any governance logic.
- Added tests: test_set_platform_fee_single_admin_no_proposal_needed — threshold 1, direct call still works. test_set_platform_fee_multisig_no_proposal_fails — threshold 2, call without a proposal returns MultisigError. test_set_platform_fee_multisig_with_approved_proposal_succeeds — threshold 2, fully approved SetPlatformFee proposal allows the call.

Files changed: src/lib.rs, src/test.rs

---

## Issue #897 — propose_add_admin does not check for duplicate admins

Problem:
Creating an AddAdmin proposal for an address already in the admins list would consume a proposal slot and confuse other admins. The duplicate check only existed at execution time (AdminAlreadyExists), not at proposal creation time.

Investigation finding:
The duplicate check was already present inside propose_parameter_change, which is called by propose_add_admin. The AddAdmin arm at line ~1400 validates address and returns AdminAlreadyExists if the address is already in config.admins. The code was correct; tests were missing.

Fix:
- Added tests to make the guarantee explicit and regression-proof: test_propose_add_admin_duplicate_rejected — creating a proposal to add the existing admin immediately returns AdminAlreadyExists. test_propose_add_admin_new_address_succeeds — creating a proposal for a genuinely new address succeeds and the proposal is stored with the correct AddAdmin change.

Files changed: src/test.rs

Closes #895
Closes #897
Closes #899
Closes #901