### PR TITLE
Fix loyalty multipliers, promo view, stats query, and healthchecks

### DIFF
--- a/contract/contracts/event_registry/src/issue_tests.rs
+++ b/contract/contracts/event_registry/src/issue_tests.rs
@@ -1,7 +1,10 @@
 use crate::error::EventRegistryError;
 use crate::types::{EventInfo, EventRegistrationArgs, EventStatus, TicketTier};
 use crate::{storage, EventRegistry, EventRegistryClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, Map, String, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, Map, String, Vec,
+};
 
 fn setup(env: &Env) -> (EventRegistryClient<'static>, Address, Address) {
     let contract_id = env.register(EventRegistry, ());
@@ -300,6 +303,62 @@ fn test_set_global_promo_expired() {
     client.set_global_promo(&2500, &expired_at);
 
     assert_eq!(client.get_global_promo_bps(), 0);
+}
+
+#[test]
+fn test_get_global_promo_returns_none_when_unset() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _contract_id) = setup(&env);
+
+    assert_eq!(client.get_global_promo(), None);
+}
+
+#[test]
+fn test_get_global_promo_returns_none_when_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _contract_id) = setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    client.set_global_promo(&500, &999);
+
+    assert_eq!(client.get_global_promo(), None);
+}
+
+#[test]
+fn test_get_global_promo_returns_active_discount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _contract_id) = setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    client.set_global_promo(&750, &2_000);
+
+    assert_eq!(client.get_global_promo(), Some((750, 2_000)));
+}
+
+#[test]
+fn test_update_loyalty_score_applies_tier_multiplier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _contract_id) = setup(&env);
+
+    let standard_guest = Address::generate(&env);
+    let vip_guest = Address::generate(&env);
+    let zero_multiplier_guest = Address::generate(&env);
+
+    client.update_loyalty_score(&admin, &standard_guest, &1, &100i128, &1);
+    client.update_loyalty_score(&admin, &vip_guest, &1, &100i128, &2);
+    client.update_loyalty_score(&admin, &zero_multiplier_guest, &1, &100i128, &0);
+
+    let standard = client.get_guest_profile(&standard_guest).unwrap();
+    let vip = client.get_guest_profile(&vip_guest).unwrap();
+    let zero_multiplier = client.get_guest_profile(&zero_multiplier_guest).unwrap();
+
+    assert_eq!(standard.loyalty_score, 10);
+    assert_eq!(vip.loyalty_score, 20);
+    assert_eq!(zero_multiplier.loyalty_score, 10);
 }
 
 #[test]

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -946,6 +946,16 @@ impl EventRegistry {
         storage::get_global_promo_bps(&env)
     }
 
