### PR TITLE
docs: add frontend environment variables reference (Resolves #793)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,32 @@
+# API / Backend
+BACKEND_URL=http://localhost:3001
+DATABASE_URL=postgresql://user:password@localhost:5432/agora
+
+# Environment
+NODE_ENV=development
+
+# Authentication
+JWT_SECRET=your_jwt_secret_here
+
+# Google OAuth
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/google
+
+# Apple OAuth
+APPLE_CLIENT_ID=your_apple_client_id
+APPLE_CLIENT_SECRET=your_apple_client_secret
+APPLE_REDIRECT_URI=http://localhost:3000/api/auth/apple
+
+# Stellar Network
+STELLAR_CONTRACT_ADDRESS=your_stellar_contract_address
+STELLAR_SOURCE_SECRET=your_stellar_source_secret
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# PostHog Analytics
+NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
+NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+
+# Site URL
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/apps/web/ENV_VARS.md
+++ b/apps/web/ENV_VARS.md
@@ -1,0 +1,25 @@
+# Frontend Environment Variables Reference
+
+This document provides a reference for all environment variables used in the frontend application.
+
+| Variable Name | Description | Required/Optional | Example Value | Where to Obtain |
+|---------------|-------------|-------------------|---------------|-----------------|
+| `BACKEND_URL` | The base URL for the backend API. | Optional | `http://localhost:3001` | Developer setup or deployment environment |
+| `DATABASE_URL` | Database connection string for Prisma. | Required | `postgresql://user:password@localhost:5432/agora` | Database provider (e.g., Supabase, Heroku, local Postgres) |
+| `NODE_ENV` | Defines the environment the application is running in (development, production, test). | Optional | `development` | Automatically set by framework or deployment platform |
+| `JWT_SECRET` | Secret key used to sign JSON Web Tokens. | Optional | `super_secret_string` | Generated securely by developer |
+| `GOOGLE_CLIENT_ID` | Client ID for Google OAuth. | Optional | `123456789-abc.apps.googleusercontent.com` | Google Cloud Console > Credentials |
+| `GOOGLE_CLIENT_SECRET` | Client Secret for Google OAuth. | Optional | `GOCSPX-abcdefg123456` | Google Cloud Console > Credentials |
+| `GOOGLE_REDIRECT_URI` | Redirect URI for Google OAuth callback. | Optional | `http://localhost:3000/api/auth/google` | Google Cloud Console > Credentials |
+| `APPLE_CLIENT_ID` | Client ID for Apple OAuth. | Optional | `com.example.agora.web` | Apple Developer Portal > Identifiers |
+| `APPLE_CLIENT_SECRET` | Client Secret for Apple OAuth. | Optional | `secret_string` | Apple Developer Portal |
+| `APPLE_REDIRECT_URI` | Redirect URI for Apple OAuth callback. | Optional | `http://localhost:3000/api/auth/apple` | Apple Developer Portal |
+| `STELLAR_CONTRACT_ADDRESS` | The address of the deployed Stellar smart contract. | Optional | `CA...XYZ` | Provided after deploying the Stellar contract |
+| `STELLAR_SOURCE_SECRET` | Secret key for the Stellar source account. | Optional | `SA...XYZ` | Stellar Laboratory or account generation tool |
+| `STELLAR_RPC_URL` | RPC URL for the Stellar network. | Optional | `https://soroban-testnet.stellar.org` | Stellar network provider |
+| `STELLAR_NETWORK_PASSPHRASE` | Passphrase for the Stellar network being used. | Optional | `Test SDF Network ; September 2015` | Stellar network documentation |
+| `NEXT_PUBLIC_POSTHOG_KEY` | Public key for PostHog analytics. | Optional | `phc_abc123` | PostHog dashboard |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Host URL for PostHog analytics. | Optional | `https://app.posthog.com` | PostHog dashboard |
+| `NEXT_PUBLIC_SITE_URL` | The public URL of the frontend site. | Optional | `http://localhost:3000` | Deployment environment or local setup |
+
+> Note: Variables marked as Optional often have default fallback values in the codebase for local development environments, but should be explicitly configured in production.


### PR DESCRIPTION
Closes #793 

## Description

This PR adds frontend environment variable documentation to improve onboarding for new contributors. Previously, the backend had an `.env.example` but the frontend was missing one, leaving new developers without a clear reference on what variables are required and where to obtain them.

## Changes Made
- Added `apps/web/.env.example` containing a template for all environment variables used in the frontend application.
- Added `apps/web/ENV_VARS.md` which serves as a human-readable reference detailing each variable's purpose, whether it is required or optional, an example value, and where to obtain the actual value.
- Documented all variables found in the codebase, including the API base URL, Stellar contract configurations, Google/Apple OAuth parameters, Database URL, Next.js Public URLs, and Posthog analytics configurations.

## Acceptance Criteria Met
- [x] Every environment variable used in the frontend codebase appears in both files.
- [x] A new contributor can now easily locate and configure every frontend variable without needing to ask for help on Discord.
