### PR TITLE
fix(#1077): pause ticket availability polling when tab is hidden

### DIFF
--- a/apps/web/hooks/useTicketAvailability.ts
+++ b/apps/web/hooks/useTicketAvailability.ts
@@ -88,6 +88,26 @@ export function useTicketAvailability(
   const [sseData, setSSEData] = useState<TicketAvailabilityData | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
 
+  // Track whether the browser tab is currently visible
+  const [isTabVisible, setIsTabVisible] = useState(
+    typeof document !== "undefined"
+      ? document.visibilityState === "visible"
+      : true,
+  );
+
+  // Page Visibility API: pause polling when hidden, resume + re-fetch on focus
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      const visible = document.visibilityState === "visible";
+      setIsTabVisible(visible);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
   // Regular SWR polling approach
   const url = `/api/events/${eventId}/availability`;
   const { data, error, isLoading, mutate } = useSWR<TicketAvailabilityData>(
@@ -97,10 +117,19 @@ export function useTicketAvailability(
       // Only revalidate on focus if pollOnBlur is false
       revalidateOnFocus: !pollOnBlur,
       revalidateOnReconnect: true,
-      // Poll at specified interval (0 disables polling)
-      refreshInterval: pollInterval > 0 ? pollInterval : 0,
+      // Pause polling while the tab is hidden; resume at the configured interval when visible
+      refreshInterval: pollInterval > 0 && isTabVisible ? pollInterval : 0,
     },
   );
+
+  // Re-fetch immediately when the tab becomes visible again to catch missed updates
+  const prevIsTabVisible = useRef(isTabVisible);
+  useEffect(() => {
+    if (!useSSE && isTabVisible && !prevIsTabVisible.current) {
+      mutate();
+    }
+    prevIsTabVisible.current = isTabVisible;
+  }, [isTabVisible, useSSE, mutate]);
 
   // Server-Sent Events (SSE) approach for real-time updates
   useEffect(() => {


### PR DESCRIPTION
# fix(#1077): Pause ticket availability polling when browser tab is hidden
closes #1077
## Summary

`useTicketAvailability` was continuously firing HTTP requests every 5 000 ms
regardless of whether the browser tab was visible or backgrounded. This wasted
client CPU and generated unnecessary server load.

The fix adds a **Page Visibility API** listener so polling is paused while the
tab is hidden and resumed — with an immediate re-fetch — the moment the tab
comes back into focus.

## Changes

**`apps/web/hooks/useTicketAvailability.ts`**

- Added `isTabVisible` state, initialised from `document.visibilityState`
  (SSR-safe guard included).
- Registered a `visibilitychange` event listener in a `useEffect` with proper
  cleanup to keep `isTabVisible` in sync.
- Changed SWR `refreshInterval` from `pollInterval > 0 ? pollInterval : 0` to
  `pollInterval > 0 && isTabVisible ? pollInterval : 0` — SWR receives `0`
  (no polling) while the tab is hidden.
- Added a second `useEffect` that calls `mutate()` immediately whenever
  `isTabVisible` transitions `false → true`, catching any availability changes
  missed during the pause.

The SSE code path is unchanged — it maintains its own persistent connection
and does not need visibility-based throttling.

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| No network requests while tab is hidden | ✅ |
| Polling resumes immediately on tab focus | ✅ |
| Ticket availability re-fetched once on tab focus | ✅ |

## How to Test

1. Open an event page with `<TicketAvailabilityDisplay />`.
2. Open DevTools → Network tab.
3. Switch to a different browser tab — confirm no `/api/events/:id/availability`
   requests fire.
4. Switch back — confirm exactly one request fires instantly, then normal
   5-second polling resumes.

## Related

Closes #1077
