### PR TITLE
feat(mobile): add ThemeContext with system theme listening (#1019)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ package-lock.json
 # PR description drafts
 pr-*.md
 
+# Kiro IDE directory
+.kiro/
+
 # Storybook build output and logs
 storybook-static
 **/storybook-static

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,29 +1,31 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
 import { TabBarIcon } from '@/components/navigation/TabBarIcon';
-import { Colors } from '@/constants/Colors';
+import { useTheme } from '@/hooks/useTheme';
 
 export default function TabLayout() {
+  const { theme, palette, colorScheme } = useTheme();
+
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors.primaryYellow,
-        tabBarInactiveTintColor: Colors.secondaryText,
+        tabBarActiveTintColor: palette.primaryYellow,
+        tabBarInactiveTintColor: theme.icon,
         tabBarStyle: {
-          backgroundColor: Colors.darkBackground,
+          backgroundColor: theme.background,
           borderTopWidth: 1,
-          borderTopColor: '#1E1E20',
+          borderTopColor: colorScheme === 'dark' ? '#1E1E20' : '#E5E5EA',
           height: 60,
           paddingBottom: 8,
           paddingTop: 8,
         },
         headerStyle: {
-          backgroundColor: Colors.darkBackground,
+          backgroundColor: theme.background,
           borderBottomWidth: 1,
-          borderBottomColor: '#1E1E20',
+          borderBottomColor: colorScheme === 'dark' ? '#1E1E20' : '#E5E5EA',
         },
         headerTitleStyle: {
-          color: Colors.primaryText,
+          color: theme.text,
           fontWeight: 'bold',
         },
         headerShown: true,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,122 +1,145 @@
-import React, { useEffect } from 'react';
-import { ThemeProvider, DarkTheme } from '@react-navigation/native';
+import React, { useEffect, useMemo } from 'react';
+import { ThemeProvider as NavThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import 'react-native-reanimated';
 
+import { ThemeProvider, useThemeContext } from '@/context/ThemeContext';
 import { useAuth } from '@/hooks/useAuth';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
-import Colors from '@/constants/Colors';
+import { Colors } from '@/constants/Colors';
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
-const AgoraNavigationTheme = {
-  ...DarkTheme,
-  colors: {
-    ...DarkTheme.colors,
-    background: Colors.darkBackground,
-    primary: Colors.primaryYellow,
-    card: Colors.darkBackground,
-    text: Colors.primaryText,
-    border: '#1E1E20',
-  },
-};
+/**
+ * Builds a react-navigation theme from the current Agora theme tokens.
+ * Re-runs whenever colorScheme changes so the navigator updates instantly.
+ */
+function useAgoraNavTheme() {
+  const { colorScheme } = useThemeContext();
+
+  return useMemo(() => {
+    const base = colorScheme === 'dark' ? DarkTheme : DefaultTheme;
+    return {
+      ...base,
+      colors: {
+        ...base.colors,
+        background: Colors[colorScheme].background,
+        primary: Colors.primaryYellow,
+        card: Colors[colorScheme].background,
+        text: Colors[colorScheme].text,
+        border: colorScheme === 'dark' ? '#1E1E20' : '#E5E5EA',
+        notification: Colors.primaryYellow,
+      },
+    };
+  }, [colorScheme]);
+}
 
 function AppNavigation() {
   const { isAuthenticated } = useAuth();
   const segments = useSegments();
   const router = useRouter();
+  const navTheme = useAgoraNavTheme();
+  const { colorScheme } = useThemeContext();
 
   useEffect(() => {
-    // Check if the user is in the auth route group
     const inAuthGroup = segments[0] === 'auth';
 
     if (!isAuthenticated && !inAuthGroup) {
-      // Redirect to the auth landing screen if not authenticated
       router.replace('/auth');
     } else if (isAuthenticated && inAuthGroup) {
-      // Redirect to discover tab once authenticated
       router.replace('/(tabs)/discover');
     }
   }, [isAuthenticated, segments, router]);
 
+  const headerStyle = useMemo(
+    () => ({
+      backgroundColor: Colors[colorScheme].background,
+    }),
+    [colorScheme]
+  );
+
+  const headerTintColor = Colors[colorScheme].text;
+
   return (
-    <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen name="auth" options={{ headerShown: false }} />
-      <Stack.Screen
-        name="checkout"
-        options={{
-          presentation: 'modal',
-          title: 'Ticket Checkout',
-          headerStyle: { backgroundColor: Colors.darkBackground },
-          headerTintColor: Colors.primaryText,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen
-        name="event/[id]"
-        options={{
-          presentation: 'modal',
-          title: 'Event Details',
-          headerStyle: { backgroundColor: Colors.darkBackground },
-          headerTintColor: Colors.primaryText,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen
-        name="create-event/index"
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name="create-event/step-1-basics"
-        options={{
-          title: 'Create Event',
-          headerStyle: { backgroundColor: Colors.darkBackground },
-          headerTintColor: Colors.primaryText,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen
-        name="create-event/step-2-location"
-        options={{
-          title: 'Create Event',
-          headerStyle: { backgroundColor: Colors.darkBackground },
-          headerTintColor: Colors.primaryText,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen
-        name="create-event/step-3-tickets"
-        options={{
-          title: 'Create Event',
-          headerStyle: { backgroundColor: Colors.darkBackground },
-          headerTintColor: Colors.primaryText,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen
-        name="create-event/step-4-review"
-        options={{
-          title: 'Create Event',
-          headerStyle: { backgroundColor: Colors.darkBackground },
-          headerTintColor: Colors.primaryText,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen
-        name="organizer/staking"
-        options={{
-          title: 'Organizer Staking',
-          headerStyle: { backgroundColor: Colors.darkBackground },
-          headerTintColor: Colors.primaryText,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen name="+not-found" options={{ title: 'Not Found' }} />
-    </Stack>
+    <NavThemeProvider value={navTheme}>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="auth" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="checkout"
+          options={{
+            presentation: 'modal',
+            title: 'Ticket Checkout',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen
+          name="event/[id]"
+          options={{
+            presentation: 'modal',
+            title: 'Event Details',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen
+          name="create-event/index"
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="create-event/step-1-basics"
+          options={{
+            title: 'Create Event',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen
+          name="create-event/step-2-location"
+          options={{
+            title: 'Create Event',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen
+          name="create-event/step-3-tickets"
+          options={{
+            title: 'Create Event',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen
+          name="create-event/step-4-review"
+          options={{
+            title: 'Create Event',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen
+          name="organizer/staking"
+          options={{
+            title: 'Organizer Staking',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen name="+not-found" options={{ title: 'Not Found' }} />
+      </Stack>
+    </NavThemeProvider>
   );
 }
 
@@ -138,7 +161,7 @@ export default function RootLayout() {
 
   return (
     <ErrorBoundary>
-      <ThemeProvider value={AgoraNavigationTheme}>
+      <ThemeProvider>
         <AppNavigation />
       </ThemeProvider>
     </ErrorBoundary>

--- a/apps/mobile/context/ThemeContext.tsx
+++ b/apps/mobile/context/ThemeContext.tsx
@@ -1,0 +1,109 @@
+/**
+ * ThemeContext
+ *
+ * Tracks the device color scheme (light | dark) via React Native's
+ * Appearance API and re-renders consumers whenever the system theme changes.
+ *
+ * Exposes:
+ *   colorScheme  – 'light' | 'dark' (never null)
+ *   theme        – resolved color tokens for the current scheme
+ *   toggleTheme  – manual override (useful for in-app toggle / testing)
+ */
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { Appearance, ColorSchemeName } from 'react-native';
+import { Colors } from '@/constants/Colors';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ThemeColorScheme = 'light' | 'dark';
+
+export type ThemeColors = typeof Colors.light; // { text, background, tint, icon, … }
+
+export interface ThemeContextValue {
+  /** Resolved color scheme – always 'light' or 'dark'. */
+  colorScheme: ThemeColorScheme;
+  /** Resolved color token map for the active scheme. */
+  theme: ThemeColors;
+  /** Brand palette (scheme-independent tokens). */
+  palette: Omit<typeof Colors, 'light' | 'dark'>;
+  /** Override the scheme manually. Pass `null` to revert to system default. */
+  toggleTheme: (scheme?: ThemeColorScheme | null) => void;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+ThemeContext.displayName = 'ThemeContext';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function resolveScheme(raw: ColorSchemeName): ThemeColorScheme {
+  return raw === 'light' ? 'light' : 'dark';
+}
+
+// Brand tokens that are not scheme-dependent
+const { light: _light, dark: _dark, ...palette } = Colors;
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  // Seed from the current system value so there's no flash on first render
+  const [colorScheme, setColorScheme] = useState<ThemeColorScheme>(() =>
+    resolveScheme(Appearance.getColorScheme())
+  );
+
+  // Whether the user manually pinned a scheme (overrides system changes)
+  const [pinned, setPinned] = useState<ThemeColorScheme | null>(null);
+
+  useEffect(() => {
+    // Appearance.addChangeListener is available since RN 0.62
+    const subscription = Appearance.addChangeListener(({ colorScheme: next }) => {
+      // Only apply system changes when not manually overridden
+      if (pinned === null) {
+        setColorScheme(resolveScheme(next));
+      }
+    });
+
+    return () => subscription.remove();
+  }, [pinned]);
+
+  const toggleTheme = useCallback((scheme?: ThemeColorScheme | null) => {
+    if (scheme == null) {
+      // Revert to system theme
+      setPinned(null);
+      setColorScheme(resolveScheme(Appearance.getColorScheme()));
+    } else {
+      setPinned(scheme);
+      setColorScheme(scheme);
+    }
+  }, []);
+
+  const theme = useMemo<ThemeColors>(() => Colors[colorScheme], [colorScheme]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ colorScheme, theme, palette, toggleTheme }),
+    [colorScheme, theme, toggleTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+// ─── Internal helper (used by useTheme & useThemeColor) ───────────────────────
+
+export function useThemeContext(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useThemeContext must be used within a <ThemeProvider>.');
+  }
+  return ctx;
+}
+
+export default ThemeContext;

--- a/apps/mobile/hooks/useTheme.ts
+++ b/apps/mobile/hooks/useTheme.ts
@@ -1,0 +1,27 @@
+/**
+ * useTheme
+ *
+ * Convenience hook that exposes the full ThemeContext value.
+ *
+ * Usage:
+ *   const { colorScheme, theme, palette, toggleTheme } = useTheme();
+ *
+ *   // Read a theme token
+ *   const bg = theme.background;     // '#0F0F10' (dark) | '#FFFFFF' (light)
+ *   const text = theme.text;
+ *
+ *   // Read a brand token (scheme-independent)
+ *   const yellow = palette.primaryYellow;  // '#FDDA23'
+ *
+ *   // Manual override
+ *   toggleTheme('light');   // pin to light
+ *   toggleTheme(null);      // revert to system
+ */
+
+import { useThemeContext } from '@/context/ThemeContext';
+
+export function useTheme() {
+  return useThemeContext();
+}
+
+export default useTheme;

--- a/apps/mobile/hooks/useThemeColor.ts
+++ b/apps/mobile/hooks/useThemeColor.ts
@@ -1,22 +1,23 @@
 /**
- * Learn more about light and dark modes:
- * https://docs.expo.dev/guides/color-schemes/
+ * useThemeColor
+ *
+ * Returns a single resolved color value for the active theme.
+ * Reads the scheme from ThemeContext so it reacts instantly to both
+ * system-level Appearance changes and manual overrides.
+ *
+ * Usage:
+ *   const bg = useThemeColor({ light: '#FFF', dark: '#000' }, 'background');
  */
 
-import { useColorScheme } from 'react-native';
-
 import { Colors } from '@/constants/Colors';
+import { useThemeContext } from '@/context/ThemeContext';
 
 export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark
 ) {
-  const theme = useColorScheme() ?? 'light';
-  const colorFromProps = props[theme];
+  const { colorScheme } = useThemeContext();
+  const colorFromProps = props[colorScheme];
 
-  if (colorFromProps) {
-    return colorFromProps;
-  } else {
-    return Colors[theme][colorName];
-  }
+  return colorFromProps ?? Colors[colorScheme][colorName];
 }


### PR DESCRIPTION
# feat(mobile): system theme listening via ThemeContext (#1019)

## Summary

Implements a React Context-based theme system for the mobile app that tracks the device color scheme (light vs dark) and propagates changes instantly to all consumers via React Native's `Appearance` API.

## Changes

### New files

| File | Purpose |
|---|---|
| `apps/mobile/context/ThemeContext.tsx` | `ThemeProvider` + `ThemeContext` + `useThemeContext` internal hook |
| `apps/mobile/hooks/useTheme.ts` | Public `useTheme()` convenience hook |

### Modified files

| File | Change |
|---|---|
| `apps/mobile/hooks/useThemeColor.ts` | Reads `colorScheme` from `ThemeContext` instead of bare `useColorScheme()` |
| `apps/mobile/app/_layout.tsx` | Wraps app in `<ThemeProvider>`; navigation theme built dynamically from context |
| `apps/mobile/app/(tabs)/_layout.tsx` | Tab bar and header colors sourced from `useTheme()` instead of static `Colors.*` |
| `.gitignore` | Added `.kiro/` IDE directory exclusion |

## How it works

1. `ThemeProvider` seeds state from `Appearance.getColorScheme()` on mount — no light/dark flash on first render.
2. `Appearance.addChangeListener` fires whenever the OS theme changes; the context state updates and all consumers re-render.
3. Manual overrides via `toggleTheme('light' | 'dark')` pin the scheme independently of the system. Passing `null` reverts to system-following behaviour.
4. `useThemeColor` (used by `ThemedText` / `ThemedView`) now reads from the context, so background and text color variables update instantly across the entire component tree.
5. The react-navigation `ThemeProvider` receives a freshly computed theme object on every `colorScheme` change, keeping headers, tab bars, and modals in sync.

## Exposed API

```ts
const { colorScheme, theme, palette, toggleTheme } = useTheme();

// colorScheme  → 'light' | 'dark'
// theme        → { text, background, tint, icon, … }  (scheme-resolved tokens)
// palette      → { primaryYellow, darkBackground, primaryText, … }  (brand tokens)
// toggleTheme  → (scheme?: 'light' | 'dark' | null) => void
```

## Acceptance criteria

- [x] Changing the emulator system theme updates `background` and `text` color variables in the app instantly.
- [x] `ThemeContext` tracks light vs dark and exposes a `useTheme` helper hook.
- [x] Native `Appearance` dynamic theme listener is wired to the context.
- [x] Manual override supported via `toggleTheme` without breaking system-follow behaviour.

## Testing

Toggle **Settings → Developer options → Dark theme** (Android) or **Settings → Display & Brightness → Appearance** (iOS) on the emulator while the app is running. The tab bar, headers, and all `ThemedView`/`ThemedText` components should switch colour immediately without a reload.

closes #1019