+    /// Returns the active global promotional discount and expiry timestamp.
+    pub fn get_global_promo(env: Env) -> Option<(u32, u64)> {
+        let expiry = storage::get_promo_expiry(&env);
+        if expiry <= env.ledger().timestamp() {
+            return None;
+        }
+
+        Some((storage::get_global_promo_bps(&env), expiry))
+    }
+
     /// Returns the expiry timestamp for the current global promo.
     pub fn get_promo_expiry(env: Env) -> u64 {
         storage::get_promo_expiry(&env)
@@ -1330,12 +1340,14 @@ impl EventRegistry {
     /// * `guest` - Guest wallet address
     /// * `tickets_purchased` - Number of tickets purchased in this transaction
     /// * `amount_spent` - Amount spent in this transaction (in token stroops)
+    /// * `loyalty_multiplier` - Tier multiplier for loyalty points; 0 is treated as 1x
     pub fn update_loyalty_score(
         env: Env,
         caller: Address,
         guest: Address,
         tickets_purchased: u32,
         amount_spent: i128,
+        loyalty_multiplier: u32,
     ) -> Result<(), EventRegistryError> {
         caller.require_auth();
 
@@ -1365,8 +1377,15 @@ impl EventRegistry {
             last_updated: 0,
         });
 
-        // Award 10 points per ticket purchased
-        let points_earned = (tickets_purchased as u64).saturating_mul(10);
+        // Award 10 base points per ticket, adjusted by the tier multiplier.
+        let effective_multiplier = if loyalty_multiplier == 0 {
+            1
+        } else {
+            loyalty_multiplier
+        } as u64;
+        let points_earned = (tickets_purchased as u64)
+            .saturating_mul(10)
+            .saturating_mul(effective_multiplier);
         profile.loyalty_score = profile.loyalty_score.saturating_add(points_earned);
         profile.total_tickets_purchased = profile
             .total_tickets_purchased

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.86
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+WORKDIR /app/server
+EXPOSE 3001
+
+CMD ["cargo", "run", "--bin", "agora-server"]

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,4 +1,27 @@
 services:
+  server:
+    build:
+      context: ..
+      dockerfile: server/Dockerfile
+    container_name: agora_server
+    environment:
+      PORT: 3001
+      DATABASE_URL: postgres://user:password@postgres:5432/agora
+      REDIS_URL: redis://redis:6379
+    ports:
+      - "3001:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3001/api/v1/health >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
   postgres:
     image: postgres:latest
     container_name: agora_postgres
@@ -12,6 +35,17 @@ services:
       - agora_postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U user -d agora"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7
+    container_name: agora_redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/server/src/handlers/profile.rs
+++ b/server/src/handlers/profile.rs
@@ -419,7 +419,7 @@ async fn fetch_profile_by_address(pool: &PgPool, redis: &mut RedisCache, address
 // Organizer stats endpoint
 // ---------------------------------------------------------------------------
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, FromRow)]
 struct OrganizerStats {
     pub total_events: i64,
     pub total_tickets_sold: i64,
@@ -430,6 +430,20 @@ static STATS_CACHE: Lazy<Mutex<HashMap<String, (Instant, OrganizerStats)>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 const STATS_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+
+fn organizer_stats_query() -> &'static str {
+    r#"
+    SELECT
+        COUNT(*) AS total_events,
+        COALESCE(SUM(e.minted_tickets), 0) AS total_tickets_sold,
+        COALESCE(AVG(CAST(e.sum_of_ratings AS FLOAT) / NULLIF(e.count_of_ratings, 0)), 0)
+            AS average_event_rating
+    FROM events e
+    JOIN organizers o ON e.organizer_id = o.id
+    WHERE o.wallet_address = $1
+      AND e.is_flagged = FALSE
+    "#
+}
 
 /// `GET /api/v1/profile/:address/stats`
 ///
@@ -450,67 +464,16 @@ pub async fn get_organizer_stats(
         }
     }
 
-    // total events
-    let total_events: i64 =
-        match sqlx::query_scalar(organizer_total_events_query())
-            .bind(&address)
-            .fetch_one(&pool)
-            .await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::error!("Failed to query total_events: {:?}", e);
-                return AppError::DatabaseError(e).into_response();
-            }
-        };
-
-    // total tickets sold
-    let total_tickets_sold: i64 = match sqlx::query_scalar(
-        r#"
-        SELECT COALESCE(SUM(e.minted_tickets), 0)
-        FROM events e
-        JOIN organizers o ON e.organizer_id = o.id
-        WHERE o.wallet_address = $1
-          AND e.is_flagged = FALSE
-        "#,
-    )
-    .bind(&address)
-    .fetch_one(&pool)
-    .await
+    let stats: OrganizerStats = match sqlx::query_as(organizer_stats_query())
+        .bind(&address)
+        .fetch_one(&pool)
+        .await
     {
         Ok(v) => v,
         Err(e) => {
-            tracing::error!("Failed to query total_tickets_sold: {:?}", e);
+            tracing::error!("Failed to query organizer stats: {:?}", e);
             return AppError::DatabaseError(e).into_response();
         }
-    };
-
-    // average event rating
-    let average_event_rating: f64 = match sqlx::query_scalar(
-        r#"
-        SELECT COALESCE(AVG(CAST(e.sum_of_ratings AS FLOAT) / NULLIF(e.count_of_ratings, 0)), 0)
-        FROM events e
-        JOIN organizers o ON e.organizer_id = o.id
-        WHERE o.wallet_address = $1
-          AND e.is_flagged = FALSE
-          AND e.count_of_ratings > 0
-        "#,
-    )
-    .bind(&address)
-    .fetch_one(&pool)
-    .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::error!("Failed to query average_event_rating: {:?}", e);
-            return AppError::DatabaseError(e).into_response();
-        }
-    };
-
-    let stats = OrganizerStats {
-        total_events,
-        total_tickets_sold,
-        average_event_rating,
     };
 
     // store in cache
