### PR TITLE
fix: centralise auth state, add useDebounce + breadcrumb, mobile filter access

### DIFF
--- a/apps/web/__tests__/breadcrumb.test.tsx
+++ b/apps/web/__tests__/breadcrumb.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Breadcrumb } from '../components/ui/breadcrumb';
+
+const items = [
+  { label: 'Home', href: '/' },
+  { label: 'Discover', href: '/discover' },
+  { label: 'Stellar Builders Summit' },
+];
+
+describe('Breadcrumb', () => {
+  it('exposes a labelled navigation landmark', () => {
+    render(<Breadcrumb items={items} />);
+
+    expect(screen.getByRole('navigation', { name: 'breadcrumb' })).toBeInTheDocument();
+  });
+
+  it('renders ancestors as keyboard-navigable links', () => {
+    render(<Breadcrumb items={items} />);
+
+    const home = screen.getByRole('link', { name: 'Home' });
+    const discover = screen.getByRole('link', { name: 'Discover' });
+
+    expect(home).toHaveAttribute('href', '/');
+    expect(discover).toHaveAttribute('href', '/discover');
+  });
+
+  it('marks the last item as the current page and does not link it', () => {
+    render(<Breadcrumb items={items} />);
+
+    const current = screen.getByText('Stellar Builders Summit');
+
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(
+      screen.queryByRole('link', { name: 'Stellar Builders Summit' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the separators from assistive technology', () => {
+    const { container } = render(<Breadcrumb items={items} />);
+
+    const separators = container.querySelectorAll('[aria-hidden="true"]');
+
+    expect(separators).toHaveLength(items.length - 1);
+  });
+
+  it('renders nothing when given no items', () => {
+    const { container } = render(<Breadcrumb items={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/__tests__/use-debounce.test.ts
+++ b/apps/web/__tests__/use-debounce.test.ts
@@ -1,0 +1,90 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useDebounce } from '../hooks/useDebounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 300));
+
+    expect(result.current).toBe('initial');
+  });
+
+  it('does not update the value before the delay has elapsed', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 'initial' } },
+    );
+
+    rerender({ value: 'updated' });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(result.current).toBe('initial');
+  });
+
+  it('updates the value once the delay has elapsed', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 'initial' } },
+    );
+
+    rerender({ value: 'updated' });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('updated');
+  });
+
+  it('only publishes the last value in a burst of changes', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 'a' } },
+    );
+
+    rerender({ value: 'ab' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender({ value: 'abc' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // The second keystroke restarted the timer, so nothing has been published.
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe('abc');
+  });
+
+  it('works with non-string values', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: { page: 1 } } },
+    );
+
+    const nextValue = { page: 2 };
+    rerender({ value: nextValue });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toEqual(nextValue);
+  });
+});

--- a/apps/web/app/api/auth/session/route.ts
+++ b/apps/web/app/api/auth/session/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthFromRequest } from "@/lib/auth";
+import { withErrorHandler } from "@/lib/api-handler";
+import type { AuthUser, SessionResponse } from "@/types/auth";
+
+/**
+ * GET /api/auth/session
+ *
+ * Returns the current session for the browser. The `auth_token` cookie is
+ * HttpOnly, so this endpoint is the only way client components can learn who is
+ * signed in. Always responds 200 — an absent or invalid token yields
+ * `{ user: null }` so callers do not have to treat "signed out" as an error.
+ */
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const auth = getAuthFromRequest(request);
+
+  if (!auth || (!auth.sub && !auth.email)) {
+    return NextResponse.json<SessionResponse>({ user: null });
+  }
+
+  const walletAddress = auth.sub ?? null;
+
+  // The profile is optional enrichment: a user can be signed in without having
+  // created an organizer profile, and a database hiccup should not sign them out.
+  let profile: {
+    displayName: string;
+    bio: string | null;
+    avatarUrl: string | null;
+  } | null = null;
+
+  if (walletAddress) {
+    try {
+      profile = await prisma.organizerProfile.findUnique({
+        where: { address: walletAddress },
+        select: { displayName: true, bio: true, avatarUrl: true },
+      });
+    } catch {
+      profile = null;
+    }
+  }
+
+  const user: AuthUser = {
+    id: auth.sub ?? auth.email!,
+    email: auth.email ?? null,
+    walletAddress,
+    displayName: profile?.displayName ?? null,
+    avatarUrl: profile?.avatarUrl ?? null,
+    bio: profile?.bio ?? null,
+  };
+
+  return NextResponse.json<SessionResponse>({ user });
+});

