### PR TITLE
feat(contract): add cleanup_expired_proposals to remove stale ActiveProposals

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -1836,6 +1836,33 @@ impl EventRegistry {
     pub fn get_active_proposals(env: Env) -> Vec<u64> {
         storage::get_active_proposals(&env)
     }
+
+    /// Removes expired proposals from the `ActiveProposals` list.
+    ///
+    /// Any proposal whose `expires_at` timestamp has passed is considered expired and
+    /// will be removed from the active list. This prevents unbounded growth of the
+    /// list over time. Any admin may call this function.
+    ///
+    /// # Returns
+    /// The number of expired proposals that were removed.
+    pub fn cleanup_expired_proposals(env: Env) -> Result<u32, EventRegistryError> {
+        let _admin = auth::require_admin(&env)?;
+
+        let now = env.ledger().timestamp();
+        let active = storage::get_active_proposals(&env);
+        let mut removed: u32 = 0;
+
+        for proposal_id in active.iter() {
+            if let Some(proposal) = storage::get_proposal(&env, proposal_id) {
+                if now > proposal.expires_at && !proposal.executed && !proposal.cancelled {
+                    storage::remove_active_proposal(&env, proposal_id);
+                    removed += 1;
+                }
+            }
+        }
+
+        Ok(removed)
+    }
 }
 
 fn validate_address(env: &Env, address: &Address) -> Result<(), EventRegistryError> {

--- a/contract/contracts/event_registry/src/test_issue_fixes.rs
+++ b/contract/contracts/event_registry/src/test_issue_fixes.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::error::EventRegistryError;
-use crate::types::{EventRegistrationArgs, EventStatus, TicketTier};
+use crate::types::{EventRegistrationArgs, EventStatus, ParameterChange, TicketTier};
 use soroban_sdk::{testutils::Address as _, Address, Env, Map, String};
 
 fn test_payment_address(env: &Env) -> Address {
@@ -339,4 +339,94 @@ fn test_cancel_event_without_reason() {
     assert_eq!(info.status, EventStatus::Cancelled);
     assert_eq!(info.cancellation_reason, None);
     assert!(!info.is_active);
+}
+
+// ── Issue #885: cleanup_expired_proposals ─────────────────────────────────
+
+#[test]
+fn test_cleanup_expired_proposals_removes_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+
+    // Set ledger time so proposals have deterministic timestamps.
+    env.ledger().set_timestamp(1000);
+
+    // Propose a change that expires quickly (expiry_ledgers = 1 ledger = 1 second offset).
+    let proposal_id = client.propose_parameter_change(
+        &admin,
+        &ParameterChange::SetPlatformFee(300),
+        &10, // expires at ledger timestamp 1000 + 10 = 1010
+    );
+
+    // Verify it's in the active list.
+    let active_before = client.get_active_proposals();
+    assert!(active_before.contains(&proposal_id));
+
+    // Advance ledger past expiry.
+    env.ledger().set_timestamp(2000);
+
+    // Cleanup should remove the expired proposal.
+    let removed = client.cleanup_expired_proposals();
+    assert_eq!(removed, 1);
+
+    // It must no longer appear in the active list.
+    let active_after = client.get_active_proposals();
+    assert!(!active_after.contains(&proposal_id));
+}
+
+#[test]
+fn test_cleanup_expired_proposals_keeps_non_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+
+    // Create a proposal with a long expiry.
+    let long_lived = client.propose_parameter_change(
+        &admin,
+        &ParameterChange::SetPlatformFee(400),
+        &100_000, // expires far in the future
+    );
+
+    // Create a proposal with a short expiry.
+    let short_lived = client.propose_parameter_change(
+        &admin,
+        &ParameterChange::SetPlatformFee(500),
+        &5, // expires at 1005
+    );
+
+    // Advance past the short-lived proposal's expiry but not the long-lived one.
+    env.ledger().set_timestamp(1010);
+
+    let removed = client.cleanup_expired_proposals();
+    assert_eq!(removed, 1);
+
+    let active = client.get_active_proposals();
+    assert!(active.contains(&long_lived));
+    assert!(!active.contains(&short_lived));
+}
+
+#[test]
+fn test_cleanup_expired_proposals_ignores_executed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+
+    // Create and execute a proposal before it expires.
+    let pid = client.propose_parameter_change(
+        &admin,
+        &ParameterChange::SetPlatformFee(300),
+        &10_000,
+    );
+    client.execute_proposal(&admin, &pid);
+
+    // Advance past "expiry" and run cleanup; count should be 0 since it was already executed
+    // (and removed from active list by execute_proposal).
+    env.ledger().set_timestamp(999_999);
+    let removed = client.cleanup_expired_proposals();
+    assert_eq!(removed, 0);
 }


### PR DESCRIPTION
## Summary

- Add `cleanup_expired_proposals(env)` function callable by any admin
- Iterates `ActiveProposals`, removes entries whose `expires_at` has passed and are not yet executed
- Returns the count of removed proposals
- Add three tests covering: removal of expired, preservation of non-expired, and ignoring already-executed proposals

## Validation

- No formatter
- No linter
- No typecheck
- No build

Closes #885