### PR TITLE
feat(server): include computed average_rating in event responses

### DIFF
--- a/server/src/models/event.rs
+++ b/server/src/models/event.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 ///
 /// Maps to the `events` table in the database.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Deserialize, FromRow)]
 pub struct Event {
     /// Unique identifier for the event (UUID v4).
     pub id: Uuid,
@@ -53,6 +53,37 @@ impl Event {
         } else {
             Some(self.sum_of_ratings as f32 / self.count_of_ratings as f32)
         }
+    }
+}
+
+/// Custom serialization that adds the computed `average_rating` field alongside
+/// the raw columns, so clients don't have to derive it from
+/// `sum_of_ratings` / `count_of_ratings` (Issue #584). It is `null` when the
+/// event has no ratings.
+impl Serialize for Event {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("Event", 16)?;
+        state.serialize_field("id", &self.id)?;
+        state.serialize_field("organizer_id", &self.organizer_id)?;
+        state.serialize_field("title", &self.title)?;
+        state.serialize_field("description", &self.description)?;
+        state.serialize_field("location", &self.location)?;
+        state.serialize_field("start_time", &self.start_time)?;
+        state.serialize_field("end_time", &self.end_time)?;
+        state.serialize_field("is_flagged", &self.is_flagged)?;
+        state.serialize_field("sum_of_ratings", &self.sum_of_ratings)?;
+        state.serialize_field("count_of_ratings", &self.count_of_ratings)?;
+        state.serialize_field("created_at", &self.created_at)?;
+        state.serialize_field("updated_at", &self.updated_at)?;
+        state.serialize_field("image_url", &self.image_url)?;
+        state.serialize_field("is_free", &self.is_free)?;
+        state.serialize_field("average_rating", &self.average_rating())?;
+        state.end()
     }
 }
 
@@ -156,5 +187,49 @@ mod tests {
             is_free: false,
         };
         assert!(event.average_rating().is_none());
+    }
+
+    #[test]
+    fn test_average_rating_serialized_when_ratings_exist() {
+        let event = Event {
+            id: Uuid::new_v4(),
+            organizer_id: Uuid::new_v4(),
+            title: "Rated".into(),
+            description: None,
+            location: "L".into(),
+            start_time: DateTime::default(),
+            end_time: None,
+            is_flagged: false,
+            sum_of_ratings: 45,
+            count_of_ratings: 10,
+            created_at: DateTime::default(),
+            updated_at: DateTime::default(),
+            image_url: None,
+            is_free: false,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["average_rating"], 4.5);
+    }
+
+    #[test]
+    fn test_average_rating_serialized_null_when_no_ratings() {
+        let event = Event {
+            id: Uuid::new_v4(),
+            organizer_id: Uuid::new_v4(),
+            title: "Unrated".into(),
+            description: None,
+            location: "L".into(),
+            start_time: DateTime::default(),
+            end_time: None,
+            is_flagged: false,
+            sum_of_ratings: 0,
+            count_of_ratings: 0,
+            created_at: DateTime::default(),
+            updated_at: DateTime::default(),
+            image_url: None,
+            is_free: false,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert!(json["average_rating"].is_null());
     }
 }


### PR DESCRIPTION
## Summary
Adds the computed `average_rating` field to the serialized `Event` JSON via a custom `Serialize` impl, so it appears in both the event list and event detail responses. Returns `null` when the event has no ratings.

## Validation
- `cargo fmt` (clean for changed file)
- Added unit tests verifying `average_rating` serializes to the computed value and to `null` when no ratings exist.

Note: the crate has two pre-existing compile errors on `main` unrelated to this change (`list_featured_events` missing in `routes/mod.rs`; undefined `start` in `search_events`); left untouched per scope.

Closes #584