### PR TITLE
fix: add pagination tests, title validation, and contract reward/feedback guards

### DIFF
--- a/contract/contracts/event_registry/src/issue_tests.rs
+++ b/contract/contracts/event_registry/src/issue_tests.rs
@@ -1,7 +1,7 @@
 use crate::error::EventRegistryError;
 use crate::types::{EventInfo, EventRegistrationArgs, EventStatus, TicketTier};
 use crate::{storage, EventRegistry, EventRegistryClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, Map, String, Vec};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, Map, String, Vec};
 
 fn setup(env: &Env) -> (EventRegistryClient<'static>, Address, Address) {
     let contract_id = env.register(EventRegistry, ());
@@ -309,4 +309,91 @@ fn test_set_global_promo_unauthorized() {
     let (client, _admin, _contract_id) = setup(&env);
 
     client.set_global_promo(&1000, &(env.ledger().timestamp() + 100));
+}
+
+fn event_args_with_end_time(
+    env: &Env,
+    event_id: &str,
+    organizer: &Address,
+    end_time: u64,
+) -> EventRegistrationArgs {
+    let mut args = event_args(env, event_id, organizer);
+    args.end_time = end_time;
+    args
+}
+
+#[test]
+fn test_distribute_staker_rewards_zero_amount_rejects() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _contract_id) = setup(&env);
+
+    let organizer = Address::generate(&env);
+    let stake_amount = 1000_0000000i128;
+    let token_id = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&organizer, &stake_amount);
+
+    client.set_staking_config(&token_id, &stake_amount);
+
+    let token_client = soroban_sdk::token::Client::new(&env, &token_id);
+    token_client.approve(&organizer, &client.address, &stake_amount, &99999);
+    client.stake_collateral(&organizer, &stake_amount);
+
+    let result = client.try_distribute_staker_rewards(&admin, &0i128);
+    assert_eq!(result, Err(Ok(EventRegistryError::InvalidRewardAmount)));
+}
+
+#[test]
+fn test_set_feedback_cid_before_event_ends_rejects() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _contract_id) = setup(&env);
+    let organizer = Address::generate(&env);
+    let event_id = String::from_str(&env, "feedback_early_event");
+    let end_time = env.ledger().timestamp() + 3600;
+
+    client.register_event(&event_args_with_end_time(
+        &env,
+        "feedback_early_event",
+        &organizer,
+        end_time,
+    ));
+
+    let feedback_cid = String::from_str(
+        &env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+    let result = client.try_set_feedback_cid(&event_id, &feedback_cid);
+    assert_eq!(result, Err(Ok(EventRegistryError::EventNotEnded)));
+}
+
+#[test]
+fn test_set_feedback_cid_after_event_ends_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _contract_id) = setup(&env);
+    let organizer = Address::generate(&env);
+    let event_id = String::from_str(&env, "feedback_late_event");
+    let end_time = env.ledger().timestamp() + 100;
+
+    client.register_event(&event_args_with_end_time(
+        &env,
+        "feedback_late_event",
+        &organizer,
+        end_time,
+    ));
+
+    env.ledger().with_mut(|li| li.timestamp = end_time + 1);
+
+    let feedback_cid = String::from_str(
+        &env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+    client.set_feedback_cid(&event_id, &feedback_cid);
+
+    let event_info = client.get_event(&event_id).unwrap();
+    assert_eq!(event_info.feedback_cid, Some(feedback_cid));
 }

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -3,12 +3,12 @@
 use crate::events::{
     AgoraEvent, CollateralStakedEvent, CollateralUnstakedEvent, CustomFeeSetEvent,
     EventArchivedEvent, EventCancelledEvent, EventPostponedEvent, EventRegisteredEvent,
-    EventStatusUpdatedEvent, EventsSuspendedEvent, FeeUpdatedEvent, GlobalPromoUpdatedEvent,
-    GoalMetEvent, InitializationEvent, InventoryIncrementedEvent, LoyaltyScoreUpdatedEvent,
-    MetadataUpdatedEvent, MinStakeAmountUpdatedEvent, OrganizerBlacklistedEvent,
-    OrganizerRemovedFromBlacklistEvent, RegistryUpgradedEvent, ScannerAuthorizedEvent,
-    ScannerRevokedEvent, StakerRewardsClaimedEvent, StakerRewardsDistributedEvent,
-    StakingTokenUpdatedEvent,
+    EventStatusUpdatedEvent, EventsSuspendedEvent, FeeUpdatedEvent, FeedbackCidSetEvent,
+    GlobalPromoUpdatedEvent, GoalMetEvent, InitializationEvent, InventoryIncrementedEvent,
+    LoyaltyScoreUpdatedEvent, MetadataUpdatedEvent, MinStakeAmountUpdatedEvent,
+    OrganizerBlacklistedEvent, OrganizerRemovedFromBlacklistEvent, RegistryUpgradedEvent,
+    ScannerAuthorizedEvent, ScannerRevokedEvent, StakerRewardsClaimedEvent,
+    StakerRewardsDistributedEvent, StakingTokenUpdatedEvent,
 };
 use crate::types::{
     BlacklistAuditEntry, EventInfo, EventReceipt, EventRegistrationArgs, EventStatus, GuestProfile,
@@ -468,10 +468,50 @@ impl EventRegistry {
         }
     }
 
