### PR TITLE
Feat/add get /api/v1/events/id/ratings( issues 575   578)

### DIFF
--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -626,6 +626,27 @@ mod tests {
     }
 
     #[test]
+    fn test_event_rating_item_fields() {
+        let item = EventRatingItem {
+            rating: 4,
+            review: Some("Great event!".to_string()),
+            created_at: Utc::now(),
+        };
+        assert_eq!(item.rating, 4);
+        assert_eq!(item.review.as_deref(), Some("Great event!"));
+    }
+
+    #[test]
+    fn test_event_rating_item_no_review() {
+        let item = EventRatingItem {
+            rating: 3,
+            review: None,
+            created_at: Utc::now(),
+        };
+        assert!(item.review.is_none());
+    }
+
+    #[test]
     fn test_ratings_summary_distribution_zero_filled() {
         let mut distribution = std::collections::HashMap::new();
         for star in 1i16..=5 {
@@ -2606,6 +2627,80 @@ pub struct RatingsSummary {
     pub average: f64,
     pub total: i64,
     pub distribution: std::collections::HashMap<String, i64>,
+}
+
+/// A single rating item returned by the list ratings endpoint (ticket ID omitted for privacy).
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct EventRatingItem {
+    pub rating: i16,
+    pub review: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// GET /api/v1/events/:id/ratings
+///
+/// Returns a paginated list of ratings for the given event.
+/// Ticket IDs are not included in the response to preserve attendee privacy.
+/// Returns 404 if the event does not exist.
+pub async fn list_event_ratings(
+    State(state): State<EventState>,
+    Path(event_id): Path<Uuid>,
+    Query(pagination): Query<PaginationParams>,
+) -> Response {
+    let exists = match sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM events WHERE id = $1)",
+    )
+    .bind(event_id)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("Failed to check event existence for ratings: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    if !exists {
+        return AppError::NotFound(format!("Event with id '{}' not found", event_id))
+            .into_response();
+    }
+
+    let validated = pagination.validate();
+
+    let total = match sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM event_ratings WHERE event_id = $1",
+    )
+    .bind(event_id)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!("Failed to count event ratings: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let items = match sqlx::query_as::<_, EventRatingItem>(
+        "SELECT rating, review, created_at FROM event_ratings \
+         WHERE event_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+    )
+    .bind(event_id)
+    .bind(validated.limit())
+    .bind(validated.offset())
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to fetch event ratings: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let response = PaginatedResponse::new(items, validated, total);
+    success(response, "Ratings retrieved successfully").into_response()
 }
 
 /// GET /api/v1/events/:id/ratings/summary

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -626,6 +626,14 @@ mod tests {
     }
 
     #[test]
+    fn test_submit_rating_cache_key_format() {
+        let event_id = Uuid::new_v4();
+        let cache_key = format!("event:detail:{}", event_id);
+        assert!(cache_key.starts_with("event:detail:"));
+        assert!(cache_key.contains(&event_id.to_string()));
+    }
+
+    #[test]
     fn test_event_rating_item_fields() {
         let item = EventRatingItem {
             rating: 4,
@@ -1574,7 +1582,7 @@ pub async fn create_event(
 /// # Endpoint
 /// POST `/api/v1/events/:id/rate`
 pub async fn submit_event_rating(
-    State(state): State<EventState>,
+    State(mut state): State<EventState>,
     Path(event_id): Path<Uuid>,
     Json(payload): Json<SubmitEventRatingRequest>,
 ) -> Response {
@@ -1701,6 +1709,15 @@ pub async fn submit_event_rating(
     if let Err(e) = tx.commit().await {
         tracing::error!("Failed to commit rating transaction: {:?}", e);
         return AppError::DatabaseError(e).into_response();
+    }
+
+    let cache_key = format!("event:detail:{}", event_id);
+    if let Err(e) = state.redis.delete(&cache_key).await {
+        tracing::warn!(
+            "Failed to invalidate event detail cache after rating for {}: {:?}",
+            event_id,
+            e
+        );
     }
 
     let response = SubmitEventRatingResponse {

--- a/server/src/handlers/profile.rs
+++ b/server/src/handlers/profile.rs
@@ -24,7 +24,11 @@ use uuid::Uuid;
 
 use crate::cache::RedisCache;
 use crate::handlers::auth::extract_auth;
+use crate::models::event::{populate_is_free, Event};
 use crate::models::organizer_profile::{OrganizerProfile, UpsertProfileRequest};
+use crate::utils::cursor_pagination::{
+    decode_cursor, encode_cursor, CursorParams, CursorResponse, EventCursor,
+};
 use crate::utils::error::AppError;
 use crate::utils::pagination::{PaginatedResponse, PaginationParams};
 use crate::utils::response::success;
@@ -525,6 +529,88 @@ pub async fn get_organizer_stats(
     success(stats, "Organizer stats retrieved successfully").into_response()
 }
 
+/// `GET /api/v1/profile/:address/events`
+///
+/// Returns a cursor-paginated list of upcoming events created by the organizer
+/// identified by their Stellar wallet address. Returns an empty list (not 404)
+/// if the organizer has no upcoming events.
+pub async fn list_events_by_organizer(
+    State(state): State<ProfileState>,
+    Path(address): Path<String>,
+    Query(pagination): Query<CursorParams>,
+) -> Response {
+    let validated = pagination.validate();
+
+    let cursor = match validated.cursor {
+        Some(ref c) => match decode_cursor::<EventCursor>(c) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                tracing::warn!("Invalid cursor for list_events_by_organizer: {}", e);
+                return AppError::ValidationError(format!("Invalid cursor: {}", e)).into_response();
+            }
+        },
+        None => None,
+    };
+
+    let items_query = if cursor.is_some() {
+        "SELECT * FROM events \
+         WHERE organizer_id = (SELECT id FROM organizers WHERE wallet_address = $1) \
+           AND end_time > NOW() \
+           AND (start_time > $3 OR (start_time = $3 AND id > $4)) \
+         ORDER BY start_time ASC, id ASC \
+         LIMIT $2"
+            .to_string()
+    } else {
+        "SELECT * FROM events \
+         WHERE organizer_id = (SELECT id FROM organizers WHERE wallet_address = $1) \
+           AND end_time > NOW() \
+         ORDER BY start_time ASC, id ASC \
+         LIMIT $2"
+            .to_string()
+    };
+
+    let mut builder = sqlx::query_as::<_, Event>(&items_query)
+        .bind(&address)
+        .bind(validated.query_limit());
+
+    if let Some(ref c) = cursor {
+        builder = builder.bind(c.start_time).bind(c.id);
+    }
+
+    let mut items = match builder.fetch_all(&state.pool).await {
+        Ok(events) => events,
+        Err(e) => {
+            tracing::error!("Failed to fetch events for organizer {}: {:?}", address, e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let has_more = items.len() > validated.page_size();
+    let next_cursor = if has_more {
+        let last = items.pop().unwrap();
+        match encode_cursor(&EventCursor {
+            start_time: last.start_time,
+            id: last.id,
+            created_at: Some(last.created_at),
+            minted_tickets: Some(last.minted_tickets),
+        }) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                tracing::error!("Failed to encode cursor: {:?}", e);
+                return AppError::InternalServerError("Failed to encode cursor".to_string())
+                    .into_response();
+            }
+        }
+    } else {
+        None
+    };
+
+    populate_is_free(&mut items, &state.pool).await;
+
+    let response = CursorResponse::new(items, &validated, next_cursor);
+    success(response, "Organizer events retrieved successfully").into_response()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -751,6 +837,28 @@ mod tests {
         assert_eq!(v["data"]["total_events"].as_i64().unwrap(), 2);
         assert_eq!(v["data"]["total_tickets_sold"].as_i64().unwrap(), 100);
         assert!((v["data"]["average_event_rating"].as_f64().unwrap() - 4.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_list_events_by_organizer_cursor_params() {
+        let params = CursorParams {
+            limit: 10,
+            cursor: None,
+        };
+        let validated = params.validate();
+        assert_eq!(validated.page_size(), 10);
+        assert_eq!(validated.query_limit(), 11);
+        assert!(validated.cursor.is_none());
+    }
+
+    #[test]
+    fn test_list_events_by_organizer_cursor_with_value() {
+        let params = CursorParams {
+            limit: 5,
+            cursor: Some("some-cursor-value".to_string()),
+        };
+        let validated = params.validate();
+        assert_eq!(validated.cursor.as_deref(), Some("some-cursor-value"));
     }
 
     #[test]

--- a/server/src/middleware/content_type.rs
+++ b/server/src/middleware/content_type.rs
@@ -1,0 +1,134 @@
+use axum::{
+    body::Body,
+    http::{header::CONTENT_LENGTH, header::CONTENT_TYPE, Method, Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+
+/// Middleware that enforces `Content-Type: application/json` on POST and PUT
+/// requests that carry a body. Requests with no body (Content-Length: 0 or
+/// absent) are allowed through so that body-less endpoints (e.g. POST /logout)
+/// are not affected.
+///
+/// Returns HTTP 415 Unsupported Media Type when the header is missing or does
+/// not start with `application/json`.
+pub async fn require_json_content_type(req: Request<Body>, next: Next) -> Response {
+    if matches!(req.method(), &Method::POST | &Method::PUT) {
+        let content_length = req
+            .headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+
+        let has_body = match content_length {
+            Some(len) => len > 0,
+            None => req
+                .headers()
+                .contains_key(axum::http::header::TRANSFER_ENCODING),
+        };
+
+        if has_body {
+            let has_json_ct = req
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|v| v.starts_with("application/json"))
+                .unwrap_or(false);
+
+            if !has_json_ct {
+                let body = json!({
+                    "success": false,
+                    "error": {
+                        "code": "UNSUPPORTED_MEDIA_TYPE",
+                        "message": "Content-Type must be application/json"
+                    }
+                });
+                return (StatusCode::UNSUPPORTED_MEDIA_TYPE, axum::Json(body)).into_response();
+            }
+        }
+    }
+
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        routing::post,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    fn test_router() -> Router {
+        Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(middleware::from_fn(require_json_content_type))
+    }
+
+    async fn send(router: Router, method: &str, content_type: Option<&str>, body: &str) -> StatusCode {
+        let mut builder = Request::builder().method(method).uri("/test");
+        if let Some(ct) = content_type {
+            builder = builder.header("content-type", ct);
+        }
+        if !body.is_empty() {
+            builder = builder.header("content-length", body.len().to_string());
+        }
+        let req = builder.body(Body::from(body.to_string())).unwrap();
+        router.oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn test_post_with_json_content_type_passes() {
+        let router = test_router();
+        let status = send(router, "POST", Some("application/json"), r#"{"x":1}"#).await;
+        assert_ne!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_post_with_wrong_content_type_returns_415() {
+        let router = test_router();
+        let status = send(router, "POST", Some("text/plain"), r#"hello"#).await;
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_post_missing_content_type_with_body_returns_415() {
+        let router = test_router();
+        let status = send(router, "POST", None, r#"{"x":1}"#).await;
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_post_no_body_passes_without_content_type() {
+        let router = test_router();
+        let status = send(router, "POST", None, "").await;
+        assert_ne!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_json_with_charset_passes() {
+        let router = test_router();
+        let status = send(router, "POST", Some("application/json; charset=utf-8"), r#"{"x":1}"#).await;
+        assert_ne!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_get_request_not_affected() {
+        let router = Router::new()
+            .route("/test", axum::routing::get(|| async { "ok" }))
+            .layer(middleware::from_fn(require_json_content_type));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let status = router.oneshot(req).await.unwrap().status();
+        assert_ne!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+}

--- a/server/src/middleware/mod.rs
+++ b/server/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod content_type;
 pub mod monitoring_auth;
 pub mod rate_limit;
 pub mod request_id_tracing;

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -60,6 +60,7 @@ use crate::handlers::{
     ws::{ws_purchases_handler, PurchaseBroadcaster},
 };
 use crate::middleware::audit::audit_layer;
+use crate::middleware::content_type::require_json_content_type;
 use crate::middleware::monitoring_auth::{require_monitoring_token, MonitoringAuthState};
 use crate::middleware::rate_limit::GovernorRateLimitLayer;
 use crate::middleware::request_id_tracing::trace_request_id;
@@ -244,6 +245,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .nest("/ws", ws_routes)
         .nest("/qr", qr_routes)
         .merge(rates_route)
+        .layer(middleware::from_fn(require_json_content_type))
         .layer(RequestBodyLimitLayer::new(1024 * 1024))
         .layer(GovernorRateLimitLayer::new(100, Duration::from_secs(60)));
 

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -51,8 +51,8 @@ use crate::handlers::{
     leaderboard::{get_leaderboard, LeaderboardState},
     monitoring::{monitoring_dashboard, MonitoringState},
     profile::{
-        get_my_profile, get_organizer_stats, get_profile_by_address, list_my_transactions,
-        patch_profile, upsert_profile, ProfileState,
+        get_my_profile, get_organizer_stats, get_profile_by_address, list_events_by_organizer,
+        list_my_transactions, patch_profile, upsert_profile, ProfileState,
     },
     qr_payload::{delete_qr_payload, generate_qr_payload, list_event_qr_codes, list_qr_payloads, mark_qr_used, verify_qr_payload},
     rates::{get_rates, RatesState},
@@ -124,6 +124,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/", get(get_my_profile).put(upsert_profile).patch(patch_profile))
         .route("/transactions", get(list_my_transactions))
         .route("/:address", get(get_profile_by_address))
+        .route("/:address/events", get(list_events_by_organizer))
         .with_state(profile_state)
         .merge(
             Router::new()

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -41,8 +41,8 @@ use crate::handlers::{
     events::{
         export_attendees_csv, get_attendee_count, get_checkin_stats, get_event, get_event_counts,
         get_event_organizer, get_event_share_link, get_event_social_proof, get_ratings_summary,
-        list_event_tickets, list_events, list_events_by_category, list_featured_events,
-        list_past_events,
+        list_event_ratings, list_event_tickets, list_events, list_events_by_category,
+        list_featured_events, list_past_events,
         list_similar_events, list_ticket_tiers, list_upcoming_events, search_events,
         submit_event_rating, toggle_event_flag, EventState,
     },
@@ -162,6 +162,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/:id/attendees/count", get(get_attendee_count))
         .route("/:id/rate", post(submit_event_rating))
         .route("/:id/check-in-stats", get(get_checkin_stats))
+        .route("/:id/ratings", get(list_event_ratings))
         .route("/:id/ratings/summary", get(get_ratings_summary))
         .route("/:id/organizer", get(get_event_organizer))
         .route("/:id/export-attendees", get(export_attendees_csv))


### PR DESCRIPTION
Summary
Adds GET /api/v1/events/:id/ratings to list paginated ratings for an event (ticket IDs excluded for privacy)
Invalidates the event:detail:{id} Redis cache after a rating is successfully submitted, so aggregate stats are never stale
Adds GET /api/v1/profile/:address/events to return cursor-paginated upcoming events for an organizer by Stellar wallet address
Adds Content-Type: application/json validation middleware that returns HTTP 415 on POST/PUT requests with a body that omit or mismatch the header; body-less requests (e.g. POST /logout) are unaffected
Changes
Issue #575 — GET /api/v1/events/:id/ratings

New EventRatingItem struct (rating, review, created_at — no ticket_id)
New list_event_ratings handler in [server/src/handlers/events.rs](https://1oamr99tda2049uf5jl8h07lrdh7jv9dfnjjqe33dv5q8oskdpqr.assets.github.dev/stable/7e7950df89d055b5a378379db9ee14290772148a/out/vs/workbench/contrib/webview/browser/pre/server/src/handlers/events.rs) using PaginatedResponse
Route registered at /:id/ratings in [server/src/routes/mod.rs](https://1oamr99tda2049uf5jl8h07lrdh7jv9dfnjjqe33dv5q8oskdpqr.assets.github.dev/stable/7e7950df89d055b5a378379db9ee14290772148a/out/vs/workbench/contrib/webview/browser/pre/server/src/routes/mod.rs)
Returns 404 if the event does not exist
Issue #576 — Cache invalidation on rating submission

submit_event_rating now takes State(mut state) and calls state.redis.delete("event:detail:{id}") after a successful tx.commit()
Redis failure is logged as a warning; the rating response is still returned
Issue #577 — GET /api/v1/profile/:address/events

New list_events_by_organizer handler in [server/src/handlers/profile.rs](https://1oamr99tda2049uf5jl8h07lrdh7jv9dfnjjqe33dv5q8oskdpqr.assets.github.dev/stable/7e7950df89d055b5a378379db9ee14290772148a/out/vs/workbench/contrib/webview/browser/pre/server/src/handlers/profile.rs) using CursorResponse / EventCursor
Resolves wallet address → organizer_id via a subquery on the organizers table
Filters to end_time > NOW(), ordered start_time ASC, id ASC; returns empty list when no events exist
Route registered at /:address/events inside profile_routes
Issue #578 — Content-Type middleware

New [server/src/middleware/content_type.rs](https://1oamr99tda2049uf5jl8h07lrdh7jv9dfnjjqe33dv5q8oskdpqr.assets.github.dev/stable/7e7950df89d055b5a378379db9ee14290772148a/out/vs/workbench/contrib/webview/browser/pre/server/src/middleware/content_type.rs) with require_json_content_type
Only enforces the header when the request has a body (Content-Length > 0 or Transfer-Encoding present), so body-less POSTs are not affected
Applied to public_api_routes via middleware::from_fn
Exported from [server/src/middleware/mod.rs](https://1oamr99tda2049uf5jl8h07lrdh7jv9dfnjjqe33dv5q8oskdpqr.assets.github.dev/stable/7e7950df89d055b5a378379db9ee14290772148a/out/vs/workbench/contrib/webview/browser/pre/server/src/middleware/mod.rs)
Test plan
 GET /api/v1/events/:id/ratings returns paginated ratings; returns 404 for unknown event
 POST /api/v1/events/:id/rate → subsequent GET /api/v1/events/:id fetches fresh data (cache was cleared)
 GET /api/v1/profile/:address/events returns events for a known wallet; returns empty list for wallet with no events; cursor pagination advances correctly
 POST with Content-Type: application/json → passes through; POST with text/plain → 415; POST with no body and no header (e.g. logout) → passes through
 GET requests are not affected by the Content-Type middleware
Closes #575
Closes #576
Closes #577
Closes #578