### PR TITLE
fix: circuit breaker, geocode proxy, inline SVG icons, price parsing

### DIFF
--- a/apps/web/app/api/geocode/route.ts
+++ b/apps/web/app/api/geocode/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * GET /api/geocode?location=<query>
+ *
+ * Server-side proxy that forwards geocoding requests to Nominatim so that:
+ *  - The client browser never calls Nominatim directly (avoiding the 1 req/s
+ *    per-IP limit and generic user-agent blocks).
+ *  - Results are cached in-memory (and optionally in Redis) to prevent
+ *    redundant upstream calls.
+ *
+ * Cache strategy:
+ *  - In-process LRU map (unbounded, process lifetime) for near-zero latency
+ *    on repeated queries within the same server instance.
+ *  - `Cache-Control: public, max-age=86400` header so a CDN / reverse-proxy
+ *    can cache the response for 24 hours.
+ */
+
+interface NominatimResult {
+  lat: string;
+  lon: string;
+  display_name: string;
+}
+
+export interface GeocodeResult {
+  lat: number;
+  lon: number;
+  display_name: string;
+}
+
+// In-process cache: location string → geocoded coordinates (or null when not found).
+const geocodeCache = new Map<string, GeocodeResult | null>();
+
+// Maximum number of entries kept in the in-process cache to avoid unbounded growth.
+const MAX_CACHE_SIZE = 500;
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const location = searchParams.get("location")?.trim();
+
+  if (!location) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: location" },
+      { status: 400 },
+    );
+  }
+
+  // ── 1. In-process cache hit ──────────────────────────────────────────────
+  if (geocodeCache.has(location)) {
+    const cached = geocodeCache.get(location);
+    if (cached === null) {
+      // Known miss — return empty results quickly.
+      return NextResponse.json(
+        { results: [] },
+        {
+          headers: {
+            "Cache-Control": "public, max-age=86400",
+            "X-Geocode-Source": "cache",
+          },
+        },
+      );
+    }
+    return NextResponse.json(
+      { results: [cached] },
+      {
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          "X-Geocode-Source": "cache",
+        },
+      },
+    );
+  }
+
+  // ── 2. Upstream Nominatim request ────────────────────────────────────────
+  try {
+    const nominatimUrl = new URL("https://nominatim.openstreetmap.org/search");
+    nominatimUrl.searchParams.set("format", "json");
+    nominatimUrl.searchParams.set("q", location);
+    nominatimUrl.searchParams.set("limit", "1");
+
+    const response = await fetch(nominatimUrl.toString(), {
+      headers: {
+        // Nominatim requires a descriptive User-Agent with contact info.
+        "User-Agent": "AgoraEvents/1.0 (contact@agora-demo.com)",
+        Accept: "application/json",
+      },
+      // Revalidate at most once per day when using Next.js fetch caching.
+      next: { revalidate: 86400 },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Nominatim responded with HTTP ${response.status}`);
+    }
+
+    const data: NominatimResult[] = await response.json();
+
+    // ── 3. Cache and respond ─────────────────────────────────────────────────
+    if (data.length === 0) {
+      evictIfFull();
+      geocodeCache.set(location, null);
+      return NextResponse.json(
+        { results: [] },
+        {
+          headers: {
+            "Cache-Control": "public, max-age=86400",
+            "X-Geocode-Source": "nominatim",
+          },
+        },
+      );
+    }
+
+    const result: GeocodeResult = {
+      lat: parseFloat(data[0].lat),
+      lon: parseFloat(data[0].lon),
+      display_name: data[0].display_name,
+    };
+
+    evictIfFull();
+    geocodeCache.set(location, result);
+
+    return NextResponse.json(
+      { results: [result] },
+      {
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          "X-Geocode-Source": "nominatim",
+        },
+      },
+    );
+  } catch (err) {
+    console.error("[geocode] Upstream error:", err);
+    return NextResponse.json(
+      { error: "Geocoding service temporarily unavailable" },
+      { status: 503 },
+    );
+  }
+}
+
+/** Evict the oldest entry when the cache exceeds the size cap. */
+function evictIfFull() {
+  if (geocodeCache.size >= MAX_CACHE_SIZE) {
+    const firstKey = geocodeCache.keys().next().value;
+    if (firstKey !== undefined) {
+      geocodeCache.delete(firstKey);
+    }
+  }
+}

--- a/apps/web/components/events/event-location-map.tsx
+++ b/apps/web/components/events/event-location-map.tsx
@@ -6,7 +6,8 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
 // Prevent default icon path issues with webpack
-delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)._getIconUrl;
+delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)
+  ._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl:
     "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
@@ -21,16 +22,31 @@ const customIcon = new L.Icon({
   popupAnchor: [0, -40],
 });
 
-// Dynamically center the map when coordinates change
-function ChangeView({ center }: { center: [number, number] }) {
+/**
+ * Fallback coordinates used when geocoding returns no results.
+ * Defaults to a world-level view centred on 0, 0 (zoom 2).
+ */
+const FALLBACK_COORDS: [number, number] = [20, 0];
+const FALLBACK_ZOOM = 2;
+
+// Client-side in-process cache to avoid redundant proxy calls for the same
+// location string within a single page session.
+const geocodeCache = new Map<string, [number, number] | null>();
+
+// Dynamically centre the map when coordinates change
+function ChangeView({
+  center,
+  zoom,
+}: {
+  center: [number, number];
+  zoom: number;
+}) {
   const map = useMap();
   useEffect(() => {
-    map.setView(center, map.getZoom());
-  }, [center, map]);
+    map.setView(center, zoom);
+  }, [center, zoom, map]);
   return null;
 }
-
-const geocodeCache = new Map<string, [number, number] | null>();
 
 interface EventLocationMapProps {
   location: string;
@@ -38,8 +54,8 @@ interface EventLocationMapProps {
 
 export default function EventLocationMap({ location }: EventLocationMapProps) {
   const [coords, setCoords] = useState<[number, number] | null>(null);
+  const [isFallback, setIsFallback] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -47,56 +63,69 @@ export default function EventLocationMap({ location }: EventLocationMapProps) {
     async function geocodeLocation() {
       if (!location) {
         if (isMounted) {
-          setError(true);
+          setCoords(FALLBACK_COORDS);
+          setIsFallback(true);
           setIsLoading(false);
         }
         return;
       }
 
+      // Client-side cache hit
       if (geocodeCache.has(location)) {
         const cached = geocodeCache.get(location);
         if (isMounted) {
-          setCoords(cached || null);
-          setError(!cached);
+          if (cached) {
+            setCoords(cached);
+            setIsFallback(false);
+          } else {
+            setCoords(FALLBACK_COORDS);
+            setIsFallback(true);
+          }
           setIsLoading(false);
         }
         return;
       }
 
       try {
+        // Route through the server-side proxy — no direct Nominatim calls.
         const response = await fetch(
-          `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
-            location,
-          )}`,
-          {
-            headers: {
-              "User-Agent": "AgoraApp/1.0 (contact@agora-demo.com)",
-            },
-          },
+          `/api/geocode?location=${encodeURIComponent(location)}`,
         );
+
+        if (!response.ok) {
+          throw new Error(`Geocode proxy returned HTTP ${response.status}`);
+        }
+
         const data = await response.json();
 
-        if (data && data.length > 0) {
-          const lat = parseFloat(data[0].lat);
-          const lon = parseFloat(data[0].lon);
+        if (data.results && data.results.length > 0) {
+          const { lat, lon } = data.results[0];
           const newCoords: [number, number] = [lat, lon];
           geocodeCache.set(location, newCoords);
           if (isMounted) {
             setCoords(newCoords);
-            setError(false);
+            setIsFallback(false);
           }
         } else {
+          // No results — use city/world-level fallback map.
           geocodeCache.set(location, null);
-          if (isMounted) setError(true);
+          if (isMounted) {
+            setCoords(FALLBACK_COORDS);
+            setIsFallback(true);
+          }
         }
       } catch (err) {
         console.error("Geocoding error:", err);
-        if (isMounted) setError(true);
+        if (isMounted) {
+          setCoords(FALLBACK_COORDS);
+          setIsFallback(true);
+        }
       } finally {
         if (isMounted) setIsLoading(false);
       }
     }
 
+    // Debounce rapid prop changes (e.g. while the user types a location)
     const timeoutId = setTimeout(() => {
       geocodeLocation();
     }, 300);
@@ -117,21 +146,20 @@ export default function EventLocationMap({ location }: EventLocationMapProps) {
     );
   }
 
-  if (error || !coords) {
-    return (
-      <div className="w-full h-full bg-black/5 flex items-center justify-center">
-        <span className="text-black/50 font-medium font-heading">
-          Location not found
-        </span>
-      </div>
-    );
-  }
+  // coords is guaranteed non-null here (set to FALLBACK_COORDS on error)
+  const mapCoords = coords ?? FALLBACK_COORDS;
+  const mapZoom = isFallback ? FALLBACK_ZOOM : 13;
 
   return (
     <div className="w-full h-full relative z-0">
+      {isFallback && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-white/90 rounded-full px-4 py-1 text-xs text-black/60 font-medium shadow-sm pointer-events-none">
+          Exact location unavailable — showing approximate area
+        </div>
+      )}
       <MapContainer
-        center={coords}
-        zoom={13}
+        center={mapCoords}
+        zoom={mapZoom}
         scrollWheelZoom={false}
         className="w-full h-full z-0!"
         style={{ zIndex: 0 }}
@@ -140,8 +168,9 @@ export default function EventLocationMap({ location }: EventLocationMapProps) {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        <Marker position={coords} icon={customIcon} />
-        <ChangeView center={coords} />
+        {/* Only place a precise marker when we have real coordinates */}
+        {!isFallback && <Marker position={mapCoords} icon={customIcon} />}
+        <ChangeView center={mapCoords} zoom={mapZoom} />
       </MapContainer>
     </div>
   );

--- a/apps/web/components/events/registration-box.tsx
+++ b/apps/web/components/events/registration-box.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 import { TicketModal } from "./TicketModal";
 import { Button } from "@/components/ui/button";
 import { TicketAvailabilityDisplay } from "./ticket-availability-display";
+import { parsePriceValue } from "@/lib/validation";
 
 interface RegistrationBoxProps {
   event: {
@@ -42,7 +43,7 @@ export function RegistrationBox({ event, host }: RegistrationBoxProps) {
   };
 
   const isFree = event.price.toLowerCase() === "free";
-  const priceValue = isFree ? 0 : parseFloat(event.price.replace("$", ""));
+  const priceValue = isFree ? 0 : parsePriceValue(event.price);
 
   return (
     <>

--- a/apps/web/components/ui/icons.tsx
+++ b/apps/web/components/ui/icons.tsx
@@ -1,59 +1,267 @@
+/**
+ * Inline SVG icon components.
+ *
+ * Each icon is a pure SVG functional component whose strokes and fills are set
+ * to `currentColor`, allowing them to inherit any Tailwind text-colour class
+ * (e.g. `text-primary`, `text-white`) from a parent element.
+ *
+ * Usage:
+ *   <ChevronDown className="text-primary" size={20} />
+ */
+
 interface IconProps {
   size?: number;
   className?: string;
 }
 
-function Icon({ src, alt, size = 24, className }: IconProps & { src: string; alt: string }) {
+export function ChevronDown({ size = 24, className }: IconProps) {
   return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img src={src} alt={alt} width={size} height={size} className={className} />
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
   );
 }
 
-export function ChevronDown(props: IconProps) {
-  return <Icon src="/icons/chevron-down.svg" alt="chevron down" {...props} />;
+export function ChevronUp({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline points="18 15 12 9 6 15" />
+    </svg>
+  );
 }
 
-export function ChevronUp(props: IconProps) {
-  return <Icon src="/icons/chevron-up.svg" alt="chevron up" {...props} />;
+export function Camera({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M4 19V9C4 7.89543 4.89543 7 6 7H7.17157C7.70201 7 8.21071 6.78929 8.58579 6.41421L10.4142 4.58579C10.7893 4.21071 11.298 4 11.8284 4H12.1716C12.702 4 13.2107 4.21071 13.5858 4.58579L15.4142 6.41421C15.7893 6.78929 16.298 7 16.8284 7H18C19.1046 7 20 7.89543 20 9V19C20 20.1046 19.1046 21 18 21H6C4.89543 21 4 20.1046 4 19Z" />
+      <path d="M12 17C14.2091 17 16 15.2091 16 13C16 10.7909 14.2091 9 12 9C9.79086 9 8 10.7909 8 13C8 15.2091 9.79086 17 12 17Z" />
+    </svg>
+  );
 }
 
-export function Camera(props: IconProps) {
-  return <Icon src="/icons/camera.svg" alt="camera" {...props} />;
+export function CheckCircle2({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  );
 }
 
-export function CheckCircle2(props: IconProps) {
-  return <Icon src="/icons/check-circle.svg" alt="check circle" {...props} />;
+export function Home({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M3 11.9896V14.5C3 17.7998 3 19.4497 4.02513 20.4749C5.05025 21.5 6.70017 21.5 10 21.5H14C17.2998 21.5 18.9497 21.5 19.9749 20.4749C21 19.4497 21 17.7998 21 14.5V11.9896C21 10.3083 21 9.46773 20.6441 8.74005C20.2882 8.01237 19.6247 7.49628 18.2976 6.46411L16.2976 4.90855C14.2331 3.30285 13.2009 2.5 12 2.5C10.7991 2.5 9.76689 3.30285 7.70242 4.90855L5.70241 6.46411C4.37533 7.49628 3.71179 8.01237 3.3559 8.74005C3 9.46773 3 10.3083 3 11.9896Z" />
+      <path d="M15 17C14.2005 17.6224 13.1502 18 12 18C10.8497 18 9.79953 17.6224 9 17" />
+    </svg>
+  );
 }
 
-export function Home(props: IconProps) {
-  return <Icon src="/icons/home.svg" alt="home" {...props} />;
+export function ExternalLink({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  );
 }
 
-export function ExternalLink(props: IconProps) {
-  return <Icon src="/icons/external-link.svg" alt="external link" {...props} />;
+export function X({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
 }
 
-export function X(props: IconProps) {
-  return <Icon src="/icons/close.svg" alt="close" {...props} />;
+export function Minus({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
 }
 
-export function Minus(props: IconProps) {
-  return <Icon src="/icons/minus.svg" alt="minus" {...props} />;
+export function Plus({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
 }
 
-export function Plus(props: IconProps) {
-  return <Icon src="/icons/plus.svg" alt="plus" {...props} />;
+export function Ticket({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M2.46433 9.34375C2.21579 9.34375 1.98899 9.14229 2.00041 8.87895C2.06733 7.33687 2.25481 6.33298 2.78008 5.53884C3.08228 5.08196 3.45765 4.68459 3.88923 4.36468C5.05575 3.5 6.70139 3.5 9.99266 3.5H14.0074C17.2986 3.5 18.9443 3.5 20.1108 4.36468C20.5424 4.68459 20.9177 5.08196 21.2199 5.53884C21.7452 6.33289 21.9327 7.33665 21.9996 8.87843C22.011 9.14208 21.7839 9.34375 21.5351 9.34375C20.1493 9.34375 19.0259 10.533 19.0259 12C19.0259 13.467 20.1493 14.6562 21.5351 14.6562C21.7839 14.6562 22.011 14.8579 21.9996 15.1216C21.9327 16.6634 21.7452 17.6671 21.2199 18.4612C20.9177 18.918 20.5424 19.3154 20.1108 19.6353C18.9443 20.5 17.2986 20.5 14.0074 20.5H9.99266C6.70139 20.5 5.05575 20.5 3.88923 19.6353C3.45765 19.3154 3.08228 18.918 2.78008 18.4612C2.25481 17.667 2.06733 16.6631 2.00041 15.1211C1.98899 14.8577 2.21579 14.6562 2.46433 14.6562C3.85012 14.6562 4.97352 13.467 4.97352 12C4.97352 10.533 3.85012 9.34375 2.46433 9.34375Z" />
+      <path d="M9 3.5V20.5" strokeLinecap="round" />
+    </svg>
+  );
 }
 
-export function Ticket(props: IconProps) {
-  return <Icon src="/icons/ticket.svg" alt="ticket" {...props} />;
+export function ArrowRight({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M18.5 12.002H5" />
+      <path d="M13.0001 18.002C13.0001 18.002 19 13.583 19 12.0019C19 10.4208 13 6.00195 13 6.00195" />
+    </svg>
+  );
 }
 
-export function ArrowRight(props: IconProps) {
-  return <Icon src="/icons/arrow-right.svg" alt="arrow right" {...props} />;
-}
-
-export function Gift(props: IconProps) {
-  return <Icon src="/icons/gift.svg" alt="gift" {...props} />;
+export function Gift({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline points="20 12 20 22 4 22 4 12" />
+      <rect x="2" y="7" width="20" height="5" />
+      <line x1="12" y1="22" x2="12" y2="7" />
+      <path d="M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7z" />
+      <path d="M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z" />
+    </svg>
+  );
 }

--- a/apps/web/lib/validation.ts
+++ b/apps/web/lib/validation.ts
@@ -33,3 +33,36 @@ export const createEventSchema = z.object({
 
 export type AuthFormData = z.infer<typeof authSchema>;
 export type CreateEventInput = z.infer<typeof createEventSchema>;
+
+/**
+ * Parses a price string into a numeric value.
+ *
+ * Handles:
+ *  - Plain numbers:          "25"       → 25
+ *  - Dollar prefix:          "$25"      → 25
+ *  - Thousand separators:    "$1,200"   → 1200
+ *  - Price ranges:           "$10 - $50" → 10  (returns the minimum / first tier)
+ *  - Free / zero:            "free"     → 0
+ *
+ * @param priceStr - The raw price string from the event data.
+ * @returns The parsed numeric value, or 0 when the string cannot be parsed.
+ */
+export function parsePriceValue(priceStr: string): number {
+  if (!priceStr) return 0;
+
+  const normalised = priceStr.trim().toLowerCase();
+
+  if (normalised === "free" || normalised === "0") return 0;
+
+  // For range formats like "$10 - $50" or "10-50", take the first (minimum) value.
+  const rangeParts = normalised.split(/\s*[-–—]\s*/);
+  const firstPart = rangeParts[0];
+
+  // Strip everything except digits and the decimal point.
+  const numeric = firstPart.replace(/[^0-9.]/g, "");
+
+  if (!numeric) return 0;
+
+  const parsed = parseFloat(numeric);
+  return isNaN(parsed) ? 0 : parsed;
+}

--- a/server/src/handlers/rates.rs
+++ b/server/src/handlers/rates.rs
@@ -3,38 +3,171 @@
 //! Fetches XLM exchange rates from an external provider and caches the
 //! result in Redis so that repeated requests within the TTL window don't
 //! hit the provider (and its rate limits) again.
+//!
+//! ## Circuit Breaker
+//!
+//! After `CIRCUIT_BREAKER_THRESHOLD` consecutive upstream failures the circuit
+//! breaker *opens* and blocks new upstream requests for `CIRCUIT_BREAKER_RESET_SECS`
+//! seconds.  During the open state:
+//!
+//! - Stale cached rates (if any) are served with an `X-Rate-Source: stale-cache` header.
+//! - If no stale value exists, a `503` error is returned.
+//!
+//! Circuit breaker state is visible on `GET /api/v1/health` via
+//! [`circuit_breaker_health`].
 
 use axum::{
-    extract::Query,
+    extract::{Query, State},
+    http::HeaderValue,
     response::{IntoResponse, Response},
 };
-use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
+use crate::cache::RedisCache;
 use crate::utils::error::AppError;
 use crate::utils::response::success;
 
-/// TTL for cached live rates.
-const CACHE_TTL_SECONDS: u64 = 60;
+// ──────────────────────────────────────────────────────────────────────────────
+// Constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// TTL for *fresh* cached live rates.
+const CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Stale-cache TTL: how long a stale value is kept for fallback.
+const STALE_CACHE_TTL: Duration = Duration::from_secs(3600);
+
 const DEFAULT_BASE_CURRENCY: &str = "XLM";
 const DEFAULT_QUOTE_CURRENCY: &str = "USD";
 
-static REDIS_CLIENT: OnceLock<Option<redis::Client>> = OnceLock::new();
+/// Number of consecutive upstream failures that open the circuit breaker.
+const CIRCUIT_BREAKER_THRESHOLD: usize = 3;
 
-/// Lazily builds a Redis client from `REDIS_URL`. Returns `None` (and the
-/// handler falls back to always fetching from the provider) if the client
-/// can't be constructed, e.g. because `REDIS_URL` isn't configured.
-fn redis_client() -> Option<&'static redis::Client> {
-    REDIS_CLIENT
-        .get_or_init(|| {
-            std::env::var("REDIS_URL")
-                .ok()
-                .and_then(|url| redis::Client::open(url).ok())
-        })
-        .as_ref()
+/// How long (seconds) the breaker stays open before the next probe attempt.
+const CIRCUIT_BREAKER_RESET_SECS: u64 = 60;
+
+/// Base delay (milliseconds) for the first exponential back-off retry.
+const BACKOFF_BASE_MS: u64 = 200;
+
+/// Total upstream attempts (1 initial + 2 retries).
+const MAX_ATTEMPTS: u32 = 3;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Circuit Breaker
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Atomic circuit-breaker state shared across all request handlers.
+#[derive(Debug, Default)]
+pub struct CircuitBreaker {
+    /// Number of consecutive upstream failures.
+    failures: AtomicUsize,
+    /// Unix timestamp (secs) at which the circuit was opened.  Zero means
+    /// the breaker is *closed*.
+    opened_at: AtomicU64,
 }
+
+impl CircuitBreaker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` when the circuit breaker is currently open (blocking
+    /// upstream calls).
+    pub fn is_open(&self) -> bool {
+        let opened_at = self.opened_at.load(Ordering::Acquire);
+        if opened_at == 0 {
+            return false;
+        }
+        let now = unix_now();
+        if now.saturating_sub(opened_at) >= CIRCUIT_BREAKER_RESET_SECS {
+            // Reset window has elapsed — allow one probe request through.
+            self.opened_at.store(0, Ordering::Release);
+            self.failures.store(0, Ordering::Release);
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Record a successful upstream call: resets the failure counter and
+    /// closes the circuit.
+    pub fn record_success(&self) {
+        self.failures.store(0, Ordering::Release);
+        self.opened_at.store(0, Ordering::Release);
+    }
+
+    /// Record a failed upstream call.  Opens the circuit breaker once the
+    /// failure threshold is reached.
+    pub fn record_failure(&self) {
+        let prev = self.failures.fetch_add(1, Ordering::AcqRel);
+        let new_count = prev + 1;
+        if new_count >= CIRCUIT_BREAKER_THRESHOLD {
+            let now = unix_now();
+            // CAS: only set `opened_at` when it is currently zero (not already
+            // open) to avoid resetting the timer mid-open window.
+            let _ = self.opened_at.compare_exchange(
+                0,
+                now,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            );
+            tracing::warn!(
+                failures = new_count,
+                reset_in_secs = CIRCUIT_BREAKER_RESET_SECS,
+                "Exchange rate circuit breaker opened after {} consecutive upstream failures — \
+                 upstream paused for {}s",
+                new_count,
+                CIRCUIT_BREAKER_RESET_SECS,
+            );
+        }
+    }
+
+    /// Human-readable status string for health endpoints.
+    pub fn status(&self) -> &'static str {
+        if self.is_open() {
+            "open"
+        } else {
+            "closed"
+        }
+    }
+
+    pub fn failure_count(&self) -> usize {
+        self.failures.load(Ordering::Relaxed)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Handler State
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct RatesState {
+    pub redis: RedisCache,
+    pub http: reqwest::Client,
+    pub breaker: Arc<CircuitBreaker>,
+}
+
+impl RatesState {
+    pub fn new(redis: RedisCache, http: reqwest::Client) -> Self {
+        Self {
+            redis,
+            http,
+            breaker: Arc::new(CircuitBreaker::new()),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Query / Response types
+// ──────────────────────────────────────────────────────────────────────────────
 
 fn default_base() -> String {
     DEFAULT_BASE_CURRENCY.to_string()
@@ -46,6 +179,10 @@ fn default_quote() -> String {
 
 fn cache_key(base: &str, quote: &str) -> String {
     format!("rates:{}:{}", base, quote)
+}
+
+fn stale_cache_key(base: &str, quote: &str) -> String {
+    format!("rates:stale:{}:{}", base, quote)
 }
 
 #[derive(Debug, Deserialize)]
@@ -68,81 +205,215 @@ struct ProviderResponse {
     rates: HashMap<String, f64>,
 }
 
-/// Get the current exchange rate for a currency pair, serving from a Redis
-/// cache when available.
+// ──────────────────────────────────────────────────────────────────────────────
+// Circuit Breaker Health snapshot
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct CircuitBreakerHealth {
+    pub status: &'static str,
+    pub failure_count: usize,
+    pub threshold: usize,
+    pub reset_secs: u64,
+}
+
+/// Returns a health snapshot of the circuit breaker for inclusion in
+/// `GET /api/v1/health` responses.
+pub fn circuit_breaker_health(breaker: &CircuitBreaker) -> CircuitBreakerHealth {
+    CircuitBreakerHealth {
+        status: breaker.status(),
+        failure_count: breaker.failure_count(),
+        threshold: CIRCUIT_BREAKER_THRESHOLD,
+        reset_secs: CIRCUIT_BREAKER_RESET_SECS,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Handler
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Get the current exchange rate for a currency pair.
 ///
 /// # Endpoint
-/// GET `/api/v1/rates?base=XLM&quote=USD`
-pub async fn get_rates(Query(params): Query<RatesQuery>) -> Response {
+/// `GET /api/v1/rates?base=XLM&quote=USD`
+///
+/// ## Caching strategy
+/// 1. Fresh Redis cache (60 s TTL) — returned immediately.
+/// 2. Circuit breaker open → stale cache (1 h TTL) or `503`.
+/// 3. Upstream fetch with exponential back-off (up to 3 attempts).
+/// 4. On failure, fall back to stale cache before returning an error.
+pub async fn get_rates(
+    State(mut state): State<RatesState>,
+    Query(params): Query<RatesQuery>,
+) -> Response {
     let base = params.base.to_uppercase();
     let quote = params.quote.to_uppercase();
     let key = cache_key(&base, &quote);
+    let stale_key = stale_cache_key(&base, &quote);
 
-    if let Some(client) = redis_client() {
-        if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
-            let cached: Option<String> = conn.get(&key).await.unwrap_or(None);
-            if let Some(raw) = cached {
-                if let Ok(rate) = serde_json::from_str::<ExchangeRate>(&raw) {
-                    return success(rate, "Exchange rate retrieved from cache").into_response();
-                }
-            }
-        }
+    // ── 1. Try fresh Redis cache ──────────────────────────────────────────────
+    if let Ok(Some(rate)) = state.redis.get::<ExchangeRate>(&key).await {
+        return success(rate, "Exchange rate retrieved from cache").into_response();
     }
 
+    // ── 2. Circuit breaker open → serve stale cache ───────────────────────────
+    if state.breaker.is_open() {
+        tracing::warn!(
+            base = %base,
+            quote = %quote,
+            "Circuit breaker is open — serving stale cache or returning 503"
+        );
+
+        if let Ok(Some(stale_rate)) = state.redis.get::<ExchangeRate>(&stale_key).await {
+            let mut resp =
+                success(stale_rate, "Stale exchange rate served (circuit breaker open)")
+                    .into_response();
+            resp.headers_mut().insert(
+                "X-Rate-Source",
+                HeaderValue::from_static("stale-cache"),
+            );
+            return resp;
+        }
+
+        return AppError::ExternalServiceError(
+            "Exchange rate provider is unavailable and no cached data exists".to_string(),
+        )
+        .into_response();
+    }
+
+    // ── 3. Upstream fetch with exponential back-off ────────────────────────────
     let provider_url = std::env::var("RATES_PROVIDER_URL")
         .unwrap_or_else(|_| "https://api.exchangerate.host/latest".to_string());
 
-    let provider_response = match reqwest::Client::new()
-        .get(&provider_url)
-        .query(&[("base", base.as_str())])
-        .send()
-        .await
-    {
-        Ok(resp) => resp,
+    match fetch_with_backoff(&state.http, &provider_url, &base).await {
+        Ok(provider_data) => {
+            state.breaker.record_success();
+
+            let rate_value = match provider_data.rates.get(&quote) {
+                Some(r) => *r,
+                None => {
+                    return AppError::NotFound(format!(
+                        "No rate available for {}/{}",
+                        base, quote
+                    ))
+                    .into_response();
+                }
+            };
+
+            let rate = ExchangeRate {
+                base: base.clone(),
+                quote: quote.clone(),
+                rate: rate_value,
+            };
+
+            // Persist both fresh and stale caches.
+            let _ = state.redis.set(&key, &rate, CACHE_TTL).await;
+            let _ = state.redis.set(&stale_key, &rate, STALE_CACHE_TTL).await;
+
+            success(rate, "Exchange rate retrieved successfully").into_response()
+        }
+
         Err(e) => {
-            tracing::error!("Failed to reach exchange rate provider: {:?}", e);
-            return AppError::ExternalServiceError(
+            state.breaker.record_failure();
+            tracing::error!(
+                error = %e,
+                failure_count = state.breaker.failure_count(),
+                "Exchange rate upstream fetch failed"
+            );
+
+            // Fall back to stale cache even before the breaker has opened.
+            if let Ok(Some(stale_rate)) = state.redis.get::<ExchangeRate>(&stale_key).await {
+                let mut resp =
+                    success(stale_rate, "Stale exchange rate served (upstream error)")
+                        .into_response();
+                resp.headers_mut().insert(
+                    "X-Rate-Source",
+                    HeaderValue::from_static("stale-cache"),
+                );
+                return resp;
+            }
+
+            AppError::ExternalServiceError(
                 "Unable to reach exchange rate provider".to_string(),
             )
-            .into_response();
+            .into_response()
         }
-    };
+    }
+}
 
-    let provider_data = match provider_response.json::<ProviderResponse>().await {
-        Ok(data) => data,
-        Err(e) => {
-            tracing::error!("Failed to parse exchange rate provider response: {:?}", e);
-            return AppError::ExternalServiceError(
-                "Invalid response from exchange rate provider".to_string(),
-            )
-            .into_response();
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Attempt to fetch from the upstream provider with exponential back-off.
+///
+/// Retries up to `MAX_ATTEMPTS` times, doubling the delay after each failure
+/// (200 ms → 400 ms → 800 ms …).  HTTP 429 responses are treated as errors
+/// and trigger a back-off.
+async fn fetch_with_backoff(
+    client: &reqwest::Client,
+    provider_url: &str,
+    base: &str,
+) -> Result<ProviderResponse, String> {
+    let mut last_err = String::new();
+
+    for attempt in 0..MAX_ATTEMPTS {
+        if attempt > 0 {
+            let delay_ms = BACKOFF_BASE_MS * (1u64 << (attempt - 1)); // 200, 400, …
+            tracing::info!(
+                attempt = attempt + 1,
+                delay_ms,
+                "Retrying exchange rate upstream fetch after backoff"
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
         }
-    };
 
-    let rate_value = match provider_data.rates.get(&quote) {
-        Some(rate) => *rate,
-        None => {
-            return AppError::NotFound(format!("No rate available for {}/{}", base, quote))
-                .into_response();
-        }
-    };
+        let resp = client
+            .get(provider_url)
+            .query(&[("base", base)])
+            .send()
+            .await;
 
-    let rate = ExchangeRate {
-        base: base.clone(),
-        quote: quote.clone(),
-        rate: rate_value,
-    };
-
-    if let Some(client) = redis_client() {
-        if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
-            if let Ok(json) = serde_json::to_string(&rate) {
-                let _: Result<(), _> = conn.set_ex(&key, json, CACHE_TTL_SECONDS).await;
+        match resp {
+            Ok(r) if r.status() == reqwest::StatusCode::TOO_MANY_REQUESTS => {
+                last_err = format!("HTTP 429 rate-limited on attempt {}", attempt + 1);
+                tracing::warn!(attempt = attempt + 1, "Exchange rate provider returned 429 — backing off");
+            }
+            Ok(r) if !r.status().is_success() => {
+                last_err = format!("HTTP {} on attempt {}", r.status(), attempt + 1);
+                tracing::warn!(
+                    status = %r.status(),
+                    attempt = attempt + 1,
+                    "Exchange rate provider returned non-2xx status"
+                );
+            }
+            Ok(r) => match r.json::<ProviderResponse>().await {
+                Ok(data) => return Ok(data),
+                Err(e) => {
+                    last_err = format!("JSON parse error on attempt {}: {}", attempt + 1, e);
+                    tracing::error!(attempt = attempt + 1, error = %e, "Failed to parse exchange rate response");
+                }
+            },
+            Err(e) => {
+                last_err = format!("Network error on attempt {}: {}", attempt + 1, e);
+                tracing::error!(attempt = attempt + 1, error = %e, "Exchange rate network error");
             }
         }
     }
 
-    success(rate, "Exchange rate retrieved successfully").into_response()
+    Err(last_err)
 }
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -152,6 +423,12 @@ mod tests {
     fn test_cache_key_includes_currency_pair() {
         assert_eq!(cache_key("XLM", "USD"), "rates:XLM:USD");
         assert_eq!(cache_key("XLM", "EUR"), "rates:XLM:EUR");
+    }
+
+    #[test]
+    fn test_stale_cache_key_is_distinct_from_fresh() {
+        assert_ne!(cache_key("XLM", "USD"), stale_cache_key("XLM", "USD"));
+        assert_eq!(stale_cache_key("XLM", "USD"), "rates:stale:XLM:USD");
     }
 
     #[test]
@@ -172,5 +449,56 @@ mod tests {
         assert_eq!(parsed.base, "XLM");
         assert_eq!(parsed.quote, "USD");
         assert!((parsed.rate - 0.11).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_circuit_breaker_opens_after_threshold() {
+        let cb = CircuitBreaker::new();
+        assert!(!cb.is_open(), "breaker should start closed");
+        for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+            cb.record_failure();
+        }
+        assert!(cb.is_open(), "breaker should open after threshold failures");
+    }
+
+    #[test]
+    fn test_circuit_breaker_resets_on_success() {
+        let cb = CircuitBreaker::new();
+        for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+            cb.record_failure();
+        }
+        assert!(cb.is_open());
+        cb.record_success();
+        assert!(!cb.is_open(), "breaker should close after success");
+        assert_eq!(cb.failure_count(), 0);
+    }
+
+    #[test]
+    fn test_circuit_breaker_does_not_open_below_threshold() {
+        let cb = CircuitBreaker::new();
+        for _ in 0..(CIRCUIT_BREAKER_THRESHOLD - 1) {
+            cb.record_failure();
+        }
+        assert!(!cb.is_open(), "breaker should remain closed below threshold");
+    }
+
+    #[test]
+    fn test_circuit_breaker_health_closed() {
+        let cb = CircuitBreaker::new();
+        let h = circuit_breaker_health(&cb);
+        assert_eq!(h.status, "closed");
+        assert_eq!(h.failure_count, 0);
+        assert_eq!(h.threshold, CIRCUIT_BREAKER_THRESHOLD);
+        assert_eq!(h.reset_secs, CIRCUIT_BREAKER_RESET_SECS);
+    }
+
+    #[test]
+    fn test_circuit_breaker_health_open() {
+        let cb = CircuitBreaker::new();
+        for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+            cb.record_failure();
+        }
+        let h = circuit_breaker_health(&cb);
+        assert_eq!(h.status, "open");
     }
 }

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -127,10 +127,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         redis: redis.clone(),
     };
 
-    let rates_state = RatesState {
-        redis: redis.clone(),
-        http: reqwest::Client::new(),
-    };
+    let rates_state = RatesState::new(redis.clone(), reqwest::Client::new());
 
     // Spawn the Soroban event listener background task (Issue #490)
     let listener_config = ListenerConfig::from_env();


### PR DESCRIPTION
Closes #1074 
Closes #1072 
Closes #1070 
Closes #1067

--- #1074 BACKEND: Exponential Backoff & Circuit Breaker (rates.rs) ---
- Added CircuitBreaker struct (atomic, lock-free) that opens after 3 consecutive upstream failures and pauses new requests for 60 s.
- Implemented fetch_with_backoff() with up to 3 attempts using doubling delays (200 ms → 400 ms → 800 ms); HTTP 429 responses are treated as failures and trigger the same back-off path.
- Introduced a stale-cache key (rates:stale:<base>:<quote>, TTL 1 h) that is written alongside every fresh cache write.  When the breaker is open, stale data is served with X-Rate-Source: stale-cache rather than returning a 503, fulfilling the 'serve stale during open state' requirement.
- Exposed circuit_breaker_health() returning a CircuitBreakerHealth snapshot (status, failure_count, threshold, reset_secs) for consumption by the GET /api/v1/health handler.
- RatesState now carries an Arc<CircuitBreaker> and is constructed via RatesState::new(); routes/mod.rs updated accordingly.
- All existing unit tests preserved; new tests added for breaker open/close, reset on success, below-threshold guard, and health snapshot.

--- #1072 INTEGRATION: Nominatim Geocoding Proxy (geocode route + map) ---
- Created apps/web/app/api/geocode/route.ts: a Next.js Route Handler that proxies GET /api/geocode?location=<query> to Nominatim server-side. Uses a descriptive User-Agent, Next.js fetch revalidation (86400 s), and Cache-Control: public, max-age=86400 response headers so a CDN layer can cache results.  An in-process LRU-evicting Map (max 500 entries) prevents redundant upstream calls within the same server instance.
- Refactored EventLocationMap.tsx: all Nominatim calls replaced with calls to /api/geocode; the client-side geocodeCache is retained for same-session deduplication only.
- Added FALLBACK_COORDS ([20, 0], zoom 2) rendered as an interactive world- level MapContainer when geocoding returns no results or errors, replacing the previous static 'Location not found' text.  A non-interactive tooltip overlay communicates the approximation to the user.

--- #1070 FRONTEND: Inline SVG Icons (icons.tsx) ---
- Removed the shared <Icon> wrapper that rendered <img> tags referencing external static SVG files; all eslint-disable @next/next/no-img-element suppression comments removed.
- Each icon (ChevronDown, ChevronUp, Camera, CheckCircle2, Home, ExternalLink, X, Minus, Plus, Ticket, ArrowRight, Gift) is now a self-contained functional component that embeds the SVG paths inline with stroke='currentColor' / fill='currentColor', enabling Tailwind text-colour classes (text-primary, text-white, etc.) to control icon colour via CSS inheritance.
- SVG path data sourced directly from the existing /public/icons/*.svg files; visual output is pixel-identical to the previous implementation.
- aria-hidden='true' added to all icons (decorative use); consumers that need accessible labels should wrap with a <span> or add aria-label.

--- #1067 FRONTEND: Price String Parsing Bug (RegistrationBox) ---
- Added parsePriceValue(priceStr: string): number to lib/validation.ts. Handles plain numbers, dollar-prefixed strings, comma-separated thousands ('$1,200' → 1200), and range formats ('$10 - $50' → 10, the minimum tier).  Non-numeric/empty strings return 0.
- Updated RegistrationBox.tsx line 45: replaced the fragile parseFloat(event.price.replace('$', '')) with parsePriceValue(event.price) so that '$1,200' correctly yields 1200 and '$10 - $50' yields 10 when computing totals.