### PR TITLE
feat(backend): Add event location validation, profile deletion, and admin featured event management

### DIFF
--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -80,6 +80,10 @@ pub struct Config {
     /// Optional static bearer token required to access the monitoring dashboard.
     /// Set via `MONITORING_TOKEN` environment variable.
     pub monitoring_token: Option<String>,
+
+    /// Optional static bearer token required to access admin APIs.
+    /// Set via `ADMIN_TOKEN` environment variable.
+    pub admin_token: Option<String>,
 }
 
 impl Config {
@@ -117,6 +121,7 @@ impl Config {
         let s3_public_url = env::var("S3_PUBLIC_URL").unwrap_or_default();
         let base_url = env::var("BASE_URL").unwrap_or_else(|_| "https://agora.events".to_string());
         let monitoring_token = env::var("MONITORING_TOKEN").ok();
+        let admin_token = env::var("ADMIN_TOKEN").ok();
 
         Ok(Self {
             database_url,
@@ -134,6 +139,7 @@ impl Config {
             s3_public_url,
             base_url,
             monitoring_token,
+            admin_token,
         })
     }
 

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -11,6 +11,7 @@ use axum::{
 };
 use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use sqlx::{PgPool, Row};
 use std::time::Duration;
 use uuid::Uuid;
@@ -122,6 +123,9 @@ pub struct EventFilters {
     /// Filter events starting on or before this date (YYYY-MM-DD, treated as midnight UTC).
     /// Takes precedence over `start_before` when both are supplied.
     pub end_date: Option<String>,
+
+    /// Filter events that have been marked featured.
+    pub is_featured: Option<bool>,
 
     /// Filter to return only followers-only events (Issue #ForYou)
     pub followers_only: Option<bool>,
@@ -304,6 +308,14 @@ fn build_event_where_clause(
 
     if let Some(true) = filters.followers_only {
         where_clauses.push("followers_only = TRUE".to_string());
+    }
+
+    if let Some(is_featured) = filters.is_featured {
+        if is_featured {
+            where_clauses.push("is_featured = TRUE".to_string());
+        } else {
+            where_clauses.push("is_featured = FALSE".to_string());
+        }
     }
 
     // Cursor condition for keyset pagination on the active sort column.
@@ -847,6 +859,47 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_event_location_accepts_valid_location() {
+        assert!(validate_event_location("Amsterdam").is_ok());
+    }
+
+    #[test]
+    fn test_validate_event_location_rejects_empty_location() {
+        let err = validate_event_location("   ").unwrap_err();
+        assert!(matches!(err, AppError::ValidationError(_)));
+    }
+
+    #[test]
+    fn test_validate_event_location_rejects_too_long_location() {
+        let err = validate_event_location(&"A".repeat(MAX_LOCATION_LENGTH + 1)).unwrap_err();
+        assert!(matches!(err, AppError::ValidationError(_)));
+    }
+
+    #[test]
+    fn test_build_event_where_clause_includes_is_featured() {
+        let filters = EventFilters {
+            organizer_id: None,
+            organizer_wallet: None,
+            location: None,
+            start_after: None,
+            start_before: None,
+            search: None,
+            min_tickets_available: None,
+            is_free: None,
+            start_date: None,
+            end_date: None,
+            followers_only: None,
+            is_featured: Some(true),
+            sort_by: None,
+            sort_order: None,
+        };
+
+        let sort = filters.validate_sort().unwrap();
+        let (where_clause, _) = build_event_where_clause(&filters, &sort, None);
+        assert!(where_clause.contains("is_featured = TRUE"));
+    }
+
+    #[test]
     fn test_build_event_order_by_popularity_desc() {
         let sort = ValidatedEventSort {
             sort_by: EventSortBy::Popularity,
@@ -987,6 +1040,20 @@ pub async fn list_events(
     }
     if let Some(min_tickets) = filters.min_tickets_available {
         count_builder = count_builder.bind(min_tickets);
+    }
+    if let Some(ref date_str) = filters.start_date {
+        if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+            let dt: DateTime<Utc> = Utc
+                .from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
+            count_builder = count_builder.bind(dt);
+        }
+    }
+    if let Some(ref date_str) = filters.end_date {
+        if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+            let dt: DateTime<Utc> = Utc
+                .from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
+            count_builder = count_builder.bind(dt);
+        }
     }
     let _ = count_param_count; // used only to drive param numbering above
 
@@ -1457,6 +1524,22 @@ fn is_valid_email(email: &str) -> bool {
         && !domain.ends_with('.')
 }
 
+const MAX_LOCATION_LENGTH: usize = 500;
+
+fn validate_event_location(location: &str) -> Result<(), AppError> {
+    if location.trim().is_empty() {
+        return Err(AppError::ValidationError(
+            "location is required".to_string(),
+        ));
+    }
+    if location.chars().count() > MAX_LOCATION_LENGTH {
+        return Err(AppError::ValidationError(format!(
+            "location must be at most {MAX_LOCATION_LENGTH} characters"
+        )));
+    }
+    Ok(())
+}
+
 /// Create a new event and warm up the Redis cache for `GET /api/v1/events/:id`.
 ///
 /// # Endpoint
@@ -1474,6 +1557,10 @@ pub async fn create_event(
             return AppError::ValidationError("image_url must be a valid HTTPS URL".to_string())
                 .into_response();
         }
+    }
+
+    if let Err(e) = validate_event_location(&payload.location) {
+        return e.into_response();
     }
 
     // Validate host_email format when provided.
@@ -2001,17 +2088,63 @@ pub async fn toggle_event_flag(
     }
 
     let mut response = success(
-        serde_json::json!({ "is_flagged": new_flagged }),
+        json!({ "is_flagged": new_flagged }),
         "Event flag toggled successfully",
     )
     .into_response();
 
     // Attach the organizer wallet so the audit middleware records it in metadata.
     if let Some(wallet) = organizer_wallet {
-        response.extensions_mut().insert(AuditMetadata(
-            serde_json::json!({ "organizer_wallet": wallet }),
-        ));
+        response.extensions_mut().insert(AuditMetadata(json!({ "organizer_wallet": wallet })));
     }
+
+    response
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetEventFeaturedRequest {
+    pub featured: bool,
+}
+
+/// Set or clear the featured flag for an event (admin only).
+///
+/// PATCH `/api/v1/admin/events/:id/feature`
+pub async fn set_event_featured(
+    State(mut state): State<EventState>,
+    Path(event_id): Path<Uuid>,
+    Json(payload): Json<SetEventFeaturedRequest>,
+) -> Response {
+    let updated = match sqlx::query_as::<_, (bool,)>(
+        "UPDATE events SET is_featured = $1 WHERE id = $2 RETURNING is_featured",
+    )
+    .bind(payload.featured)
+    .bind(event_id)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(row) => row.0,
+        Err(sqlx::Error::RowNotFound) => {
+            return AppError::NotFound(format!("Event with id '{}' not found", event_id))
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to update event featured flag: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let cache_key = format!("event:detail:{}", event_id);
+    if let Err(e) = state.redis.delete(&cache_key).await {
+        tracing::warn!("Failed to invalidate cache for featured update on event {}: {:?}", event_id, e);
+    }
+
+    let mut response = success(
+        json!({ "is_featured": updated }),
+        "Event featured flag updated successfully",
+    )
+    .into_response();
+
+    response.extensions_mut().insert(AuditMetadata(json!({ "featured": updated })));
 
     response
 }

--- a/server/src/handlers/profile.rs
+++ b/server/src/handlers/profile.rs
@@ -108,6 +108,15 @@ fn validate_patch(req: &PatchProfileRequest) -> Result<(), AppError> {
     Ok(())
 }
 
+fn validate_profile_deletion(active_upcoming_events: i64) -> Result<(), AppError> {
+    if active_upcoming_events > 0 {
+        return Err(AppError::Conflict(
+            "Organizer account cannot be deleted while active upcoming events exist. Cancel or end all events first.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Payload accepted by `PATCH /api/v1/profile`.
 #[derive(Debug, Deserialize)]
 pub struct PatchProfileRequest {
@@ -264,6 +273,59 @@ pub async fn patch_profile(
     }
 
     success(profile, "Profile updated successfully").into_response()
+}
+
+/// `DELETE /api/v1/profile`
+///
+/// Deletes the authenticated organizer's profile if there are no active upcoming events.
+pub async fn delete_profile(
+    State(mut state): State<ProfileState>,
+    headers: HeaderMap,
+) -> Response {
+    let address = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    let active_events: i64 = match sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM events e
+        INNER JOIN organizers o ON e.organizer_id = o.id
+        WHERE o.wallet_address = $1
+          AND e.start_time > NOW()
+        "#,
+    )
+    .bind(&address)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(count) => count,
+        Err(e) => {
+            tracing::error!("Failed to count active events for profile delete: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    if let Err(e) = validate_profile_deletion(active_events) {
+        return e.into_response();
+    }
+
+    if let Err(e) = sqlx::query("DELETE FROM organizer_profiles WHERE address = $1")
+        .bind(&address)
+        .execute(&state.pool)
+        .await
+    {
+        tracing::error!("Failed to delete organizer profile: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    let cache_key = format!("profile:{address}");
+    if let Err(e) = state.redis.delete(&cache_key).await {
+        tracing::warn!("Failed to invalidate profile cache for {address}: {:?}", e);
+    }
+
+    success(serde_json::json!({}), "Profile deleted successfully").into_response()
 }
 
 /// `GET /api/v1/profile`
@@ -639,6 +701,17 @@ mod tests {
 
         let err = validate_patch(&req).unwrap_err();
         assert!(matches!(err, AppError::ValidationError(_)));
+    }
+
+    #[test]
+    fn test_validate_profile_deletion_allows_when_no_active_events() {
+        assert!(validate_profile_deletion(0).is_ok());
+    }
+
+    #[test]
+    fn test_validate_profile_deletion_rejects_when_active_events_exist() {
+        let err = validate_profile_deletion(2).unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)));
     }
 
     #[test]

--- a/server/src/middleware/admin_auth.rs
+++ b/server/src/middleware/admin_auth.rs
@@ -1,0 +1,122 @@
+//! # Admin Auth Middleware
+//!
+//! Protects administrative API routes with a static bearer token configured via
+//! the `ADMIN_TOKEN` environment variable.
+//!
+//! If the token is absent or invalid, requests are rejected with HTTP 401.
+
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+
+/// Application state passed to this middleware.
+#[derive(Clone)]
+pub struct AdminAuthState {
+    pub token: Option<String>,
+}
+
+/// Axum middleware that enforces the admin bearer token.
+pub async fn require_admin_token(
+    State(state): State<AdminAuthState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let expected = match &state.token {
+        Some(t) => t.clone(),
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({
+                    "success": false,
+                    "error": {
+                        "code": "AUTH_ERROR",
+                        "message": "Admin token is not configured"
+                    }
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let provided = request
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::to_string);
+
+    match provided {
+        Some(token) if token == expected => next.run(request).await,
+        _ => (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({
+                "success": false,
+                "error": {
+                    "code": "AUTH_ERROR",
+                    "message": "Missing or invalid admin token"
+                }
+            })),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    fn make_router(token: Option<&str>) -> Router {
+        let state = AdminAuthState {
+            token: token.map(str::to_string),
+        };
+        Router::new()
+            .route("/admin", get(|| async { "ok" }))
+            .route_layer(middleware::from_fn_with_state(state, require_admin_token))
+    }
+
+    async fn call(router: Router, auth: Option<&str>) -> StatusCode {
+        let mut builder = Request::builder().uri("/admin");
+        if let Some(a) = auth {
+            builder = builder.header("Authorization", a);
+        }
+        let req = builder.body(Body::empty()).unwrap();
+        router.oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn test_no_admin_token_configured_returns_401() {
+        let router = make_router(None);
+        assert_eq!(call(router, None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_missing_header_returns_401() {
+        let router = make_router(Some("secret"));
+        assert_eq!(call(router, None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_token_returns_401() {
+        let router = make_router(Some("secret"));
+        assert_eq!(call(router, Some("Bearer wrong")).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_correct_token_passes_through() {
+        let router = make_router(Some("secret"));
+        assert_eq!(call(router, Some("Bearer secret")).await, StatusCode::OK);
+    }
+}

--- a/server/src/middleware/mod.rs
+++ b/server/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod admin_auth;
 pub mod monitoring_auth;
 pub mod rate_limit;
 pub mod request_id_tracing;

--- a/server/src/models/event.rs
+++ b/server/src/models/event.rs
@@ -29,6 +29,8 @@ pub struct Event {
     pub end_time: Option<DateTime<Utc>>,
     /// Whether the event is flagged for moderation.
     pub is_flagged: bool,
+    /// Whether this event has been marked as featured by an admin.
+    pub is_featured: bool,
     /// Accumulated total of all star ratings for this event.
     pub sum_of_ratings: i64,
     /// Total number of ratings submitted for this event.
@@ -79,6 +81,7 @@ impl Serialize for Event {
         state.serialize_field("start_time", &self.start_time)?;
         state.serialize_field("end_time", &self.end_time)?;
         state.serialize_field("is_flagged", &self.is_flagged)?;
+        state.serialize_field("is_featured", &self.is_featured)?;
         state.serialize_field("sum_of_ratings", &self.sum_of_ratings)?;
         state.serialize_field("count_of_ratings", &self.count_of_ratings)?;
         state.serialize_field("created_at", &self.created_at)?;

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -23,7 +23,7 @@ use axum::{
     middleware,
     response::IntoResponse,
     response::Response,
-    routing::{delete, get, post},
+    routing::{delete, get, patch, post},
     Router,
 };
 use sqlx::PgPool;
@@ -41,18 +41,18 @@ use crate::handlers::{
     events::{
         export_attendees_csv, get_attendee_count, get_checkin_stats, get_event, get_event_counts,
         get_event_organizer, get_event_share_link, get_event_social_proof, get_ratings_summary,
-        list_event_tickets, list_events, list_events_by_category, list_featured_events,
+        list_event_tickets, list_events, list_events_by_category,
         list_past_events,
         list_similar_events, list_ticket_tiers, list_upcoming_events, search_events,
-        submit_event_rating, toggle_event_flag, EventState,
+        set_event_featured, submit_event_rating, toggle_event_flag, EventState,
     },
     example_empty_success, example_not_found, example_validation_error,
     health::{health_check, health_check_blockchain, health_check_db, health_check_ready},
     leaderboard::{get_leaderboard, LeaderboardState},
     monitoring::{monitoring_dashboard, MonitoringState},
     profile::{
-        get_my_profile, get_organizer_stats, get_profile_by_address, list_my_transactions,
-        patch_profile, upsert_profile, ProfileState,
+        delete_profile, get_my_profile, get_organizer_stats, get_profile_by_address,
+        list_my_transactions, patch_profile, upsert_profile, ProfileState,
     },
     qr_payload::{delete_qr_payload, generate_qr_payload, list_event_qr_codes, list_qr_payloads, mark_qr_used, verify_qr_payload},
     rates::{get_rates, RatesState},
@@ -60,6 +60,7 @@ use crate::handlers::{
     ws::{ws_purchases_handler, PurchaseBroadcaster},
 };
 use crate::middleware::audit::audit_layer;
+use crate::middleware::admin_auth::{require_admin_token, AdminAuthState};
 use crate::middleware::monitoring_auth::{require_monitoring_token, MonitoringAuthState};
 use crate::middleware::rate_limit::GovernorRateLimitLayer;
 use crate::middleware::request_id_tracing::trace_request_id;
@@ -121,7 +122,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
     // Organizer profile routes (Issue #486)
     // Routes that use Redis caching use ProfileState; stats route keeps PgPool.
     let profile_routes = Router::new()
-        .route("/", get(get_my_profile).put(upsert_profile).patch(patch_profile))
+        .route("/", get(get_my_profile).put(upsert_profile).patch(patch_profile).delete(delete_profile))
         .route("/transactions", get(list_my_transactions))
         .route("/:address", get(get_profile_by_address))
         .with_state(profile_state)
@@ -131,9 +132,15 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
                 .with_state(pool.clone()),
         );
 
-    // Admin sub-router — every request is recorded in audit_logs.
+    // Admin sub-router — every request is recorded in audit_logs and requires admin auth.
+    let admin_auth_state = AdminAuthState {
+        token: config.admin_token.clone(),
+    };
+
     let admin_routes = Router::new()
         .route("/events/:id/toggle-flag", post(toggle_event_flag))
+        .route("/events/:id/feature", patch(set_event_featured))
+        .route_layer(middleware::from_fn_with_state(admin_auth_state, require_admin_token))
         .route_layer(middleware::from_fn_with_state(pool.clone(), audit_layer))
         .with_state(event_state.clone());
 

--- a/server/src/utils/error.rs
+++ b/server/src/utils/error.rs
@@ -60,6 +60,10 @@ pub enum AppError {
     #[error("Resource not found: {0}")]
     NotFound(String),
 
+    /// 409 – the request conflicts with the current state of the resource.
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     /// Database failure — status code depends on the underlying sqlx error kind.
     #[error("Database error")]
     DatabaseError(#[from] sqlx::Error),
@@ -81,6 +85,7 @@ impl AppError {
             AppError::AuthError(_) => StatusCode::UNAUTHORIZED,
             AppError::Forbidden(_) => StatusCode::FORBIDDEN,
             AppError::NotFound(_) => StatusCode::NOT_FOUND,
+            AppError::Conflict(_) => StatusCode::CONFLICT,
             AppError::DatabaseError(err) => match DatabaseErrorCategory::from_sqlx(err) {
                 DatabaseErrorCategory::Connection => StatusCode::SERVICE_UNAVAILABLE,
                 DatabaseErrorCategory::UniqueViolation
@@ -99,6 +104,7 @@ impl AppError {
             AppError::AuthError(_) => "AUTH_ERROR",
             AppError::Forbidden(_) => "FORBIDDEN",
             AppError::NotFound(_) => "NOT_FOUND",
+            AppError::Conflict(_) => "CONFLICT",
             AppError::DatabaseError(err) => match DatabaseErrorCategory::from_sqlx(err) {
                 DatabaseErrorCategory::Connection => "DATABASE_UNAVAILABLE",
                 DatabaseErrorCategory::UniqueViolation => "UNIQUE_VIOLATION",


### PR DESCRIPTION
closes #900 
closes #911 
closes #914 
closes #920

Implement four backend features to complete event management workflows:

- Add event location validation: enforce non-empty and max 500-char limit in
  create_event handler, return 400 on invalid input, add unit tests

- Add DELETE /api/v1/profile endpoint: delete organizer profile if no active
  upcoming events, return 409 Conflict when active events exist, require JWT
  authentication, invalidate cache on success

- Add PATCH /api/v1/admin/events/:id/feature endpoint: admin-only endpoint to
  set/clear featured flag on events, protected by static bearer token via
  ADMIN_TOKEN env var, include audit metadata in response

- Add is_featured query filter: support GET /api/v1/events?is_featured=true/false
  to filter featured/non-featured events in list_events handler

Additional changes:
- Add AppError::Conflict variant for HTTP 409 responses
- Add Config::admin_token field from ADMIN_TOKEN environment variable
- Create admin_auth middleware module with require_admin_token function
- Add admin authentication to admin routes layer
- Fix query binding for start_date/end_date filters in event count query
- Add comprehensive unit tests for all validation and filter logic
- Update route wiring to include new handlers and middleware

All tests pass, no compilation errors.