@@ -718,6 +681,19 @@ mod tests {
         assert!(query.contains("JOIN organizers"));
         assert!(query.contains("wallet_address = $1"));
         assert!(query.contains("is_flagged = FALSE"));
+    }
+
+    #[test]
+    fn test_organizer_stats_query_combines_aggregates() {
+        let query = organizer_stats_query();
+
+        assert_eq!(query.matches("SELECT").count(), 1);
+        assert!(query.contains("COUNT(*) AS total_events"));
+        assert!(query.contains("COALESCE(SUM(e.minted_tickets), 0) AS total_tickets_sold"));
+        assert!(query.contains("AVG(CAST(e.sum_of_ratings AS FLOAT) / NULLIF(e.count_of_ratings, 0))"));
+        assert!(query.contains("JOIN organizers"));
+        assert!(query.contains("o.wallet_address = $1"));
+        assert!(query.contains("e.is_flagged = FALSE"));
     }
 
     #[tokio::test]

--- a/server/src/utils/docker_compose_tests.rs
+++ b/server/src/utils/docker_compose_tests.rs
@@ -36,6 +36,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_compose_has_server_service_with_healthcheck() {
+        let compose = load_compose();
+        let server = &compose["services"]["server"];
+        assert!(server.is_mapping(), "services should contain a 'server' entry");
+
+        let healthcheck = &server["healthcheck"];
+        assert!(
+            healthcheck.is_mapping(),
+            "server should define a healthcheck"
+        );
+        let test = healthcheck["test"]
+            .as_sequence()
+            .expect("server healthcheck test should be a sequence");
+        let test_command = test
+            .iter()
+            .filter_map(|value| value.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            test_command.contains("http://localhost:3001/api/v1/health"),
+            "server healthcheck should call the health endpoint"
+        );
+        assert_eq!(healthcheck["interval"].as_str(), Some("30s"));
+        assert_eq!(healthcheck["timeout"].as_str(), Some("5s"));
+        assert_eq!(healthcheck["retries"].as_i64(), Some(3));
+    }
+
+    #[tokio::test]
+    async fn test_compose_has_redis_service_with_healthcheck() {
+        let compose = load_compose();
+        let redis = &compose["services"]["redis"];
+        assert!(redis.is_mapping(), "services should contain a 'redis' entry");
+
+        let healthcheck = &redis["healthcheck"];
+        assert!(healthcheck.is_mapping(), "redis should define a healthcheck");
+        let test = healthcheck["test"]
+            .as_sequence()
+            .expect("redis healthcheck test should be a sequence");
+        assert!(
+            test.iter()
+                .filter_map(|value| value.as_str())
+                .any(|part| part.contains("redis-cli")),
+            "redis healthcheck should use redis-cli"
+        );
+    }
+
+    #[tokio::test]
     async fn test_postgres_env_vars_are_set() {
         let compose = load_compose();
         let required_keys = ["POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"];


### PR DESCRIPTION
PR Description
Adds get_global_promo() to return active global promo discount/expiry or None.
Updates loyalty scoring to apply loyalty_multiplier, treating 0 as 1x.
Replaces three organizer stats DB queries with one aggregate query while preserving cache behavior.
Adds server and Redis healthchecks in server/docker-compose.yml, plus a minimal server/Dockerfile.
Adds focused tests for loyalty multiplier, promo states, combined stats query, cache path, and compose healthchecks.
Validation
cargo test -p event-registry test_update_loyalty_score_applies_tier_multiplier
cargo test -p event-registry test_get_global_promo
cargo test organizer_stats
cargo test docker_compose_tests

closes #915 
closes #916 
closes #918 
closes #921