### PR TITLE
feat: add pre-commit hooks for formatting and linting

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,50 @@
+name: Pre-commit
+
+on:
+  push:
+    branches: ["main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+
+jobs:
+  pre-commit:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install JS dependencies
+        run: pnpm install
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+repos:
+  # General file hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+
+  # Rust: rustfmt
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        description: Format Rust code with rustfmt
+        language: system
+        entry: cargo fmt --all --
+        args: ["--check"]
+        types: [rust]
+        pass_filenames: false
+
+  # Rust: clippy
+  - repo: local
+    hooks:
+      - id: clippy
+        name: cargo clippy
+        description: Lint Rust code with Clippy
+        language: system
+        entry: cargo clippy --all-targets --all-features
+        args: ["--", "-D", "warnings"]
+        types: [rust]
+        pass_filenames: false
+
+  # JS/TS: prettier
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        files: \.(js|jsx|ts|tsx|css|json|md|yaml|yml)$
+        exclude: ^(pnpm-lock\.yaml|apps/web/prisma/.*)$
+
+  # JS/TS: eslint
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        description: Lint JS/TS code with ESLint
+        language: system
+        entry: pnpm --filter web lint
+        types_or: [javascript, jsx, ts, tsx]
+        pass_filenames: false

--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -243,7 +243,68 @@ You should also be able to open:
 - Confirm Rust and Cargo are installed correctly.
 - Confirm Soroban CLI is installed if your contract workflow depends on it.
 
-## 11. PR Reminder
+## 11. Pre-commit Hooks
+
+Pre-commit hooks enforce formatting and linting before every commit, catching issues locally before they reach CI.
+
+### Install pre-commit
+
+```bash
+pip install pre-commit
+```
+
+### Activate hooks for this repo
+
+Run once after cloning (or after any change to `.pre-commit-config.yaml`):
+
+```bash
+pre-commit install
+```
+
+This installs the hooks into `.git/hooks/pre-commit`.
+
+### What runs on each commit
+
+| Hook | What it checks |
+|------|---------------|
+| `trailing-whitespace` | Removes trailing whitespace |
+| `end-of-file-fixer` | Ensures files end with a newline |
+| `check-merge-conflict` | Catches leftover merge conflict markers |
+| `rustfmt` | Formats Rust code (`cargo fmt --check`) |
+| `clippy` | Lints Rust code (`cargo clippy -D warnings`) |
+| `prettier` | Formats JS/TS/CSS/JSON/MD files |
+| `eslint` | Lints JS/TS files in `apps/web` |
+
+### Run hooks manually
+
+```bash
+# Run on all files (same as CI)
+pre-commit run --all-files
+
+# Run a single hook
+pre-commit run rustfmt --all-files
+pre-commit run eslint --all-files
+```
+
+### Auto-fix formatting before committing
+
+```bash
+# Rust
+cargo fmt --all
+
+# JS/TS/CSS/JSON/MD (from repo root)
+pnpm --filter web format
+```
+
+### Skipping hooks (not recommended)
+
+```bash
+git commit --no-verify -m "message"
+```
+
+Only skip when you have a specific reason; CI will still run all checks.
+
+## 12. PR Reminder
 
 When you open the PR for this task, include the linked issue in the PR description:
 


### PR DESCRIPTION
## Summary

Closes #956

Adds pre-commit hooks to enforce code formatting and linting at commit time, preventing unformatted code from reaching CI.

## Changes

- **`.pre-commit-config.yaml`** — defines hooks for:
  - `pre-commit-hooks`: trailing whitespace, EOF fixer, merge-conflict detector
  - `rustfmt` (local): `cargo fmt --all -- --check`
  - `cargo clippy` (local): `--all-targets --all-features -D warnings`
  - `prettier` (mirrors-prettier v3.1.0): JS/TS/CSS/JSON/MD files
  - `eslint` (local via pnpm): `pnpm --filter web lint`

- **`.github/workflows/pre-commit.yml`** — CI job that runs `pre-commit run --all-files` on every push/PR to `main` and `develop`

- **`DEVELOPMENT_SETUP.md`** — added section 11 documenting install, activation, hook table, manual run, auto-fix, and skip instructions

## How to activate locally

```bash
pip install pre-commit
pre-commit install
```

From then on, every `git commit` will run the hooks automatically.

## Acceptance Criteria

- [x] Commits that violate formatting are rejected locally
- [x] CI fails if a push contains unformatted code