### PR TITLE
Attendees pagination, ticket-tiers response fix, and event token whitelist enforcement

### DIFF
--- a/contract/contracts/event_registry/src/error.rs
+++ b/contract/contracts/event_registry/src/error.rs
@@ -56,4 +56,6 @@ pub enum EventRegistryError {
     AlreadyOnWaitlist = 75,
     TooManyTiers = 80,
     // TooManyIds = 81,
+    /// Issue #851: payment token is not in the event's accepted_tokens list.
+    TokenNotAccepted = 82,
 }

--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -241,6 +241,21 @@ impl EventRegistry {
             }
         }
 
+        // Validate milestone plan: the sum of all release_percent values
+        // (basis points) must not exceed 10000 (100%), or the plan would
+        // release more revenue than was ever collected (Issue #850).
+        if let Some(ref milestones) = args.milestone_plan {
+            let mut total_release_bps: u32 = 0;
+            for milestone in milestones.iter() {
+                total_release_bps = total_release_bps
+                    .checked_add(milestone.release_percent)
+                    .ok_or(EventRegistryError::InvalidMilestonePlan)?;
+            }
+            if total_release_bps > 10000 {
+                return Err(EventRegistryError::InvalidMilestonePlan);
+            }
+        }
+
         // Validate event time range
         if args.start_time != 0 && args.end_time != 0 && args.end_time <= args.start_time {
             return Err(EventRegistryError::InvalidDeadline);
@@ -728,12 +743,18 @@ impl EventRegistry {
     /// * `TierSupplyExceeded` - If the tier's limit has been reached.
     /// * `MaxSupplyExceeded` - If the event's max supply has been reached (when max_supply > 0).
     /// * `SupplyOverflow` - If incrementing would cause an i128 overflow.
+    /// * `TokenNotAccepted` - If the event configured a non-empty `accepted_tokens`
+    ///   list and `payment_token` is not in it (Issue #851). This is a defense-in-depth
+    ///   cross-validation: the primary enforcement lives in the `TicketPayment`
+    ///   contract, but a misconfigured or malicious caller of this function
+    ///   would otherwise bypass it entirely.
     pub fn increment_inventory(
         env: Env,
         event_id: String,
         tier_id: String,
         user: Address,
         quantity: u32,
+        payment_token: Address,
     ) -> Result<(), EventRegistryError> {
         let ticket_payment_addr =
             storage::get_ticket_payment_contract(&env).ok_or(EventRegistryError::NotInitialized)?;
@@ -748,6 +769,15 @@ impl EventRegistry {
 
         if !event_info.is_active || matches!(event_info.status, EventStatus::Cancelled) {
             return Err(EventRegistryError::EventInactive);
+        }
+
+        // Issue #851: when the event restricts payments to specific tokens,
+        // enforce that here too rather than trusting the caller (normally
+        // the TicketPayment contract) to have already validated it.
+        if !event_info.accepted_tokens.is_empty()
+            && !event_info.accepted_tokens.contains(&payment_token)
+        {
+            return Err(EventRegistryError::TokenNotAccepted);
         }
 
         let quantity_i128 = quantity as i128;

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -3986,9 +3986,14 @@ fn test_goal_met_flag_set_when_target_reached() {
     // Initially goal_met should be false
     assert!(!client.get_event(&event_id).unwrap().goal_met);
 
+    // This event opted into use_global_whitelist, so the payment token must
+    // be globally whitelisted first (Issue #851).
+    let payment_token = Address::generate(&env);
+    client.add_to_token_whitelist(&payment_token);
+
     // Increment inventory 10 times to reach the target
     for _ in 0..10 {
-        client.increment_inventory(&event_id, &tier_id, &Address::generate(&env), &1);
+        client.increment_inventory(&event_id, &tier_id, &Address::generate(&env), &1, &payment_token);
     }
 
     // After reaching target, goal_met should be true
@@ -4232,8 +4237,13 @@ fn test_global_counters_full_lifecycle() {
         referral_rate_bps: None,
     });
 
+    // This event opted into use_global_whitelist, so the payment token must
+    // be globally whitelisted first (Issue #851).
+    let payment_token = Address::generate(&env);
+    client.add_to_token_whitelist(&payment_token);
+
     for _ in 0..5 {
-        client.increment_inventory(&event_id2, &tier_id2, &Address::generate(&env), &1);
+        client.increment_inventory(&event_id2, &tier_id2, &Address::generate(&env), &1, &payment_token);
     }
     assert_eq!(client.get_global_tickets_sold(), 5);
 }

--- a/contract/contracts/event_registry/src/test_issue_fixes.rs
+++ b/contract/contracts/event_registry/src/test_issue_fixes.rs
@@ -106,6 +106,7 @@ fn test_per_user_limit_enforced() {
         &String::from_str(&env, "tier_1"),
         &user,
         &2,
+        &Address::generate(&env),
     );
 
     // Second purchase of 1 should fail (2 + 1 > 2)
@@ -146,6 +147,7 @@ fn test_per_user_limit_zero_means_unlimited() {
             &String::from_str(&env, "tier_1"),
             &user,
             &1,
+            &Address::generate(&env),
         );
     }
 }
@@ -185,6 +187,7 @@ fn test_global_tickets_sold_increments() {
         &String::from_str(&env, "tier_1"),
         &user1,
         &3,
+        &Address::generate(&env),
     );
     assert_eq!(client.get_global_tickets_sold(), 3);
 
@@ -194,6 +197,7 @@ fn test_global_tickets_sold_increments() {
         &String::from_str(&env, "tier_1"),
         &user2,
         &2,
+        &Address::generate(&env),
     );
     assert_eq!(client.get_global_tickets_sold(), 5);
 
@@ -212,6 +216,7 @@ fn test_global_tickets_sold_increments() {
         &String::from_str(&env, "tier_1"),
         &user1,
         &4,
+        &Address::generate(&env),
     );
     assert_eq!(client.get_global_tickets_sold(), 9);
 }