+    /// Sets the post-event feedback IPFS CID. Only callable by the organizer after end_time.
+    pub fn set_feedback_cid(
+        env: Env,
+        event_id: String,
+        feedback_cid: String,
+    ) -> Result<(), EventRegistryError> {
+        match storage::get_event(&env, event_id.clone()) {
+            Some(mut event_info) => {
+                auth::require_organizer(&env, &event_id, &event_info.organizer_address)?;
+
+                require_event_ended(&env, &event_info)?;
+
+                validate_metadata_cid(&env, &feedback_cid)?;
+
+                if event_info.feedback_cid.as_ref() == Some(&feedback_cid) {
+                    return Ok(());
+                }
+
+                event_info.feedback_cid = Some(feedback_cid.clone());
+                storage::update_event(&env, event_info.clone());
+
+                env.events().publish(
+                    (AgoraEvent::FeedbackCidSet,),
+                    FeedbackCidSetEvent {
+                        event_id,
+                        feedback_cid,
+                        updated_by: event_info.organizer_address,
+                        timestamp: env.ledger().timestamp(),
+                    },
+                );
+
+                Ok(())
+            }
+            None => Err(EventRegistryError::EventNotFound),
+        }
+    }
+
     /// Stores or updates an event (legacy function for backward compatibility).
     pub fn store_event(env: Env, event_info: EventInfo) {
         // Require authorization to ensure only the organizer can store/update their event directly
         auth::require_organizer(&env, &event_info.event_id, &event_info.organizer_address).unwrap();
+        if event_info.feedback_cid.is_some() {
+            require_event_ended(&env, &event_info).unwrap();
+        }
         storage::store_event(&env, event_info);
     }
 
@@ -1753,6 +1793,14 @@ fn validate_metadata_cid(env: &Env, cid: &String) -> Result<(), EventRegistryErr
         return Err(EventRegistryError::InvalidMetadataCid);
     }
 
+    Ok(())
+}
+
+fn require_event_ended(env: &Env, event_info: &EventInfo) -> Result<(), EventRegistryError> {
+    let now = env.ledger().timestamp();
+    if event_info.end_time == 0 || now <= event_info.end_time {
+        return Err(EventRegistryError::EventNotEnded);
+    }
     Ok(())
 }
 

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -1430,6 +1430,24 @@ pub async fn list_similar_events(
     success(events, "Similar events retrieved successfully").into_response()
 }
 
+/// Maximum allowed length for an event title.
+pub const MAX_EVENT_TITLE_LENGTH: usize = 200;
+
+/// Validates an event title for create/update requests.
+pub fn validate_event_title(title: &str) -> Result<(), String> {
+    let trimmed = title.trim();
+    if trimmed.is_empty() {
+        return Err("title must not be empty".to_string());
+    }
+    if title.chars().count() > MAX_EVENT_TITLE_LENGTH {
+        return Err(format!(
+            "title must not exceed {} characters",
+            MAX_EVENT_TITLE_LENGTH
+        ));
+    }
+    Ok(())
+}
+
 /// Request body for creating a new event
 #[derive(Debug, Deserialize)]
 pub struct CreateEventRequest {
@@ -1484,6 +1502,10 @@ pub async fn create_event(
             )
             .into_response();
         }
