### PR TITLE
feat(server): log organizer wallet in audit metadata for toggle-flag

### DIFF
--- a/server/migrations/20260625000001_add_metadata_to_audit_logs.sql
+++ b/server/migrations/20260625000001_add_metadata_to_audit_logs.sql
@@ -1,0 +1,3 @@
+-- Add a metadata JSONB column to audit_logs for action-specific context,
+-- e.g. the organizer wallet affected by an admin toggle-flag action (Issue #586).
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS metadata JSONB;

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use axum::http::HeaderValue;
 use crate::cache::RedisCache;
+use crate::middleware::audit::AuditMetadata;
 use crate::models::event::{populate_is_free, Event};
 use crate::models::organizer_profile::OrganizerProfile;
 use crate::utils::cursor_pagination::{
@@ -1651,23 +1652,28 @@ pub async fn toggle_event_flag(
     State(mut state): State<EventState>,
     Path(event_id): Path<Uuid>,
 ) -> Response {
-    // Fetch current flag status
-    let current_flagged =
-        match sqlx::query_scalar::<_, bool>("SELECT is_flagged FROM events WHERE id = $1")
-            .bind(event_id)
-            .fetch_optional(&state.pool)
-            .await
-        {
-            Ok(Some(flagged)) => flagged,
-            Ok(None) => {
-                return AppError::NotFound(format!("Event with id '{}' not found", event_id))
-                    .into_response();
-            }
-            Err(e) => {
-                tracing::error!("Failed to fetch event flag status: {:?}", e);
-                return AppError::DatabaseError(e).into_response();
-            }
-        };
+    // Fetch current flag status and the affected event's organizer wallet so the
+    // audit log can record who was impacted by the moderation action (Issue #586).
+    let (current_flagged, organizer_wallet) = match sqlx::query_as::<_, (bool, Option<String>)>(
+        "SELECT e.is_flagged, o.wallet_address
+         FROM events e
+         LEFT JOIN organizers o ON o.id = e.organizer_id
+         WHERE e.id = $1",
+    )
+    .bind(event_id)
+    .fetch_optional(&state.pool)
+    .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return AppError::NotFound(format!("Event with id '{}' not found", event_id))
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch event flag status: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
 
     // Toggle the flag
     let new_flagged = !current_flagged;
@@ -1687,11 +1693,20 @@ pub async fn toggle_event_flag(
         tracing::warn!("Failed to invalidate cache for event {}: {:?}", event_id, e);
     }
 
-    success(
+    let mut response = success(
         serde_json::json!({ "is_flagged": new_flagged }),
         "Event flag toggled successfully",
     )
-    .into_response()
+    .into_response();
+
+    // Attach the organizer wallet so the audit middleware records it in metadata.
+    if let Some(wallet) = organizer_wallet {
+        response.extensions_mut().insert(AuditMetadata(
+            serde_json::json!({ "organizer_wallet": wallet }),
+        ));
+    }
+
+    response
 }
 
 /// Revenue summary response for an event

--- a/server/src/middleware/audit.rs
+++ b/server/src/middleware/audit.rs
@@ -16,6 +16,12 @@ use serde_json::Value;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+/// Action-specific context a handler can attach to its response so the audit
+/// layer records it in the `metadata` column. Insert it into the response
+/// extensions, e.g. `response.extensions_mut().insert(AuditMetadata(json))`.
+#[derive(Clone, Debug)]
+pub struct AuditMetadata(pub Value);
+
 /// Axum middleware that records every admin request to `audit_logs`.
 ///
 /// Attach via `axum::middleware::from_fn_with_state` on the admin router.
@@ -49,6 +55,12 @@ pub async fn audit_layer(State(pool): State<PgPool>, request: Request, next: Nex
     let response = next.run(request).await;
     let status_code = response.status().as_u16() as i32;
 
+    // Pick up any handler-supplied metadata from the response extensions.
+    let metadata = response
+        .extensions()
+        .get::<AuditMetadata>()
+        .map(|m| m.0.clone());
+
     // Derive a human-readable action from the method + path.
     let action = derive_action(&method, &path);
 
@@ -66,6 +78,7 @@ pub async fn audit_layer(State(pool): State<PgPool>, request: Request, next: Nex
             request_body,
             ip_clone,
             status_code,
+            metadata,
         )
         .await
         {
@@ -92,6 +105,7 @@ fn derive_action(method: &str, path: &str) -> String {
     format!("admin.{base}.{verb}")
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn persist_audit_log(
     pool: &PgPool,
     action: &str,
@@ -100,12 +114,13 @@ async fn persist_audit_log(
     request_body: Option<Value>,
     ip_address: Option<String>,
     status_code: i32,
+    metadata: Option<Value>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
         INSERT INTO audit_logs
-            (id, action, request_path, request_method, request_body, ip_address, status_code)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+            (id, action, request_path, request_method, request_body, ip_address, status_code, metadata)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         "#,
     )
     .bind(Uuid::new_v4())
@@ -115,7 +130,19 @@ async fn persist_audit_log(
     .bind(request_body)
     .bind(ip_address)
     .bind(status_code)
+    .bind(metadata)
     .execute(pool)
     .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_audit_metadata_holds_organizer_wallet() {
+        let metadata = AuditMetadata(serde_json::json!({ "organizer_wallet": "GABC123" }));
+        assert_eq!(metadata.0["organizer_wallet"], "GABC123");
+    }
 }


### PR DESCRIPTION
## Summary
Records the affected event's `organizer_wallet` in the audit log for admin `toggle-flag` actions.

- New migration adds a `metadata JSONB` column to `audit_logs`.
- `toggle_event_flag` now fetches the organizer wallet (via a join on `organizers`) and attaches it to the response via a new `AuditMetadata` response extension.
- The audit middleware reads that extension and persists it to `audit_logs.metadata`.

## Validation
- `cargo check` introduces no new errors (only two pre-existing `main` errors remain: `list_featured_events` missing in `routes/mod.rs`; undefined `start` in `search_events`).
- Added a unit test for the metadata payload.

Closes #586