--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -789,7 +789,13 @@ impl TicketPaymentContract {
 
         // 6. Increment inventory after successful payment
         // Use owner_address (recipient) for inventory tracking, not buyer_address
-        registry_client.increment_inventory(&event_id, &ticket_tier_id, &owner_address, &quantity);
+        registry_client.increment_inventory(
+            &event_id,
+            &ticket_tier_id,
+            &owner_address,
+            &quantity,
+            &token_address,
+        );
 
         // 7. Create payment records for each individual ticket
         let quantity_i128 = quantity as i128;
@@ -2363,7 +2369,13 @@ impl TicketPaymentContract {
         );
 
         // Increment inventory
-        registry_client.increment_inventory(&event_id, &ticket_tier_id, &bidder_address, &1);
+        registry_client.increment_inventory(
+            &event_id,
+            &ticket_tier_id,
+            &bidder_address,
+            &1,
+            &winning_bid.token_address,
+        );
 
         // Record the payment
         let empty_tx_hash = String::from_str(&env, "");

--- a/contract/contracts/ticket_payment/src/interfaces.rs
+++ b/contract/contracts/ticket_payment/src/interfaces.rs
@@ -75,6 +75,7 @@ pub mod event_registry {
             tier_id: String,
             user: Address,
             quantity: u32,
+            payment_token: Address,
         );
         fn decrement_inventory(env: Env, event_id: String, tier_id: String, user: Address);
         fn get_global_promo_bps(env: Env) -> u32;

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -168,6 +168,7 @@ impl MockEventRegistry {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -253,6 +254,7 @@ impl MockEventRegistry2 {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -339,6 +341,7 @@ impl MockAuctionEventRegistry {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -370,6 +373,7 @@ impl MockEventRegistryNotFound {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -1298,6 +1302,7 @@ impl MockEventRegistryMaxSupply {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
         panic!("MaxSupplyExceeded");
     }
@@ -1429,6 +1434,7 @@ impl MockEventRegistryWithInventory {
         _tier_id: String,
         _user: Address,
         quantity: u32,
+    _payment_token: Address,
     ) {
         let key = Symbol::new(&env, "supply");
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
@@ -1690,6 +1696,7 @@ impl MockEventRegistryWithMilestones {
         _tier_id: String,
         _user: Address,
         quantity: u32,
+    _payment_token: Address,
     ) {
         let key = Symbol::new(&env, "supply");
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
@@ -2124,6 +2131,7 @@ impl MockEventRegistryEarlyBird {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -2689,6 +2697,7 @@ impl MockEventRegistryWithOrganizer {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -3090,6 +3099,7 @@ impl MockPlatformRegistryE2E {
         tier_id: String,
         _user: Address,
         quantity: u32,
+    _payment_token: Address,
     ) {
         let mut event = env
             .storage()
@@ -3581,6 +3591,7 @@ impl MockEventRegistryRefund {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -3668,6 +3679,7 @@ impl MockEventRegistryWithResaleCap {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -3974,6 +3986,7 @@ impl MockRegistryZeroCap {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -4646,6 +4659,7 @@ impl MockEventRegistryUsdPriced {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -5400,6 +5414,7 @@ impl MockEventRegistryWithFailingLoyaltyUpdate {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -5548,6 +5563,7 @@ impl MockEventRegistryWithLoyalty {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -5644,6 +5660,7 @@ impl MockEventRegistryWithExcessiveLoyaltyDiscount {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -5892,6 +5909,7 @@ impl MockEventRegistryCustomFee {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -6041,6 +6059,7 @@ impl MockEventRegistryHighPrice {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -6169,6 +6188,7 @@ impl MockEventRegistryRefundDeadline {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -6801,6 +6821,7 @@ impl MockEventRegistryForDust {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -7030,6 +7051,7 @@ impl MockEventRegistryEnforceMaxPerUser {
         _tier_id: String,
         user: Address,
         quantity: u32,
+    _payment_token: Address,
     ) {
         // Track purchases per user in instance storage keyed by Address.
         let current: u32 = env.storage().instance().get(&user).unwrap_or(0u32);
@@ -7149,6 +7171,7 @@ impl MockEventRegistryUnlimitedPerUser {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
         // Unlimited: accept any increments
     }
@@ -7393,6 +7416,7 @@ impl MockEventRegistryForReferral {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -7487,6 +7511,7 @@ impl MockEventRegistryFullLoyaltyDiscount {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn get_global_promo_bps(_env: Env) -> u32 {
@@ -8778,6 +8803,7 @@ impl MockTransferLockRegistry {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}
@@ -9686,6 +9712,7 @@ impl MockRegistryNoScanner {
         _tier_id: String,
         _buyer: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _buyer: Address) {}
@@ -9781,6 +9808,7 @@ impl MockRegistryWithScanner {
         _tier_id: String,
         _buyer: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _buyer: Address) {}
@@ -10046,6 +10074,7 @@ impl MockRegistryMilestone {
         _tier_id: String,
         _buyer: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _buyer: Address) {}

--- a/contract/contracts/ticket_payment/src/test_e2e.rs
+++ b/contract/contracts/ticket_payment/src/test_e2e.rs
@@ -109,6 +109,7 @@ impl MockRegistryE2E {
         _tier_id: String,
         _user: Address,
         quantity: u32,
+    _payment_token: Address,
     ) {
         let key = Symbol::new(&env, "supply");
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
@@ -344,6 +345,7 @@ impl MockRegistryWithGoal {
         _tier_id: String,
         _user: Address,
         quantity: u32,
+    _payment_token: Address,
     ) {
         let key = (Symbol::new(&env, "supply"), event_id);
         let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
@@ -1180,6 +1182,7 @@ impl MockRegistryAuction {
         _tier_id: String,
         _user: Address,
         _quantity: u32,
+    _payment_token: Address,
     ) {
     }
     pub fn decrement_inventory(_env: Env, _event_id: String, _tier_id: String, _user: Address) {}

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -21,7 +21,8 @@ use crate::middleware::audit::AuditMetadata;
 use crate::models::event::{populate_is_free, Event};
 use crate::models::organizer_profile::OrganizerProfile;
 use crate::utils::cursor_pagination::{
-    decode_cursor, encode_cursor, CursorParams, CursorResponse, EventCursor, PastEventCursor,
+    decode_cursor, encode_cursor, AttendeeCursor, CursorParams, CursorResponse, EventCursor,
+    PastEventCursor,
 };
 use crate::utils::db_timer::log_if_slow;
 use crate::utils::error::AppError;
@@ -3383,6 +3384,116 @@ pub async fn get_event_organizer(
     success(profile, "Organizer profile retrieved successfully").into_response()
 }
 
+/// Response shape for a single attendee row.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct AttendeeResponse {
+    pub id: Uuid,
+    pub owner_wallet: Option<String>,
+    pub buyer_wallet: Option<String>,
+    pub quantity: i32,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+/// GET /api/v1/events/:id/attendees
+///
+/// Cursor-paginated list of ticket holders for an event. Default page size
+/// is 20, maximum 100. Requesting beyond the last page returns an empty
+/// list and no `next_cursor` (Issue #854).
+pub async fn list_event_attendees(
+    State(state): State<EventState>,
+    Path(event_id): Path<Uuid>,
+    Query(pagination): Query<CursorParams>,
+) -> Response {
+    let event_exists = match sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM events WHERE id = $1 AND is_flagged = FALSE)",
+    )
+    .bind(event_id)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("Failed to check event existence: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    if !event_exists {
+        return AppError::NotFound(format!("Event with id '{event_id}' not found")).into_response();
+    }
+
+    let validated = pagination.validate();
+
+    let cursor = match validated.cursor {
+        Some(ref c) => match decode_cursor::<AttendeeCursor>(c) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                tracing::warn!("Invalid cursor provided: {}", e);
+                return AppError::ValidationError(format!("Invalid cursor: {}", e)).into_response();
+            }
+        },
+        None => None,
+    };
+
+    let items_query = if cursor.is_some() {
+        r#"
+        SELECT t.id, t.owner_wallet, t.buyer_wallet, t.quantity, t.created_at
+        FROM tickets t
+        JOIN ticket_tiers tt ON t.ticket_tier_id = tt.id
+        WHERE tt.event_id = $1
+          AND (t.created_at > $3 OR (t.created_at = $3 AND t.id > $4))
+        ORDER BY t.created_at ASC, t.id ASC
+        LIMIT $2
+        "#
+    } else {
+        r#"
+        SELECT t.id, t.owner_wallet, t.buyer_wallet, t.quantity, t.created_at
+        FROM tickets t
+        JOIN ticket_tiers tt ON t.ticket_tier_id = tt.id
+        WHERE tt.event_id = $1
+        ORDER BY t.created_at ASC, t.id ASC
+        LIMIT $2
+        "#
+    };
+
+    let mut query_builder = sqlx::query_as::<_, AttendeeResponse>(items_query)
+        .bind(event_id)
+        .bind(validated.query_limit());
+
+    if let Some(ref c) = cursor {
+        query_builder = query_builder.bind(c.created_at).bind(c.id);
+    }
+
+    let mut items = match query_builder.fetch_all(&state.pool).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to fetch attendees for event {}: {:?}", event_id, e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let has_more = items.len() > validated.page_size();
+    let next_cursor = if has_more {
+        let last = items.pop().unwrap();
+        match encode_cursor(&AttendeeCursor {
+            created_at: last.created_at,
+            id: last.id,
+        }) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                tracing::error!("Failed to encode attendee cursor: {:?}", e);
+                return AppError::InternalServerError("Failed to encode cursor".to_string())
+                    .into_response();
+            }
+        }
+    } else {
+        None
+    };
+
+    let response = CursorResponse::new(items, &validated, next_cursor);
+    success(response, "Attendees retrieved successfully").into_response()
+}
+
 /// GET /api/v1/events/:id/export-attendees
 ///
 /// Exports all attendees for an event as a CSV file.
@@ -3673,20 +3784,23 @@ pub async fn list_events_by_category(
     success(response, "Events in category retrieved successfully").into_response()
 }
 
-/// Response shape for a single ticket tier.
+/// Response shape for a single ticket tier (Issue #853).
 #[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct TicketTierResponse {
     pub id: Uuid,
     pub name: String,
+    pub description: Option<String>,
     pub price: rust_decimal::Decimal,
-    pub quantity: i32,
-    pub sold: i32,
+    pub total_quantity: i32,
+    pub available_quantity: i32,
+    pub created_at: chrono::DateTime<Utc>,
 }
 
 /// GET `/api/v1/events/:id/ticket-tiers`
 ///
 /// Returns all ticket tiers for the given event ordered by price ascending.
-/// Returns 404 if the event does not exist.
+/// Returns 404 if the event does not exist; returns an empty list if the
+/// event exists but has no tiers (Issue #853).
 pub async fn list_ticket_tiers(
     State(state): State<EventState>,
     Path(event_id): Path<Uuid>,
@@ -3714,9 +3828,11 @@ pub async fn list_ticket_tiers(
         SELECT
             id,
             name,
+            description,
             price,
-            total_quantity    AS quantity,
-            (total_quantity - available_quantity) AS sold
+            total_quantity,
+            available_quantity,
+            created_at
         FROM ticket_tiers
         WHERE event_id = $1
         ORDER BY price ASC
@@ -3744,14 +3860,17 @@ fn test_ticket_tier_response_serialization() {
     let tier = TicketTierResponse {
         id: Uuid::new_v4(),
         name: "General".to_string(),
+        description: Some("General admission".to_string()),
         price: Decimal::new(2500, 2),
-        quantity: 500,
-        sold: 120,
+        total_quantity: 500,
+        available_quantity: 380,
+        created_at: Utc::now(),
     };
     let json = serde_json::to_value(&tier).unwrap();
     assert_eq!(json["name"], "General");
-    assert_eq!(json["quantity"], 500);
-    assert_eq!(json["sold"], 120);
+    assert_eq!(json["description"], "General admission");
+    assert_eq!(json["total_quantity"], 500);
+    assert_eq!(json["available_quantity"], 380);
 }
 
 #[test]

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -41,9 +41,10 @@ use crate::handlers::{
     events::{
         export_attendees_csv, get_attendee_count, get_checkin_stats, get_event, get_event_counts,
         get_event_organizer, get_event_share_link, get_event_social_proof, get_ratings_summary,
-        list_event_ratings, list_event_tickets, list_events, list_events_by_category,
-        list_past_events, list_similar_events, list_ticket_tiers, list_upcoming_events,
-        search_events, set_event_featured, submit_event_rating, toggle_event_flag, EventState,
+        list_event_attendees, list_event_ratings, list_event_tickets, list_events,
+        list_events_by_category, list_past_events, list_similar_events, list_ticket_tiers,
+        list_upcoming_events, search_events, set_event_featured, submit_event_rating,
+        toggle_event_flag, EventState,
     },
     example_empty_success, example_not_found, example_validation_error,
     health::{
@@ -200,6 +201,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/upcoming", get(list_upcoming_events))
         .route("/search", get(search_events))
         .route("/:id", get(get_event))
+        .route("/:id/attendees", get(list_event_attendees))
         .route("/:id/attendees/count", get(get_attendee_count))
         .route("/:id/rate", post(submit_event_rating))
         .route("/:id/check-in-stats", get(get_checkin_stats))

--- a/server/src/utils/cursor_pagination.rs
+++ b/server/src/utils/cursor_pagination.rs
@@ -165,6 +165,13 @@ pub struct PastEventCursor {
     pub id: uuid::Uuid,
 }
 
+/// Cursor structure for event attendee listings ordered by (created_at ASC, id ASC).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AttendeeCursor {
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub id: uuid::Uuid,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- **Attendees pagination**: added `GET /api/v1/events/:id/attendees`, cursor-paginated (`limit`/`cursor` query params, default page size 20, max 100, `next_cursor` in the response), reusing the existing `CursorParams`/`CursorResponse` utilities used elsewhere in the codebase. Requesting beyond the last page returns an empty list with no `next_cursor`. Closes #854
- **Ticket tiers response shape**: `GET /api/v1/events/:id/ticket-tiers` existed but returned a derived `quantity`/`sold` pair missing `description`, `total_quantity`, `available_quantity`, and `created_at`. Updated the response to select and return those fields directly from `ticket_tiers` (all already present in the schema). 404 on missing event and empty-list-on-no-tiers behavior were already correct. Closes #853
- **Event-specific token whitelist enforcement**: `increment_inventory` now takes a `payment_token: Address` parameter and rejects the call with a new `TokenNotAccepted` error when the event's `accepted_tokens` list is non-empty and doesn't contain it — closing the gap where a misconfigured or malicious `TicketPayment`-compatible caller could bypass event-specific token restrictions. The two real call sites in `ticket_payment/src/contract.rs` now pass the actual payment token. The check only activates when `accepted_tokens` is explicitly configured (non-empty), so it's non-breaking for events that don't restrict tokens (the existing `storage::is_token_accepted_for_event` global-whitelist fallback was left as-is to avoid a much larger, riskier retrofit of ~40 existing call sites that predate any token-whitelist enforcement). Closes #851
- **Milestone plan validation**: `register_event` now sums all `release_percent` values (basis points) across the milestone plan and returns `InvalidMilestonePlan` if the total exceeds 10000 (100%), preventing an organizer from registering a plan that would cumulatively release more revenue than was ever collected. Closes #850

## Test plan

- [ ] `cd server && cargo build` — new `list_event_attendees` handler and updated `TicketTierResponse`
- [ ] `cd contract && cargo build -p event_registry -p ticket_payment` — new `payment_token` parameter on `increment_inventory` and the milestone-plan sum check
- [ ] Manually call `GET /api/v1/events/:id/attendees?limit=2` and page through with the returned `next_cursor`
- [ ] Manually call `GET /api/v1/events/:id/ticket-tiers` and confirm `description`/`total_quantity`/`available_quantity`/`created_at` are present
- [ ] Register an event with `accepted_tokens` set, then call `increment_inventory` with a token not in that list and confirm it's rejected with `TokenNotAccepted`
- [ ] Register an event with a milestone plan whose `release_percent` values sum to >10000 and confirm `InvalidMilestonePlan` is returned; confirm exactly-10000 and under-10000 plans are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)