+    }
+
+    if let Err(message) = validate_event_title(&payload.title) {
+        return AppError::ValidationError(message).into_response();
     }
 
     let event = match sqlx::query_as::<_, Event>(
@@ -3230,6 +3252,31 @@ fn test_ticket_tier_response_serialization() {
     assert_eq!(json["name"], "General");
     assert_eq!(json["quantity"], 500);
     assert_eq!(json["sold"], 120);
+}
+
+#[test]
+fn test_validate_event_title_accepts_max_length() {
+    let title = "a".repeat(MAX_EVENT_TITLE_LENGTH);
+    assert!(validate_event_title(&title).is_ok());
+}
+
+#[test]
+fn test_validate_event_title_rejects_empty() {
+    let err = validate_event_title("").unwrap_err();
+    assert!(err.contains("empty"));
+}
+
+#[test]
+fn test_validate_event_title_rejects_whitespace_only() {
+    let err = validate_event_title("   ").unwrap_err();
+    assert!(err.contains("empty"));
+}
+
+#[test]
+fn test_validate_event_title_rejects_too_long() {
+    let title = "a".repeat(MAX_EVENT_TITLE_LENGTH + 1);
+    let err = validate_event_title(&title).unwrap_err();
+    assert!(err.contains("200"));
 }
 
 #[test]

--- a/server/src/utils/cursor_pagination.rs
+++ b/server/src/utils/cursor_pagination.rs
@@ -199,12 +199,12 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_decode_event_cursor() {
+    fn test_encode_decode_event_cursor_roundtrip() {
         let cursor = EventCursor {
             start_time: Utc::now(),
             id: Uuid::new_v4(),
-            created_at: None,
-            minted_tickets: None,
+            created_at: Some(Utc::now()),
+            minted_tickets: Some(42),
         };
 
         let encoded = encode_cursor(&cursor).unwrap();
@@ -212,10 +212,12 @@ mod tests {
 
         assert_eq!(cursor.start_time, decoded.start_time);
         assert_eq!(cursor.id, decoded.id);
+        assert_eq!(cursor.created_at, decoded.created_at);
+        assert_eq!(cursor.minted_tickets, decoded.minted_tickets);
     }
 
     #[test]
-    fn test_encode_decode_past_event_cursor() {
+    fn test_encode_decode_past_event_cursor_roundtrip() {
         let cursor = PastEventCursor {
             end_time: Utc::now(),
             id: Uuid::new_v4(),
@@ -230,7 +232,21 @@ mod tests {
 
     #[test]
     fn test_decode_invalid_base64() {
-        let result: Result<EventCursor, _> = decode_cursor("!!!");
+        let result: Result<EventCursor, _> = decode_cursor("!!!not-valid-base64!!!");
+        assert!(matches!(result, Err(CursorError::Decode(_))));
+    }
+
+    #[test]
+    fn test_decode_truncated_base64() {
+        let cursor = EventCursor {
+            start_time: Utc::now(),
+            id: Uuid::new_v4(),
+            created_at: None,
+            minted_tickets: None,
+        };
+        let encoded = encode_cursor(&cursor).unwrap();
+        let truncated = &encoded[..encoded.len() / 2];
+        let result: Result<EventCursor, _> = decode_cursor(truncated);
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
PR description
Summary
This PR closes four correctness gaps across the backend and EventRegistry contract: cursor pagination test coverage, server-side event title validation, a zero-reward distribution guard, and post-event-only feedback CID writes.

Changes
Backend — cursor pagination roundtrip tests
Added structured unit tests in server/src/utils/cursor_pagination.rs verifying encode/decode roundtrips for EventCursor (all fields) and PastEventCursor.
Added error-path tests for invalid and truncated base64 cursor strings.
Backend — event title length validation
Introduced MAX_EVENT_TITLE_LENGTH (200) and validate_event_title().
POST /api/v1/events (create_event) now returns 400 when:
title is empty or whitespace-only
title exceeds 200 characters
Unit tests cover valid max-length titles, empty titles, and over-limit titles.
Contract — staker rewards zero-amount guard
distribute_staker_rewards rejects total_rewards_amount == 0 with InvalidRewardAmount (no-op token transfer or unnecessary events).
Added test_distribute_staker_rewards_zero_amount_rejects in issue_tests.rs.
Contract — feedback CID only after event ends
Added set_feedback_cid(event_id, feedback_cid) for organizers, requiring env.ledger().timestamp() > event_info.end_time.
Returns EventNotEnded if called prematurely.
Legacy store_event() applies the same guard when feedback_cid is set.
Emits FeedbackCidSet on success.
Tests verify rejection before end_time and success after the event ends.

closes #910 
closes #912 
closes #913 
closes #917