### PR TITLE
feat: smart contract tier/CID validation fixes and help center metadata

### DIFF
--- a/apps/web/app/help/[category]/[slug]/page.tsx
+++ b/apps/web/app/help/[category]/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -9,6 +10,45 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import HelpCircleIcon from "@/public/icons/help-circle.svg";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ category: string; slug: string }>;
+}): Promise<Metadata> {
+  const { category, slug } = await params;
+  const article = getArticle(category, slug);
+
+  if (!article) {
+    return {
+      title: "Article Not Found | Agora Help Center",
+    };
+  }
+
+  const title = `${article.title} | Help Center - Agora`;
+  const description = article.summary || article.content.slice(0, 160).replace(/[#*`]/g, "").trim();
+  const canonicalUrl = `https://agora.events/help/${category}/${slug}`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonicalUrl,
+      type: "article",
+      siteName: "Agora Events",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
 
 export default async function HelpArticlePage({
   params,

--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -622,9 +622,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
 
 [[package]]
 name = "event-registry"

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -838,6 +838,74 @@ impl EventRegistry {
         Ok(())
     }
 
+    /// Checks whether a specific tier for an event is sold out.
+    pub fn is_tier_sold_out(
+        env: Env,
+        event_id: String,
+        tier_id: String,
+    ) -> Result<bool, EventRegistryError> {
+        let event_info = storage::get_event(&env, event_id).ok_or(EventRegistryError::EventNotFound)?;
+        let tier = event_info
+            .tiers
+            .get(tier_id)
+            .ok_or(EventRegistryError::TierNotFound)?;
+        Ok(tier.current_sold >= tier.tier_limit)
+    }
+
+    /// Adds a new ticket tier to an existing event.
+    /// Restricted to the event organizer.
+    pub fn add_tier(
+        env: Env,
+        event_id: String,
+        tier_id: String,
+        tier: TicketTier,
+    ) -> Result<(), EventRegistryError> {
+        let mut event_info = storage::get_event(&env, event_id.clone()).ok_or(EventRegistryError::EventNotFound)?;
+        event_info.organizer.require_auth();
+
+        if event_info.max_supply > 0 {
+            let mut total_tier_limit: i128 = 0;
+            for existing_tier in event_info.tiers.values() {
+                total_tier_limit = total_tier_limit
+                    .checked_add(existing_tier.tier_limit)
+                    .ok_or(EventRegistryError::SupplyOverflow)?;
+            }
+            total_tier_limit = total_tier_limit
+                .checked_add(tier.tier_limit)
+                .ok_or(EventRegistryError::SupplyOverflow)?;
+
+            if total_tier_limit > event_info.max_supply {
+                return Err(EventRegistryError::TierLimitExceeds);
+            }
+        }
+
+        event_info.tiers.set(tier_id, tier);
+        storage::set_event(&env, &event_id, &event_info);
+        Ok(())
+    }
+
+    /// Deactivates a tier by setting its limit equal to current_sold, preventing further sales.
+    /// Restricted to the event organizer.
+    pub fn deactivate_tier(
+        env: Env,
+        event_id: String,
+        tier_id: String,
+    ) -> Result<(), EventRegistryError> {
+        let mut event_info = storage::get_event(&env, event_id.clone()).ok_or(EventRegistryError::EventNotFound)?;
+        event_info.organizer.require_auth();
+
+        let mut tier = event_info
+            .tiers
+            .get(tier_id.clone())
+            .ok_or(EventRegistryError::TierNotFound)?;
+
+        tier.tier_limit = tier.current_sold;
+        event_info.tiers.set(tier_id, tier);
+        storage::set_event(&env, &event_id, &event_info);
+        Ok(())
+    }
+
+
     /// Decrements the current_supply counter for a given event and tier.
     /// This function is restricted to calls from the authorized TicketPayment contract upon refund.
     ///
@@ -1907,20 +1975,27 @@ fn validate_address(env: &Env, address: &Address) -> Result<(), EventRegistryErr
 }
 
 fn validate_metadata_cid(env: &Env, cid: &String) -> Result<(), EventRegistryError> {
-    if cid.len() < 46 {
-        return Err(EventRegistryError::InvalidMetadataCid);
-    }
-
-    // We expect CIDv1 base32, which starts with 'b'
-    // Convert to Bytes to check the first character safely
+    let len = cid.len();
     let mut bytes = soroban_sdk::Bytes::new(env);
     bytes.append(&cid.clone().into());
 
-    if !bytes.is_empty() && bytes.get(0) != Some(b'b') {
-        return Err(EventRegistryError::InvalidMetadataCid);
+    // CIDv0: starts with "Qm" and is at least 46 characters long
+    if len >= 46 && bytes.len() >= 2 && bytes.get(0) == Some(b'Q') && bytes.get(1) == Some(b'm') {
+        return Ok(());
     }
 
-    Ok(())
+    // CIDv1: starts with "bafy" and is at least 59 characters long
+    if len >= 59
+        && bytes.len() >= 4
+        && bytes.get(0) == Some(b'b')
+        && bytes.get(1) == Some(b'a')
+        && bytes.get(2) == Some(b'f')
+        && bytes.get(3) == Some(b'y')
+    {
+        return Ok(());
+    }
+
+    Err(EventRegistryError::InvalidMetadataCid)
 }
 
 fn require_event_ended(env: &Env, event_info: &EventInfo) -> Result<(), EventRegistryError> {

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -4488,3 +4488,121 @@ fn test_get_events_batch_limit() {
     let res = client.try_get_events_batch(&event_ids);
     assert_eq!(res, Err(Ok(EventRegistryError::TooManyTiers)));
 }
+
+// ── Issues #862, #863, #864: CID validation, is_tier_sold_out, add_tier, deactivate_tier ──
+
+#[test]
+fn test_validate_metadata_cid_v0_and_v1() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_contract(&env);
+    let organizer = Address::generate(&env);
+
+    // CIDv0 (Qm... len >= 46) should succeed
+    let cid_v0 = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    let mut args = make_args(&env, "event_cid_v0", &organizer, None);
+    args.metadata_cid = cid_v0;
+    client.register_event(&args);
+
+    // CIDv1 (bafy... len >= 59) should succeed
+    let cid_v1 = String::from_str(&env, "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi");
+    let mut args2 = make_args(&env, "event_cid_v1", &organizer, None);
+    args2.metadata_cid = cid_v1;
+    client.register_event(&args2);
+
+    // Invalid prefix should fail
+    let invalid_cid = String::from_str(&env, "invalid_cid_prefix_1234567890123456789012345678901234567890");
+    let mut args3 = make_args(&env, "event_invalid_cid", &organizer, None);
+    args3.metadata_cid = invalid_cid;
+    let res = client.try_register_event(&args3);
+    assert_eq!(res, Err(Ok(EventRegistryError::InvalidMetadataCid)));
+}
+
+#[test]
+fn test_is_tier_sold_out() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_contract(&env);
+    let organizer = Address::generate(&env);
+    let event_id = String::from_str(&env, "sold_out_event");
+    let tier_id = String::from_str(&env, "general");
+
+    client.register_event(&make_args(&env, "sold_out_event", &organizer, None));
+
+    // Initially not sold out
+    assert!(!client.is_tier_sold_out(&event_id, &tier_id));
+
+    // Non-existent event returns EventNotFound
+    let fake_event = String::from_str(&env, "non_existent");
+    assert_eq!(
+        client.try_is_tier_sold_out(&fake_event, &tier_id),
+        Err(Ok(EventRegistryError::EventNotFound))
+    );
+
+    // Non-existent tier returns TierNotFound
+    let fake_tier = String::from_str(&env, "fake_tier");
+    assert_eq!(
+        client.try_is_tier_sold_out(&event_id, &fake_tier),
+        Err(Ok(EventRegistryError::TierNotFound))
+    );
+}
+
+#[test]
+fn test_add_tier_and_deactivate_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_contract(&env);
+    let organizer = Address::generate(&env);
+    let event_id = String::from_str(&env, "tier_mgmt_event");
+    let new_tier_id = String::from_str(&env, "vip_new");
+
+    client.register_event(&make_args(&env, "tier_mgmt_event", &organizer, None));
+
+    let new_tier = TicketTier {
+        name: String::from_str(&env, "VIP New"),
+        price: 200,
+        tier_limit: 50,
+        current_sold: 0,
+        is_refundable: true,
+        auction_config: soroban_sdk::Vec::new(&env),
+        loyalty_multiplier: 2,
+        max_per_user: 5,
+    };
+
+    // Add new tier succeeds
+    client.add_tier(&event_id, &new_tier_id, &new_tier);
+    assert!(!client.is_tier_sold_out(&event_id, &new_tier_id));
+
+    // Deactivate tier sets tier_limit = current_sold (0), making it sold out
+    client.deactivate_tier(&event_id, &new_tier_id);
+    assert!(client.is_tier_sold_out(&event_id, &new_tier_id));
+}
+
+#[test]
+fn test_add_tier_exceeds_max_supply() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_contract(&env);
+    let organizer = Address::generate(&env);
+    let event_id = String::from_str(&env, "max_supply_event");
+    let new_tier_id = String::from_str(&env, "overflow_tier");
+
+    let mut args = make_args(&env, "max_supply_event", &organizer, None);
+    args.max_supply = 100; // Total supply limit 100, initial tier limit is 100
+    client.register_event(&args);
+
+    let overflow_tier = TicketTier {
+        name: String::from_str(&env, "Extra Tier"),
+        price: 100,
+        tier_limit: 10, // 100 + 10 > 100 max_supply
+        current_sold: 0,
+        is_refundable: true,
+        auction_config: soroban_sdk::Vec::new(&env),
+        loyalty_multiplier: 1,
+        max_per_user: 0,
+    };
+
+    let res = client.try_add_tier(&event_id, &new_tier_id, &overflow_tier);
+    assert_eq!(res, Err(Ok(EventRegistryError::TierLimitExceeds)));
+}
+


### PR DESCRIPTION
## Description

This PR resolves four outstanding issues across the smart contract and frontend packages with complete implementations and test coverage:

### 1. Smart Contract CID Format Validation (#862)
- Updated `validate_metadata_cid` in `contract/contracts/event_registry/src/lib.rs` to validate both CIDv0 (prefix `Qm`, length ≥ 46) and CIDv1 (prefix `bafy`, length ≥ 59).
- Rejects any other string format with `InvalidMetadataCid`.

### 2. Tier Sold-Out Query Function (#863)
- Added `is_tier_sold_out(env, event_id, tier_id) -> Result<bool, EventRegistryError>` to check if `current_sold >= tier_limit`.
- Returns `EventNotFound` if the event does not exist and `TierNotFound` if the tier does not exist.

### 3. Organizer Tier Management (#864)
- Added `add_tier(env, event_id, tier_id, tier)` restricted to event organizers. Validates that adding the tier does not cause total tier limits to exceed `max_supply` (returning `TierLimitExceeds` if exceeded).
- Added `deactivate_tier(env, event_id, tier_id)` restricted to event organizers. Sets `tier_limit = current_sold` to prevent future sales while preserving historical sales data.

### 4. Help Center Article Page OG Meta & Title Tags (#1058)
- Exported `generateMetadata({ params })` in `apps/web/app/help/[category]/[slug]/page.tsx` to set dynamic `<title>`, `<meta name="description">`, canonical URL, OpenGraph, and Twitter card metadata for each help article.

### 5. Unit Tests
- Added test coverage in `contract/contracts/event_registry/src/test.rs` for CIDv0/CIDv1 validation, `is_tier_sold_out`, `add_tier` max supply bounds, and `deactivate_tier`.

Closes #864
Closes #862
Closes #863
Closes #1058