### PR TITLE
fix: resolve issues #1066 #1069 #1071 #1073

### DIFF
--- a/apps/web/components/layout/chat-sidebar.tsx
+++ b/apps/web/components/layout/chat-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useMemo } from "react";
 import Image from "next/image";
 import { EmptyState } from "@/components/ui/empty-state";
 
@@ -17,8 +18,20 @@ interface ChatSidebarProps {
 }
 
 export function ChatSidebar({ conversations = [], onNewChat }: ChatSidebarProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredConversations = useMemo(() => {
+    if (!searchQuery.trim()) return conversations;
+    const q = searchQuery.toLowerCase();
+    return conversations.filter(
+      (conv) =>
+        conv.name.toLowerCase().includes(q) ||
+        conv.lastMessage.toLowerCase().includes(q)
+    );
+  }, [conversations, searchQuery]);
+
   return (
-    <div className="w-full max-w-sm bg-white rounded-2xl border border-border-warm shadow-[-4px_4px_0_rgba(0,0,0,1)] overflow-hidden">
+    <div className="w-full md:max-w-sm bg-white rounded-2xl border border-border-warm shadow-[-4px_4px_0_rgba(0,0,0,1)] overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-5 py-4 border-b border-border-warm">
         <h3 className="font-semibold text-ink-deep text-base">Messages</h3>
@@ -34,10 +47,24 @@ export function ChatSidebar({ conversations = [], onNewChat }: ChatSidebarProps)
         )}
       </div>
 
+      {/* Search / Filter */}
+      {conversations.length > 0 && (
+        <div className="px-4 py-3 border-b border-border-warm">
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search conversations…"
+            aria-label="Filter conversations"
+            className="w-full rounded-lg border border-border-warm bg-surface px-3 py-2 text-sm text-ink-deep placeholder:text-ink-deep/40 focus:outline-none focus:ring-2 focus:ring-primary/50"
+          />
+        </div>
+      )}
+
       {/* Body */}
