### PR TITLE
feat(server): add GET /api/v1/events/upcoming shortcut endpoint

### DIFF
--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -587,6 +587,18 @@ mod tests {
     }
 
     #[test]
+    fn test_upcoming_limit_clamping() {
+        // Default when absent.
+        assert_eq!(None::<u32>.unwrap_or(5).clamp(1, 20), 5);
+        // Values above the max are clamped to 20.
+        assert_eq!(Some(100u32).unwrap_or(5).clamp(1, 20), 20);
+        // Zero is clamped up to the minimum of 1.
+        assert_eq!(Some(0u32).unwrap_or(5).clamp(1, 20), 1);
+        // In-range values pass through.
+        assert_eq!(Some(10u32).unwrap_or(5).clamp(1, 20), 10);
+    }
+
+    #[test]
     fn test_search_params_ticket_type() {
         let params = SearchParams {
             q: None,
@@ -884,6 +896,48 @@ pub async fn list_events(
         resp.headers_mut().insert("X-Total-Count", v);
     }
     resp
+}
+
+/// Query parameters for `GET /api/v1/events/upcoming`.
+#[derive(Debug, Deserialize)]
+pub struct UpcomingParams {
+    /// Number of events to return (clamped to 1–20, default 5).
+    pub limit: Option<u32>,
+}
+
+/// List the next upcoming events ordered by `start_time ASC`.
+///
+/// A simplified feed for home pages and the mobile app — no cursor contract,
+/// just a single `limit` parameter.
+///
+/// # Endpoint
+/// GET `/api/v1/events/upcoming`
+///
+/// # Query Parameters
+/// - `limit` (optional): Number of events to return (1–20, default 5)
+pub async fn list_upcoming_events(
+    State(state): State<EventState>,
+    Query(params): Query<UpcomingParams>,
+) -> Response {
+    // Clamp limit to 1–20, defaulting to 5.
+    let limit = params.limit.unwrap_or(5).clamp(1, 20) as i64;
+
+    let mut events = match sqlx::query_as::<_, Event>(
+        "SELECT * FROM events WHERE end_time > NOW() AND is_flagged = FALSE ORDER BY start_time ASC LIMIT $1",
+    )
+    .bind(limit)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(events) => events,
+        Err(e) => {
+            tracing::error!("Failed to fetch upcoming events: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    populate_is_free(&mut events, &state.pool).await;
+    success(events, "Upcoming events retrieved successfully").into_response()
 }
 
 /// List completed events with cursor-based pagination and optional filters.

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -42,8 +42,8 @@ use crate::handlers::{
         export_attendees_csv, get_attendee_count, get_checkin_stats, get_event, get_event_counts,
         get_event_organizer, get_event_share_link, get_event_social_proof, get_ratings_summary,
         list_event_tickets, list_events, list_events_by_category, list_past_events,
-        list_similar_events, list_ticket_tiers, search_events, submit_event_rating,
-        toggle_event_flag, EventState,
+        list_similar_events, list_ticket_tiers, list_upcoming_events, search_events,
+        submit_event_rating, toggle_event_flag, EventState,
     },
     example_empty_success, example_not_found, example_validation_error,
     health::{health_check, health_check_blockchain, health_check_db, health_check_ready},
@@ -155,6 +155,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/count", get(get_event_counts))
         .route("/featured", get(list_featured_events))
         .route("/past", get(list_past_events))
+        .route("/upcoming", get(list_upcoming_events))
         .route("/search", get(search_events))
         .route("/:id", get(get_event))
         .route("/:id/attendees/count", get(get_attendee_count))


### PR DESCRIPTION
## Summary
Adds a simplified `GET /api/v1/events/upcoming?limit=N` endpoint returning the next upcoming events ordered by `start_time ASC`, with no cursor contract. `limit` defaults to 5 and is clamped to 1–20. Flagged and ended events are excluded.

## Validation
- `cargo check` introduces no new errors (only two pre-existing `main` errors remain: `list_featured_events` missing in `routes/mod.rs`; undefined `start` in `search_events`).
- Added a unit test for the limit clamping behaviour.

Closes #585