### PR TITLE
feat: add Prometheus metrics exporter

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "jsonwebtoken",
  "once_cell",
  "pin-project",
+ "prometheus",
  "rand 0.8.5",
  "redis",
  "reqwest",
@@ -2041,6 +2042,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -2476,6 +2483,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,6 +2958,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2912,7 +2978,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3634,7 +3700,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -66,6 +66,9 @@ aws-config = "1.5"
 # Lazy static initialization
 once_cell = "1.19"
 
+# Prometheus metrics
+prometheus = { version = "0.13", features = ["process"] }
+
 # Currency conversion HTTP client already covered by reqwest above
 
 # Testing

--- a/server/src/cache/mod.rs
+++ b/server/src/cache/mod.rs
@@ -26,6 +26,9 @@ impl RedisCache {
         let value: Option<String> = self.client.get(key).await?;
         match value {
             Some(json) => {
+                crate::metrics::CACHE_HITS_TOTAL
+                    .with_label_values(&[key])
+                    .inc();
                 let parsed = serde_json::from_str(&json).map_err(|e| {
                     RedisError::from((
                         redis::ErrorKind::TypeError,
@@ -35,7 +38,12 @@ impl RedisCache {
                 })?;
                 Ok(Some(parsed))
             }
-            None => Ok(None),
+            None => {
+                crate::metrics::CACHE_MISSES_TOTAL
+                    .with_label_values(&[key])
+                    .inc();
+                Ok(None)
+            }
         }
     }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cache;
 pub mod config;
 pub mod handlers;
+pub mod metrics;
 pub mod middleware;
 pub mod models;
 pub mod notifications;

--- a/server/src/metrics/mod.rs
+++ b/server/src/metrics/mod.rs
@@ -1,0 +1,88 @@
+use axum::{
+    extract::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use once_cell::sync::Lazy;
+use prometheus::{
+    register_counter_vec_with_registry, register_histogram_vec_with_registry, CounterVec,
+    Encoder, HistogramOpts, HistogramVec, Opts, Registry, TextEncoder,
+};
+use std::time::Instant;
+
+static REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
+
+pub static HTTP_REQUESTS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec_with_registry!(
+        Opts::new("http_requests_total", "Total number of HTTP requests"),
+        &["method", "path", "status"],
+        REGISTRY
+    )
+    .unwrap()
+});
+
+pub static HTTP_REQUESTS_DURATION_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec_with_registry!(
+        HistogramOpts::new(
+            "http_requests_duration_seconds",
+            "HTTP request latency in seconds"
+        ),
+        &["method", "path", "status"],
+        REGISTRY
+    )
+    .unwrap()
+});
+
+pub static CACHE_HITS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec_with_registry!(
+        Opts::new("cache_hits_total", "Total number of cache hits"),
+        &["cache_key"],
+        REGISTRY
+    )
+    .unwrap()
+});
+
+pub static CACHE_MISSES_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec_with_registry!(
+        Opts::new("cache_misses_total", "Total number of cache misses"),
+        &["cache_key"],
+        REGISTRY
+    )
+    .unwrap()
+});
+
+pub async fn metrics_handler() -> Response {
+    let encoder = TextEncoder::new();
+    let mut buffer = Vec::new();
+    encoder.encode(&REGISTRY.gather(), &mut buffer).unwrap();
+    (
+        StatusCode::OK,
+        [(
+            "content-type",
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        buffer,
+    )
+        .into_response()
+}
+
+pub async fn track_metrics(request: Request, next: Next) -> Response {
+    let start = Instant::now();
+    let method = request.method().to_string();
+    let path = request.uri().path().to_string();
+
+    let response = next.run(request).await;
+
+    let duration = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16().to_string();
+
+    HTTP_REQUESTS_TOTAL
+        .with_label_values(&[&method, &path, &status])
+        .inc();
+    HTTP_REQUESTS_DURATION_SECONDS
+        .with_label_values(&[&method, &path, &status])
+        .observe(duration);
+
+    response
+}

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -35,6 +35,7 @@ use crate::config::{
     create_cors_layer, create_security_headers_layer, propagate_request_id_layer,
     set_request_id_layer, Config,
 };
+use crate::metrics::{metrics_handler, track_metrics};
 use crate::handlers::{
     auth::{logout, request_nonce, verify_signature},
     categories::{get_category, list_categories, CategoryState},
@@ -268,9 +269,11 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/.well-known/assetlinks.json", get(serve_assetlinks));
 
     Router::new()
+        .route("/metrics", get(metrics_handler))
         .nest("/api/v1", api_routes)
         .nest("/api/v1/admin", admin_routes)
         .merge(deep_link_routes)
+        .layer(middleware::from_fn(track_metrics))
         .layer(create_security_headers_layer())
         .layer(create_cors_layer())
         .layer(middleware::from_fn(trace_request_id))


### PR DESCRIPTION
- Add prometheus crate to Cargo.toml
- Create metrics module with http_requests_total, http_requests_duration_seconds, cache_hits_total, cache_misses_total counters
- Add middleware to track request metrics and latency
- Expose GET /metrics handler with Prometheus text format
- Instrument Redis cache for hit/miss tracking

Closes #952