### PR TITLE
feat(contract): enforce max 20 tiers per event in register_event

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -49,12 +49,12 @@ pub enum EventRegistryError {
     StateError = 46,
     MultisigError = 47,
     ProposalAlreadyCancelled = 49,
-    InvalidTargetDeadline = 54,
     DeadlineAfterEndTime = 55,
     PerUserLimitExceeded = 60,
     InvalidDeadline = 61,
     InvalidCategoryId = 71,
     AlreadyOnWaitlist = 75,
+    TooManyTiers = 80,
 }
 
 impl core::fmt::Display for EventRegistryError {
@@ -182,7 +182,7 @@ impl core::fmt::Display for EventRegistryError {
             EventRegistryError::ProposalAlreadyCancelled => {
                 write!(f, "Proposal has already been cancelled")
             }
-            EventRegistryError::InvalidTargetDeadline | EventRegistryError::InvalidDeadline => {
+            EventRegistryError::InvalidDeadline => {
                 write!(f, "Target deadline must be in the future")
             }
             EventRegistryError::DeadlineAfterEndTime => {
@@ -199,6 +199,9 @@ impl core::fmt::Display for EventRegistryError {
             }
             EventRegistryError::AlreadyOnWaitlist => {
                 write!(f, "User is already on the waitlist for this event")
+            }
+            EventRegistryError::TooManyTiers => {
+                write!(f, "Event exceeds the maximum number of ticket tiers")
             }
         }
     }

--- a/contract/contracts/event_registry/src/issue_tests.rs
+++ b/contract/contracts/event_registry/src/issue_tests.rs
@@ -23,20 +23,40 @@ fn metadata_cid(env: &Env) -> String {
 }
 
 fn event_args(env: &Env, event_id: &str, organizer: &Address) -> EventRegistrationArgs {
+    event_args_with_tier_count(env, event_id, organizer, 1)
+}
+
+fn tier_id_for_index(env: &Env, i: u32) -> String {
+    const IDS: [&str; 21] = [
+        "tier_00", "tier_01", "tier_02", "tier_03", "tier_04", "tier_05", "tier_06", "tier_07",
+        "tier_08", "tier_09", "tier_10", "tier_11", "tier_12", "tier_13", "tier_14", "tier_15",
+        "tier_16", "tier_17", "tier_18", "tier_19", "tier_20",
+    ];
+    String::from_str(env, IDS[i as usize])
+}
+
+fn event_args_with_tier_count(
+    env: &Env,
+    event_id: &str,
+    organizer: &Address,
+    tier_count: u32,
+) -> EventRegistrationArgs {
     let mut tiers = Map::new(env);
-    tiers.set(
-        String::from_str(env, "general"),
-        TicketTier {
-            name: String::from_str(env, "General"),
-            price: 1000,
-            tier_limit: 100,
-            current_sold: 0,
-            is_refundable: true,
-            auction_config: Vec::new(env),
-            loyalty_multiplier: 1,
-            max_per_user: 0,
-        },
-    );
+    for i in 0..tier_count {
+        tiers.set(
+            tier_id_for_index(env, i),
+            TicketTier {
+                name: String::from_str(env, "General"),
+                price: 1000,
+                tier_limit: 100,
+                current_sold: 0,
+                is_refundable: true,
+                auction_config: Vec::new(env),
+                loyalty_multiplier: 1,
+                max_per_user: 0,
+            },
+        );
+    }
 
     EventRegistrationArgs {
         event_id: String::from_str(env, event_id),
@@ -44,7 +64,7 @@ fn event_args(env: &Env, event_id: &str, organizer: &Address) -> EventRegistrati
         organizer_address: organizer.clone(),
         payment_address: Address::generate(env),
         metadata_cid: metadata_cid(env),
-        max_supply: 100,
+        max_supply: (tier_count as i128) * 100,
         milestone_plan: None,
         tiers,
         refund_deadline: 0,
@@ -105,6 +125,37 @@ fn store_event_without_auth(env: &Env, contract_id: &Address, event_id: &str, or
     };
 
     env.as_contract(contract_id, || storage::store_event(env, event));
+}
+
+#[test]
+fn test_register_event_too_many_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _contract_id) = setup(&env);
+    let organizer = Address::generate(&env);
+
+    let result = client.try_register_event(&event_args_with_tier_count(
+        &env,
+        "too_many_tiers_event",
+        &organizer,
+        21,
+    ));
+    assert_eq!(result, Err(Ok(EventRegistryError::TooManyTiers)));
+
+    client.register_event(&event_args_with_tier_count(
+        &env,
+        "max_tiers_event",
+        &organizer,
+        20,
+    ));
+    assert_eq!(
+        client
+            .get_event(&String::from_str(&env, "max_tiers_event"))
+            .unwrap()
+            .tiers
+            .len(),
+        20
+    );
 }
 
 #[test]

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -27,6 +27,9 @@ use crate::types::{SeriesPass, SeriesRegistry};
 
 use crate::error::EventRegistryError;
 
+/// Maximum number of ticket tiers allowed per event during registration.
+const MAX_TIERS_PER_EVENT: u32 = 20;
+
 #[contract]
 pub struct EventRegistry;
 
@@ -212,6 +215,10 @@ impl EventRegistry {
 
         if storage::event_exists(&env, args.event_id.clone()) {
             return Err(EventRegistryError::EventAlreadyExists);
+        }
+
+        if args.tiers.len() > MAX_TIERS_PER_EVENT {
+            return Err(EventRegistryError::TooManyTiers);
         }
 
         // Validate tier limits don't exceed max_supply


### PR DESCRIPTION
## Summary

Enforces a maximum of 20 ticket tiers per event in `EventRegistry::register_event` to prevent organizers from submitting oversized tier maps that could exceed Soroban per-transaction instruction limits.

- Return `EventRegistryError::TooManyTiers` (code `80`) when `args.tiers.len() > 20`
- Add `MAX_TIERS_PER_EVENT` constant and validate before existing tier supply checks
- Add boundary test: 21 tiers fails, 20 tiers succeeds

## Notes

Removed unused `InvalidTargetDeadline` (`54`) to stay within Soroban's 50-variant XDR error spec limit. `InvalidDeadline` (`61`) remains and covers the same case in contract code.

Closes #893

## Test plan

- [x] `cargo test -p event-registry test_register_event_too_many_tiers`
- [x] `cargo test -p event-registry` (all 13 tests pass)
- [ ] Register an event with 20 tiers via integration/UI flow
- [ ] Confirm registration with 21 tiers is rejected with `TooManyTiers`