--- a/apps/web/app/api/auth/signout/route.ts
+++ b/apps/web/app/api/auth/signout/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+/**
+ * POST /api/auth/signout
+ *
+ * Clears the `auth_token` cookie. Because the cookie is HttpOnly the browser
+ * cannot expire it itself, so `useAuth().signOut()` calls this first and then
+ * redirects to `/`.
+ */
+export async function POST() {
+  const cookieStore = await cookies();
+
+  cookieStore.set("auth_token", "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -7,6 +7,7 @@ import { RegistrationBox } from "@/components/events/registration-box";
 import { notFound } from "next/navigation";
 import MapClient from "@/components/events/map-client";
 import { buildMetadata } from "@/components/layout/seo";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
 
 export async function generateMetadata({
   params,
@@ -50,6 +51,15 @@ export default async function EventDetailPage({
       <Navbar />
 
       <div className="flex-1 w-full max-w-[1221px] mx-auto px-6 py-6 sm:py-12">
+        <Breadcrumb
+          className="mb-6 sm:mb-8"
+          items={[
+            { label: "Home", href: "/" },
+            { label: "Discover", href: "/discover" },
+            { label: event.title },
+          ]}
+        />
+
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-16">
           {/* LEFT COLUMN (Desktop) / TOP ITEMS (Mobile) */}
           <div className="lg:w-[55%] flex flex-col gap-8 lg:gap-10">

--- a/apps/web/app/help/[category]/[slug]/page.tsx
+++ b/apps/web/app/help/[category]/[slug]/page.tsx
@@ -1,15 +1,13 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { getArticle, getArticlesByCategory } from "../../data";
 import { ClientSidebar } from "./client-sidebar";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-
-import HelpCircleIcon from "@/public/icons/help-circle.svg";
 
 export async function generateMetadata({
   params,
@@ -64,6 +62,12 @@ export default async function HelpArticlePage({
 
   const categoryArticles = getArticlesByCategory(category);
 
+  // "getting-started" -> "Getting Started"
+  const categoryLabel = category
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
   return (
     <main className="flex flex-col min-h-screen bg-[#FFFBE9]">
       <Navbar />
@@ -71,14 +75,20 @@ export default async function HelpArticlePage({
       {/* Breadcrumb & Header Banner */}
       <div className="bg-[#FDDA23] border-b-2 border-black pt-28 pb-8 px-4 md:px-8 shadow-[0px_4px_0px_0px_rgba(0,0,0,1)]">
         <div className="max-w-5xl mx-auto w-full flex flex-col gap-4">
-          <nav className="flex items-center gap-2 text-sm font-semibold text-black">
-            <Link href="/help" className="hover:underline flex items-center gap-1">
-              <Image src={HelpCircleIcon} alt="" width={16} height={16} />
-              Help Center
-            </Link>
-            <span>/</span>
-            <span className="capitalize">{category.replace("-", " ")}</span>
-          </nav>
+          <Breadcrumb
+            items={[
+              { label: "Home", href: "/" },
+              { label: "Help", href: "/help" },
+              // No /help/[category] index route exists yet, so this level is
+              // context only rather than a link to a 404.
+              { label: categoryLabel },
+              { label: article.title },
+            ]}
+            className="font-semibold"
+            linkClassName="text-black/70 hover:text-black"
+            separatorClassName="text-black/40"
+            currentClassName="text-black"
+          />
           <h1 className="text-3xl md:text-5xl font-black tracking-tight text-black">
             {article.title}
           </h1>

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
@@ -15,6 +16,7 @@ import BubbleChatIcon from "@/public/icons/bubble-chat.svg";
 import ZeroIcon from "@/public/icons/zero.svg";
 import EmptyStateBg from "@/public/icons/empty-state-bg.svg";
 import useSWR from "swr";
+import { useAuth } from "@/hooks/useAuth";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -449,21 +451,37 @@ function ForYouContent({ activeTab, events, isLoading }: { activeTab: ForYouTab,
 }
 
 export default function HomePage() {
+  const router = useRouter();
+  const {
+    walletAddress: userWallet,
+    isAuthenticated,
+    isLoading: isAuthLoading,
+  } = useAuth();
   const [myEventsTab, setMyEventsTab] = useState<MyEventsTab>("upcoming");
   const [forYouTab, setForYouTab] = useState<ForYouTab>("discover");
   const [isChatOpen, setIsChatOpen] = useState(false);
 
-  // Authenticated user's wallet address (placeholder logic for now)
-  const userWallet = "0xUSERWALLET"; 
+  // "My Events" is personal — signed-out visitors belong on the auth page.
+  useEffect(() => {
+    if (!isAuthLoading && !isAuthenticated) {
+      router.replace("/auth");
+    }
+  }, [isAuthLoading, isAuthenticated, router]);
 
-  const { data, isLoading } = useSWR("/api/v1/events", fetcher);
+  const { data, isLoading: isEventsLoading } = useSWR(
+    isAuthenticated ? "/api/v1/events" : null,
+    fetcher,
+  );
+  const isLoading = isAuthLoading || isEventsLoading;
   const allEvents = data?.events || [];
-  
+
   const now = new Date().getTime();
 
   // Filter for 'My Events'
   const upcomingEvents = allEvents.filter((e: any) => new Date(e.start_time).getTime() > now); // assuming user has ticket logically mapped
-  const hostingEvents = allEvents.filter((e: any) => e.organizer_wallet === userWallet);
+  const hostingEvents = userWallet
+    ? allEvents.filter((e: any) => e.organizer_wallet === userWallet)
+    : [];
   const pastEvents = allEvents.filter((e: any) => new Date(e.end_time).getTime() < now);
 
   let displayedMyEvents = [];

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useMemo } from "react";
 import { Navbar } from "@/components/layout/navbar";
+import { useAuth } from "@/hooks/useAuth";
 import { Footer } from "@/components/layout/footer";
 import { ProfileSidebar } from "@/components/profile/profile-sidebar";
 import { EventCard } from "@/components/events/event-card";
@@ -139,34 +140,24 @@ function OrganizerProfileSection({ profile }: { profile: OrganizerProfile | null
 
 function ProfileContent() {
   const searchParams = useSearchParams();
+  const { user, walletAddress } = useAuth();
   const isEmpty = searchParams.get("empty") === "1";
-  const profileAddress = searchParams.get("address") ?? "me";
-  const [profile, setProfile] = useState<OrganizerProfile | null>(null);
-  const [, setLoading] = useState(true);
-  const [, setError] = useState<string | null>(null);
+  const profileAddress = searchParams.get("address") ?? walletAddress ?? "me";
 
   const hostedEvents = isEmpty ? [] : HOSTED_EVENTS;
   const attendedEvents = isEmpty ? [] : ATTENDED_EVENTS;
 
-  useEffect(() => {
-    const fetchProfile = async () => {
-      try {
-        setLoading(true);
-        const response = await fetch("/api/profile");
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const data = await response.json();
-        setProfile(data.profile);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load profile");
-      } finally {
-        setLoading(false);
-      }
+  // The signed-in user's organizer details come from the shared session so this
+  // page no longer issues its own /api/profile request.
+  const profile: OrganizerProfile | null = useMemo(() => {
+    if (!user || !user.displayName) return null;
+    return {
+      address: user.walletAddress ?? user.id,
+      displayName: user.displayName,
+      bio: user.bio ?? undefined,
+      avatarUrl: user.avatarUrl ?? undefined,
     };
-
-    fetchProfile();
-  }, []);
+  }, [user]);
 
   return (
     <div className="flex-1 w-full max-w-6xl mx-auto px-4 py-10">

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
+import { useAuth } from "@/hooks/useAuth";
 
 type SettingsTab = "profile" | "notifications" | "payment";
 
@@ -26,6 +27,7 @@ const tabs: { id: SettingsTab; label: string }[] = [
 
 export default function SettingsPage() {
   const router = useRouter();
+  const { user, isAuthenticated, isLoading: isAuthLoading, signOut } = useAuth();
   const [activeTab, setActiveTab] = useState<SettingsTab>("profile");
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -61,10 +63,23 @@ export default function SettingsPage() {
     notifications.email !== initialNotifications.email ||
     notifications.inApp !== initialNotifications.inApp;
 
+  // Settings are personal — send signed-out visitors to the auth page.
   useEffect(() => {
+    if (!isAuthLoading && !isAuthenticated) {
+      router.replace("/auth");
+    }
+  }, [isAuthLoading, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const controller = new AbortController();
+
     const fetchProfile = async () => {
       try {
-        const response = await fetch("/api/profile");
+        const response = await fetch("/api/profile", {
+          signal: controller.signal,
+        });
         if (!response.ok) {
           throw new Error(`Failed to load profile: ${response.status}`);
         }
@@ -80,13 +95,15 @@ export default function SettingsPage() {
         if (loadedProfile.avatarUrl) {
           setAvatarPreview(loadedProfile.avatarUrl);
         }
-      } catch {
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") return;
         setSaveError("Failed to load profile data");
       }
     };
 
     fetchProfile();
-  }, []);
+    return () => controller.abort();
+  }, [isAuthenticated]);
 
   const handleBeforeUnload = useCallback(
     (event: BeforeUnloadEvent) => {
@@ -188,11 +205,30 @@ export default function SettingsPage() {
   return (
     <main className="flex flex-col min-h-screen bg-base">
       <div className="w-full max-w-3xl mx-auto px-4 py-10">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-ink-soft">Settings</h1>
-          <p className="text-muted-text mt-1">
-            Manage your account preferences
-          </p>
+        <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-ink-soft">Settings</h1>
+            <p className="text-muted-text mt-1">
+              Manage your account preferences
+            </p>
+            {user && (
+              <p className="text-muted-text mt-1 text-sm break-all">
+                Signed in as{" "}
+                <span className="font-medium text-ink-soft">
+                  {user.email ?? user.walletAddress ?? user.id}
+                </span>
+              </p>
+            )}
+          </div>
+          {user && (
+            <Button
+              variant="secondary"
+              onClick={signOut}
+              className="shrink-0"
+            >
+              Sign out
+            </Button>
+          )}
         </div>
 
         <div className="bg-white rounded-2xl border border-border-warm shadow-[_-4px_4px_0_rgba(0,0,0,1)] overflow-hidden">

--- a/apps/web/components/events/filter-sidebar.tsx
+++ b/apps/web/components/events/filter-sidebar.tsx
@@ -118,13 +118,12 @@ export function FilterSidebar({
 
   const [localFilters, setLocalFilters] = useState<FilterState>(filters);
 
-  // Sync local filters with parent filters when opened
+  // Sync only when the applied filters change (apply/reset). Deliberately not
+  // keyed on `isOpen`: the draft selections must survive closing and reopening
+  // the drawer, which is how mobile users dip in and out of the filter UI.
   useEffect(() => {
-    if (isOpen) {
-      setLocalFilters(filters);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+    setLocalFilters(filters);
+  }, [filters]);
 
   // Close on Escape key
   useEffect(() => {
@@ -203,9 +202,9 @@ export function FilterSidebar({
             aria-label="Filter events"
             className="
               fixed top-0 right-0 z-50 h-full
-              w-full max-w-[360px] sm:max-w-[420px]
+              w-full max-w-full sm:max-w-[420px]
               bg-base shadow-[-8px_0_32px_rgba(0,0,0,0.12)]
-              flex flex-col overflow-y-auto
+              flex flex-col overflow-x-hidden
             "
             variants={sidebarVariants}
             initial="hidden"
@@ -248,7 +247,9 @@ export function FilterSidebar({
             </div>
 
             {/* ── Scrollable body ── */}
-            <div className="flex flex-col gap-7 px-6 py-6 flex-1">
+            {/* Scrolls independently so the Apply CTA stays reachable on short
+                mobile viewports. */}
+            <div className="flex flex-col gap-7 px-6 py-6 flex-1 overflow-y-auto">
               {/* ─ Date section ─ */}
               <section>
                 <h3 className="font-semibold text-[15px] text-black mb-3">

--- a/apps/web/components/events/popular-events-section.tsx
+++ b/apps/web/components/events/popular-events-section.tsx
@@ -9,6 +9,10 @@ import { Button } from "../ui/button";
 import { EmptyState } from "../ui/empty-state";
 import { FilterSidebar, FilterState } from "./filter-sidebar";
 import { fetchPopularEvents, type DiscoverEvent } from "@/utils/api";
+import { useDebounce } from "@/hooks/useDebounce";
+
+/** Quiet period before a search query is applied, in milliseconds. */
+const SEARCH_DEBOUNCE_MS = 300;
 
 const container = {
   hidden: { opacity: 0 },
@@ -56,6 +60,9 @@ type PopularEventsSectionProps = {
 export function PopularEventsSection({ activeCategory, onError, onEventsChange }: PopularEventsSectionProps) {
   const [isFocused, setIsFocused] = useState(false);
   const [search, setSearch] = useState("");
+  // Keystrokes update `search` instantly for the input; filtering (and any
+  // future server-side search) only runs once typing pauses.
+  const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_MS);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const [events, setEvents] = useState<DiscoverEvent[]>([]);
@@ -123,7 +130,7 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
     let result = events;
 
     // 1. Search Query
-    const query = search.toLowerCase().trim();
+    const query = debouncedSearch.toLowerCase().trim();
     if (query) {
       result = result.filter((event) =>
         event.title.toLowerCase().includes(query),
@@ -170,7 +177,7 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
     }
 
     return result;
-  }, [search, filters, events, activeCategory]);
+  }, [debouncedSearch, filters, events, activeCategory]);
 
   // Notify parent whenever the visible count changes
   const prevCountRef = useRef<number | null>(null);
@@ -189,10 +196,13 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
     unfocused: { width: "8.5rem" },
   };
 
-  const widthVariantsMobile = {
-    focused: { width: "8rem", paddingLeft: "2.5rem" },
-    unfocused: { width: "2.438rem" },
-  };
+  // Surfaced next to the mobile "Filter" button so users can tell at a glance
+  // that filters are still applied after the drawer closes.
+  const activeFilterCount =
+    (filters.date ? 1 : 0) +
+    filters.categories.length +
+    filters.locations.length +
+    (filters.minPrice !== "" || filters.maxPrice !== "" ? 1 : 0);
 
   const allLoaded = total !== null && events.length >= total;
 
@@ -200,7 +210,7 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
     <section className="px-4 bg-base py-12">
       <div className="max-w-305.25 mx-auto">
         <motion.div
-          className="flex justify-between gap-3 mb-5.75"
+          className="flex flex-col sm:flex-row sm:justify-between gap-3 mb-5.75"
           variants={container}
           initial="hidden"
           animate="show"
@@ -218,7 +228,11 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
             />
           </motion.h3>
 
-          <motion.div variants={item} className="flex items-center gap-3.75">
+          {/* ── Desktop controls ── */}
+          <motion.div
+            variants={item}
+            className="max-sm:hidden flex items-center gap-3.75"
+          >
             <div className="relative">
               <Image
                 src="/icons/search.svg"
@@ -229,9 +243,10 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
               />
 
               <motion.input
-                className="max-sm:hidden pl-13 h-9.75 rounded-4xl bg-black pr-4 py-2 text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
+                className="pl-13 h-9.75 rounded-4xl bg-black pr-4 py-2 text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
                 type="text"
                 placeholder="Search"
+                aria-label="Search events"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 onFocus={() => setIsFocused(true)}
@@ -241,25 +256,12 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
                 animate={isFocused ? "focused" : "unfocused"}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
               />
-
-              <motion.input
-                className="sm:hidden h-9.75 rounded-4xl bg-black pr-4 py-2 text-white outline-1 -outline-offset-1 outline-white/10 focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
-                variants={widthVariantsMobile}
-                initial="unfocused"
-                animate={isFocused ? "focused" : "unfocused"}
-                transition={{ duration: 0.3, ease: "easeInOut" }}
-              />
             </div>
 
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.97 }}>
               <Button
                 variant="primary"
-                className="border-none sm:rounded-4xl! max-sm:p-0 h-9.75 sm:w-34 w-9.75"
+                className="border-none rounded-4xl! h-9.75 w-34"
                 onClick={() => setIsFilterOpen(true)}
                 aria-haspopup="dialog"
                 aria-expanded={isFilterOpen}
@@ -268,11 +270,66 @@ export function PopularEventsSection({ activeCategory, onError, onEventsChange }
                   src="/icons/filter.svg"
                   width={24}
                   height={24}
-                  alt="filter icon"
+                  alt=""
+                  aria-hidden="true"
                 />
-                <span className="max-sm:hidden">Filter</span>
+                Filter
+                {activeFilterCount > 0 && (
+                  <span className="ml-1 inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-black px-1.5 text-[11px] font-bold text-white">
+                    {activeFilterCount}
+                  </span>
+                )}
               </Button>
             </motion.div>
+          </motion.div>
+
+          {/* ── Mobile controls ──
+              A full-width search field plus an explicitly labelled "Filter"
+              button, so the filter drawer is reachable on small viewports. */}
+          <motion.div
+            variants={item}
+            className="sm:hidden flex items-center gap-2 w-full min-w-0"
+          >
+            <div className="relative flex-1 min-w-0">
+              <Image
+                src="/icons/search.svg"
+                width={20}
+                height={20}
+                alt=""
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
+              />
+              <input
+                className="w-full pl-10 h-9.75 rounded-4xl bg-black pr-4 py-2 text-sm text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white/70 focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
+                type="text"
+                placeholder="Search events"
+                aria-label="Search events"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+
+            <Button
+              variant="primary"
+              className="border-none rounded-4xl! h-9.75 px-4 shrink-0"
+              onClick={() => setIsFilterOpen(true)}
+              aria-haspopup="dialog"
+              aria-expanded={isFilterOpen}
+            >
+              <Image
+                src="/icons/filter.svg"
+                width={20}
+                height={20}
+                alt=""
+                aria-hidden="true"
+              />
+              Filter
+              {activeFilterCount > 0 && (
+                <span className="inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-black px-1.5 text-[11px] font-bold text-white">
+                  {activeFilterCount}
+                </span>
+              )}
+            </Button>
           </motion.div>
         </motion.div>
 

--- a/apps/web/components/ui/breadcrumb.tsx
+++ b/apps/web/components/ui/breadcrumb.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+
+/** A single entry in a breadcrumb trail. */
+export interface BreadcrumbItem {
+  /** Visible text for this level. */
+  label: string;
+  /** Destination. Omit for the current page (rendered as plain text). */
+  href?: string;
+}
+
+interface BreadcrumbProps {
+  /** Ordered trail, from the root down to the current page. */
+  items: BreadcrumbItem[];
+  /** Extra classes for the wrapping `<nav>`. */
+  className?: string;
+  /**
+   * Colour classes for the linked ancestors, the separators and the current
+   * page. Override when the breadcrumb sits on a surface the default tokens
+   * were not chosen for — e.g. the Help Center's accent banner.
+   */
+  linkClassName?: string;
+  separatorClassName?: string;
+  currentClassName?: string;
+}
+
+/**
+ * Hierarchical breadcrumb navigation.
+ *
+ * Renders an ordered list inside a labelled `<nav>`; the final entry is marked
+ * with `aria-current="page"` and is never a link, matching the WAI-ARIA
+ * breadcrumb pattern. Separators are decorative and hidden from screen readers.
+ *
+ * @example
+ * <Breadcrumb
+ *   items={[
+ *     { label: "Home", href: "/" },
+ *     { label: "Discover", href: "/discover" },
+ *     { label: event.title },
+ *   ]}
+ * />
+ */
+export function Breadcrumb({
+  items,
+  className = "",
+  linkClassName = "text-ink-soft/70 hover:text-ink-soft",
+  separatorClassName = "text-ink-soft/40",
+  currentClassName = "text-ink-soft",
+}: BreadcrumbProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <nav aria-label="breadcrumb" className={className}>
+      <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+
+          return (
+            <li
+              key={`${item.href ?? "current"}-${item.label}`}
+              className="flex items-center gap-2 min-w-0"
+            >
+              {isLast || !item.href ? (
+                <span
+                  aria-current={isLast ? "page" : undefined}
+                  className={`max-w-[16rem] truncate font-semibold ${currentClassName}`}
+                  title={item.label}
+                >
+                  {item.label}
+                </span>
+              ) : (
+                <Link
+                  href={item.href}
+                  className={`rounded-sm transition-colors hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${linkClassName}`}
+                >
+                  {item.label}
+                </Link>
+              )}
+
+              {!isLast && (
+                <span
+                  aria-hidden="true"
+                  className={`select-none ${separatorClassName}`}
+                >
+                  /
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+export default Breadcrumb;

--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import useSWR from "swr";
+import type { AuthUser, SessionResponse } from "@/types/auth";
+
+export type { AuthUser, SessionResponse };
+
+const SESSION_ENDPOINT = "/api/auth/session";
+const SIGNOUT_ENDPOINT = "/api/auth/signout";
+
+const SIGNED_OUT: SessionResponse = { user: null };
+
+async function fetchSession(url: string): Promise<SessionResponse> {
+  const response = await fetch(url, { credentials: "same-origin" });
+
+  // Treat an unauthorized response as "signed out" rather than a failure.
+  if (response.status === 401) {
+    return SIGNED_OUT;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load session (${response.status})`);
+  }
+
+  return (await response.json()) as SessionResponse;
+}
+
+/** Value returned by {@link useAuth}. */
+export interface UseAuthResult {
+  /** The signed-in user, or `null` when signed out or still loading. */
+  user: AuthUser | null;
+  /** Convenience accessor for `user.walletAddress`. */
+  walletAddress: string | null;
+  /** `true` once a valid session has been loaded. */
+  isAuthenticated: boolean;
+  /** `true` while the session request is in flight. */
+  isLoading: boolean;
+  /** Clears the session cookie and redirects to `/`. */
+  signOut: () => Promise<void>;
+}
+
+/**
+ * Centralised authentication state.
+ *
+ * Wraps the custom-JWT session behind `GET /api/auth/session` and shares it
+ * across the app through SWR's cache, so every consumer sees the same user
+ * without issuing its own request.
+ *
+ * @example
+ * const { user, walletAddress, isAuthenticated, isLoading, signOut } = useAuth();
+ */
+export function useAuth(): UseAuthResult {
+  const router = useRouter();
+
+  const { data, error, isLoading, mutate } = useSWR<SessionResponse>(
+    SESSION_ENDPOINT,
+    fetchSession,
+    {
+      revalidateOnFocus: false,
+      shouldRetryOnError: false,
+    },
+  );
+
+  // A failed session lookup means we cannot prove the user is signed in.
+  const user: AuthUser | null = error ? null : (data?.user ?? null);
+
+  const signOut = useCallback(async () => {
+    try {
+      await fetch(SIGNOUT_ENDPOINT, {
+        method: "POST",
+        credentials: "same-origin",
+      });
+    } finally {
+      // Drop the cached session even if the request failed, so the UI never
+      // keeps showing a user we can no longer authenticate.
+      await mutate(SIGNED_OUT, { revalidate: false });
+      router.replace("/");
+      router.refresh();
+    }
+  }, [mutate, router]);
+
+  return {
+    user,
+    walletAddress: user?.walletAddress ?? null,
+    isAuthenticated: user !== null,
+    isLoading,
+    signOut,
+  };
+}

--- a/apps/web/hooks/useDebounce.ts
+++ b/apps/web/hooks/useDebounce.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Debounces a rapidly changing value.
+ *
+ * Returns the previous value until `delay` milliseconds have elapsed without a
+ * further change, which keeps search inputs from firing a request on every
+ * keystroke.
+ *
+ * @typeParam T - Type of the debounced value.
+ * @param value - The value to debounce.
+ * @param delay - Quiet period in milliseconds before the value is published.
+ * @returns The most recent value that stayed unchanged for `delay` ms.
+ *
+ * @example
+ * const [search, setSearch] = useState("");
+ * const debouncedSearch = useDebounce(search, 300);
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedValue(value), delay);
+
+    // Restarting the timer on every change is what collapses a burst of
+    // keystrokes into a single update.
+    return () => clearTimeout(timeout);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/apps/web/types/auth.ts
+++ b/apps/web/types/auth.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared authentication types.
+ *
+ * Agora uses a custom JWT stored in an HttpOnly `auth_token` cookie (see
+ * `lib/auth.ts`), so the browser cannot read the session directly. Client code
+ * reads it through `GET /api/auth/session`, which returns the shape below.
+ */
+
+/** The authenticated user, as exposed to the browser. */
+export interface AuthUser {
+  /** Stable identifier: the JWT `sub` when present, otherwise the email. */
+  id: string;
+  /** Email address on the session token, if the provider supplied one. */
+  email: string | null;
+  /**
+   * Wallet / organizer address for this user. Mirrors the JWT `sub`, which is
+   * what `OrganizerProfile.address` is keyed on.
+   */
+  walletAddress: string | null;
+  /** Display name from the organizer profile, if one exists. */
+  displayName: string | null;
+  /** Avatar URL from the organizer profile, if one exists. */
+  avatarUrl: string | null;
+  /** Bio from the organizer profile, if one exists. */
+  bio: string | null;
+}
+
+/** Response body of `GET /api/auth/session`. */
+export interface SessionResponse {
+  /** `null` when there is no valid session cookie. */
+  user: AuthUser | null;
+}


### PR DESCRIPTION
Resolves four Wave 7 frontend issues in a single branch.

Closes #1057
Closes #1056
Closes #1054
Closes #1053

---

### #1057 — `useAuth` hook / centralised auth state

Auth is a custom JWT in an **HttpOnly** `auth_token` cookie (`lib/auth.ts`), so the browser cannot read the session directly. Two small endpoints back the hook:

- `GET /api/auth/session` — returns `{ user }`, enriched with the organizer profile when one exists. Always 200; no session yields `{ user: null }` so callers don't treat "signed out" as an error. A profile lookup failure degrades to `null` rather than signing the user out.
- `POST /api/auth/signout` — clears the cookie (the browser can't expire an HttpOnly cookie itself).

`hooks/useAuth.ts` wraps this with SWR, so every consumer shares one cached session:

```ts
const { user, walletAddress, isAuthenticated, isLoading, signOut } = useAuth();
```

`signOut` clears the cookie, drops the cached session even if the request fails, then redirects to `/`.

Pages migrated:
- **`settings/page.tsx`** — redirects signed-out visitors to `/auth`, gates the `/api/profile` fetch (now abortable) on being authenticated, and gains a "Signed in as …" line and a **Sign out** button.
- **`profile/page.tsx`** — dropped its own `/api/profile` request; organizer details now derive from the shared session.
- **`home/page.tsx`** — previously had **no auth check** and a hardcoded `const userWallet = "0xUSERWALLET"`. Now redirects when signed out, uses the real `walletAddress`, and only fetches events once authenticated.

User types live in `types/auth.ts` (`AuthUser`, `SessionResponse`) — no implicit `any`.

### #1056 — `useDebounce` hook

`hooks/useDebounce.ts` implements the generic `useDebounce<T>(value: T, delay: number): T`. Applied to the Discover search input at 300ms: keystrokes update the field instantly while filtering only runs once typing pauses.

`__tests__/use-debounce.test.ts` covers the two required cases plus burst collapsing and non-string values — **5 tests passing**.

### #1054 — Filter sidebar not reachable on mobile

- The mobile filter trigger was an unlabelled icon-only button next to a search box that collapsed to ~39px. It's now an explicitly labelled **Filter** button with an active-filter count badge, beside a full-width search field.
- `FilterSidebar` goes full-width below `sm` (was capped at 360px) with `overflow-x-hidden`, so there's no horizontal overflow at 375px.
- The panel body now scrolls independently of the header/footer, so **Apply Filters** stays reachable on short viewports — previously the whole panel scrolled and the CTA could sit off-screen.
- **Filter state is preserved across close/reopen**: the draft-sync effect was keyed on `isOpen`, which discarded in-progress selections every time the drawer reopened. It's now keyed on the applied `filters`, so drafts survive dipping in and out of the drawer.

### #1053 — Breadcrumb navigation

`components/ui/breadcrumb.tsx` — an ordered list inside `<nav aria-label="breadcrumb">`, last item marked `aria-current="page"` and never a link, separators `aria-hidden`. Links are native anchors with a visible `focus-visible` ring, so the trail is keyboard-navigable. Colours use existing design tokens, with optional overrides for surfaces the defaults weren't picked for (the Help Center's accent banner).

- Event detail: `Home > Discover > [Event Title]`
- Help article: `Home > Help > [Category] > [Article Title]` — replaces the ad-hoc inline `<nav>`. The category level is text, not a link, since no `/help/[category]` index route exists yet and linking it would point at a 404.

`__tests__/breadcrumb.test.tsx` — **5 tests passing** covering the landmark, links, `aria-current`, hidden separators, and the empty case.

---

### Verification

- `tsc --noEmit` reports **no errors in any file this PR adds or touches**. Pre-existing repo-wide errors (missing SVG module declarations, ungenerated Prisma client, `"ghost"`/`"outline"` Button variants) are untouched, per the brief to fix the issues only.
- `eslint` clean on all changed files.
- `vitest`: 10 new tests pass. The 16 failures in `gift-tickets`, `navbar`, `lazy-image` and `button` are **pre-existing** — verified identical on a clean `main` checkout — and are in files this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)