### PR TITLE
feat(contract): add set_resale_cap_bps and validate resale cap on all write paths

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -522,7 +522,41 @@ impl EventRegistry {
         if event_info.feedback_cid.is_some() {
             require_event_ended(&env, &event_info).unwrap();
         }
+        // Validate resale_cap_bps on every write path (Issue #883).
+        if let Some(cap) = event_info.resale_cap_bps {
+            if cap > 10000 {
+                panic!("InvalidResaleCapBps");
+            }
+        }
         storage::store_event(&env, event_info);
+    }
+
+    /// Updates the resale cap for an event. Only callable by the event organizer.
+    ///
+    /// # Arguments
+    /// * `event_id` - The event to update.
+    /// * `resale_cap_bps` - New resale cap in basis points (`None` removes the cap).
+    ///   Must be `<= 10000` when `Some`.
+    pub fn set_resale_cap_bps(
+        env: Env,
+        event_id: String,
+        resale_cap_bps: Option<u32>,
+    ) -> Result<(), EventRegistryError> {
+        let mut event_info =
+            storage::get_event(&env, event_id.clone()).ok_or(EventRegistryError::EventNotFound)?;
+
+        auth::require_organizer(&env, &event_id, &event_info.organizer_address)?;
+
+        if let Some(cap) = resale_cap_bps {
+            if cap > 10000 {
+                return Err(EventRegistryError::InvalidResaleCapBps);
+            }
+        }
+
+        event_info.resale_cap_bps = resale_cap_bps;
+        storage::update_event(&env, event_info);
+
+        Ok(())
     }
 
     /// Retrieves an event by its ID.

--- a/contract/contracts/event_registry/src/test_issue_fixes.rs
+++ b/contract/contracts/event_registry/src/test_issue_fixes.rs
@@ -340,3 +340,117 @@ fn test_cancel_event_without_reason() {
     assert_eq!(info.cancellation_reason, None);
     assert!(!info.is_active);
 }
+
+// ── Issue #883: resale_cap_bps validation for update scenarios ─────────────
+
+#[test]
+fn test_set_resale_cap_bps_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let organizer = Address::generate(&env);
+
+    let args = make_event_args(
+        &env,
+        "evt_resale_valid",
+        &organizer,
+        100,
+        single_tier(&env, 100, 0),
+    );
+    client.register_event(&args);
+
+    // Setting a valid cap should succeed.
+    client.set_resale_cap_bps(
+        &String::from_str(&env, "evt_resale_valid"),
+        &Some(5000),
+    );
+
+    let info = client
+        .get_event(&String::from_str(&env, "evt_resale_valid"))
+        .unwrap();
+    assert_eq!(info.resale_cap_bps, Some(5000));
+}
+
+#[test]
+fn test_set_resale_cap_bps_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let organizer = Address::generate(&env);
+
+    let args = make_event_args(
+        &env,
+        "evt_resale_boundary",
+        &organizer,
+        100,
+        single_tier(&env, 100, 0),
+    );
+    client.register_event(&args);
+
+    // Exactly 10000 (100%) must be accepted.
+    client.set_resale_cap_bps(
+        &String::from_str(&env, "evt_resale_boundary"),
+        &Some(10000),
+    );
+
+    let info = client
+        .get_event(&String::from_str(&env, "evt_resale_boundary"))
+        .unwrap();
+    assert_eq!(info.resale_cap_bps, Some(10000));
+}
+
+#[test]
+fn test_set_resale_cap_bps_invalid_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let organizer = Address::generate(&env);
+
+    let args = make_event_args(
+        &env,
+        "evt_resale_invalid",
+        &organizer,
+        100,
+        single_tier(&env, 100, 0),
+    );
+    client.register_event(&args);
+
+    // Value above 10000 must return InvalidResaleCapBps.
+    let result = client.try_set_resale_cap_bps(
+        &String::from_str(&env, "evt_resale_invalid"),
+        &Some(10001),
+    );
+    assert_eq!(
+        result,
+        Err(Ok(EventRegistryError::InvalidResaleCapBps))
+    );
+}
+
+#[test]
+fn test_set_resale_cap_bps_none_clears_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let organizer = Address::generate(&env);
+
+    let mut args = make_event_args(
+        &env,
+        "evt_resale_clear",
+        &organizer,
+        100,
+        single_tier(&env, 100, 0),
+    );
+    args.resale_cap_bps = Some(3000);
+    client.register_event(&args);
+
+    // Clearing the cap (None) must be allowed.
+    client.set_resale_cap_bps(
+        &String::from_str(&env, "evt_resale_clear"),
+        &None,
+    );
+
+    let info = client
+        .get_event(&String::from_str(&env, "evt_resale_clear"))
+        .unwrap();
+    assert_eq!(info.resale_cap_bps, None);
+}


### PR DESCRIPTION
## Summary

- Add `set_resale_cap_bps(event_id, cap)` function for organizers to update the resale cap post-registration
- Validates that `resale_cap_bps <= 10000`; returns `InvalidResaleCapBps` on violation
- Add the same guard to the legacy `store_event` write path to close the bypass
- Add four tests: valid cap, boundary (10000), invalid (10001), and clearing cap with `None`

## Validation

- No formatter
- No linter
- No typecheck
- No build

Closes #883