-      {conversations.length > 0 ? (
+      {filteredConversations.length > 0 ? (
         <ul className="divide-y divide-border-warm">
-          {conversations.map((conv) => (
+          {filteredConversations.map((conv) => (
             <li
               key={conv.id}
               className="flex items-center gap-3 px-5 py-3 hover:bg-surface/50 cursor-pointer transition-colors"
@@ -65,9 +92,13 @@ export function ChatSidebar({ conversations = [], onNewChat }: ChatSidebarProps)
               alt="no messages"
             />
           }
-          title="No conversations yet"
-          description="Start a conversation with an organizer or attendee to connect."
-          action={onNewChat ? { label: "Start a Chat", onClick: onNewChat } : undefined}
+          title={searchQuery ? "No conversations found" : "No conversations yet"}
+          description={
+            searchQuery
+              ? "No conversations match your search. Try a different name or message."
+              : "Start a conversation with an organizer or attendee to connect."
+          }
+          action={!searchQuery && onNewChat ? { label: "Start a Chat", onClick: onNewChat } : undefined}
         />
       )}
     </div>

--- a/apps/web/components/ui/LazyImage.tsx
+++ b/apps/web/components/ui/LazyImage.tsx
@@ -25,12 +25,24 @@ export function LazyImage({
   const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
+    // Reset revealed state whenever src changes so the blur-up transition
+    // re-runs for dynamically updated image URLs
+    setRevealed(false);
+    setLoaded(!supportsIO);
+
     if (!supportsIO) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          setLoaded(true);
+          // Handle already-cached images: if complete flag is already set,
+          // the onLoad event will not fire, so mark as revealed immediately
+          if (imgRef.current?.complete) {
+            setLoaded(true);
+            setRevealed(true);
+          } else {
+            setLoaded(true);
+          }
           observer.disconnect();
         }
       },
@@ -39,7 +51,8 @@ export function LazyImage({
 
     if (imgRef.current) observer.observe(imgRef.current);
     return () => observer.disconnect();
-  }, []);
+    // Re-run the effect when src changes to handle dynamic URL updates
+  }, [src, supportsIO]);
 
   return (
     <img

--- a/apps/web/hooks/useFocusTrap.ts
+++ b/apps/web/hooks/useFocusTrap.ts
@@ -4,7 +4,8 @@ const FOCUSABLE =
   'a[href],area[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),button:not([disabled]),iframe,object,embed,[contenteditable],[tabindex]:not([tabindex="-1"])';
 
 export function useFocusTrap<T extends HTMLElement>(
-  active: boolean
+  active: boolean,
+  onClose?: () => void
 ): RefObject<T | null> {
   const containerRef = useRef<T | null>(null);
   const triggerRef = useRef<Element | null>(null);
@@ -15,15 +16,29 @@ export function useFocusTrap<T extends HTMLElement>(
       return;
     }
 
+    // Store the element that triggered the modal so focus can be restored on close
     triggerRef.current = document.activeElement;
 
+    // Use double-frame requestAnimationFrame to ensure the DOM is fully painted
+    // and focusable before attempting to move focus (avoids 50ms hardcoded delay)
+    let frameId: number;
     const focusFirst = () => {
       const el = containerRef.current?.querySelector<HTMLElement>(FOCUSABLE);
       el?.focus();
     };
-    setTimeout(focusFirst, 50);
+
+    frameId = requestAnimationFrame(() => {
+      frameId = requestAnimationFrame(focusFirst);
+    });
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Escape key closes the active modal
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose?.();
+        return;
+      }
+
       if (e.key !== "Tab" || !containerRef.current) return;
 
       const focusable = Array.from(
@@ -49,10 +64,12 @@ export function useFocusTrap<T extends HTMLElement>(
 
     document.addEventListener("keydown", handleKeyDown);
     return () => {
+      cancelAnimationFrame(frameId);
       document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to the original trigger element when the modal unmounts
       (triggerRef.current as HTMLElement | null)?.focus();
     };
-  }, [active]);
+  }, [active, onClose]);
 
   return containerRef;
 }

--- a/apps/web/lib/events-store.ts
+++ b/apps/web/lib/events-store.ts
@@ -31,7 +31,7 @@ type CreateEventInput = {
 
 const eventsStore: EventRecord[] = [
   {
-    id: "evt_1",
+    id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
     title: "Stellar Developer Meetup",
     description: "Hands-on workshop for building with Stellar tooling.",
     startsAt: "2026-06-01T18:00:00.000Z",
@@ -46,7 +46,7 @@ const eventsStore: EventRecord[] = [
     hostEmail: "host@agora.dev",
   },
   {
-    id: "evt_2",
+    id: "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
     title: "Community Builder Night",
     description: "Networking event for local ecosystem builders.",
     startsAt: "2026-03-01T17:00:00.000Z",
@@ -62,7 +62,7 @@ const eventsStore: EventRecord[] = [
     hostEmail: "community@agora.dev",
   },
   {
-    id: "evt_3",
+    id: "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
     title: "Future of Payments Summit",
     description: "Panel and demos on modern payment rails.",
     startsAt: "2026-10-20T09:00:00.000Z",
@@ -78,8 +78,6 @@ const eventsStore: EventRecord[] = [
   },
 ];
 
-let nextEventId = 4;
-
 export function listEvents(): EventRecord[] {
   return [...eventsStore];
 }
@@ -90,7 +88,7 @@ export function getEventById(id: string): EventRecord | null {
 
 export function createEvent(input: CreateEventInput, hostEmail: string): EventRecord {
   const event: EventRecord = {
-    id: `evt_${nextEventId++}`,
+    id: crypto.randomUUID(),
     title: input.title,
     description: input.description || "",
     startsAt: input.startsAt,


### PR DESCRIPTION
## Summary

Closes #1073 — Standardise events-store.ts Mock Data IDs to UUID v4
- Replaced hardcoded evt_1/evt_2/evt_3 IDs with valid UUID v4 strings to satisfy PostgreSQL schema and Rust backend UUID validation.
- Removed nextEventId counter; createEvent() now generates IDs via crypto.randomUUID(), ensuring all new events have proper UUID v4 format.

Closes #1071 — Make ChatSidebar Layout Responsive + Add Conversation Filter
- Replaced hardcoded max-w-sm with w-full md:max-w-sm so the sidebar renders full-width on mobile without horizontal overflow.
- Added a controlled search input above the conversation list that filters in real time by conv.name and conv.lastMessage (case-insensitive).
- EmptyState is shown with context-aware copy when the filter returns zero results, distinct from the zero-conversations initial state.

Closes #1069 — Replace Fixed setTimeout in useFocusTrap with rAF
- Swapped setTimeout(focusFirst, 50) for a double-frame requestAnimationFrame so focus is applied only after the DOM is fully painted, eliminating premature or late focus on slow/fast devices.
- Added an Escape keydown listener that calls an optional onClose() callback, giving modals a reliable keyboard-dismiss path.
- Focus is correctly restored to the original trigger element on modal unmount; cancelAnimationFrame cleans up any pending frame on teardown.

Closes #1066 — Fix LazyImage Hydration Blur Lock on Cached Assets
- Added src to the useEffect dependency array so the observer is re-created and revealed/loaded state is reset whenever the image URL changes dynamically (e.g. gallery/filter updates).
- On intersection, imgRef.current.complete is checked immediately; cached images whose onLoad already fired are revealed right away instead of being permanently stuck with lazy-image--blurred.