### PR TITLE
fix: skeleton pills and clean fallback for CategorySection

### DIFF
--- a/apps/web/components/events/category-section.tsx
+++ b/apps/web/components/events/category-section.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useEffect } from "react";
 import { motion, type Transition } from "framer-motion";
 import useSWR from "swr";
 import { fetchCategories, type DiscoverCategory } from "@/utils/api";
+import { CategoryChips } from "./category-chips";
 
-const defaultCategories = [
+const defaultCategories: DiscoverCategory[] = [
   { name: "Tech", icon: "/icons/Tech.svg", color: "#DBF4B9" },
   { name: "Party", icon: "/icons/party.svg", color: "#FFA4D5" },
   { name: "global", icon: "/icons/global.svg", color: "#B9C7FE" },
@@ -40,8 +42,6 @@ const item = {
   },
 };
 
-import { CategoryChips } from "./category-chips";
-
 type CategorySectionProps = {
   activeCategory: string;
   onCategoryChange: (category: string) => void;
@@ -49,30 +49,40 @@ type CategorySectionProps = {
 };
 
 export function CategorySection({ activeCategory, onCategoryChange, onError }: CategorySectionProps) {
-  // Use SWR for category fetching with automatic caching and revalidation
   const { data: categories, error, isLoading } = useSWR<DiscoverCategory[]>(
     "/api/events/discover/categories",
     () => fetchCategories(),
     {
-      // Revalidate on window focus to keep data fresh
       revalidateOnFocus: true,
-      // Revalidate on reconnect
       revalidateOnReconnect: true,
-      // Don't revalidate on mount if data is already cached
       revalidateIfStale: false,
-      // Keep previous data while revalidating
       keepPreviousData: true,
-      // Deduplicate requests within 2 seconds
       dedupingInterval: 2000,
     }
   );
 
-  // Handle errors from SWR
-  if (error && !categories) {
-    onError("Could not load categories");
-  }
+  // Fire onError once per error occurrence — not on every render.
+  useEffect(() => {
+    if (error) {
+      onError("Could not load categories");
+    }
+  }, [error, onError]);
 
-  const categoriesToRender = categories && categories.length > 0 ? categories : defaultCategories;
+  // While loading: show skeleton pills (pass empty array + isLoading=true).
+  // After load: use API data when available, otherwise fall back to defaults.
+  // If both are exhausted (error + no cache): still use defaults so the
+  // section never renders as an empty gap.
+  const loaded = !isLoading;
+  const apiCategories = categories && categories.length > 0 ? categories : null;
+  const categoriesToRender: DiscoverCategory[] = loaded
+    ? (apiCategories ?? defaultCategories)
+    : [];
+
+  // Hide the entire block only when loading has finished, the fetch failed,
+  // AND we somehow ended up with zero categories (shouldn't happen given the
+  // defaultCategories fallback above, but guards against future regressions).
+  const hasCategories = isLoading || categoriesToRender.length > 0;
+  if (!hasCategories) return null;
 
   return (
     <section className="px-4 bg-base pt-12 pb-6">
@@ -93,18 +103,24 @@ export function CategorySection({ activeCategory, onCategoryChange, onError }: C
         </motion.div>
 
         <motion.div variants={container} initial="hidden" animate="show">
-          <motion.h3
-            variants={item}
-            className="font-semibold text-xl mb-6 flex items-center gap-2"
-          >
-            Browse by Category
-          </motion.h3>
+          {/* Heading is suppressed while loading so it doesn't float above skeletons */}
+          {!isLoading && (
+            <motion.h3
+              variants={item}
+              className="font-semibold text-xl mb-6 flex items-center gap-2"
+            >
+              Browse by Category
+            </motion.h3>
+          )}
+          {isLoading && (
+            <div className="h-7 w-48 rounded-md bg-black/10 animate-pulse mb-6" />
+          )}
 
-          <CategoryChips 
-            categories={categoriesToRender} 
-            activeCategory={activeCategory} 
-            onCategoryChange={onCategoryChange} 
-            isLoading={isLoading} 
+          <CategoryChips
+            categories={categoriesToRender}
+            activeCategory={activeCategory}
+            onCategoryChange={onCategoryChange}
+            isLoading={isLoading}
           />
         </motion.div>
       </div>


### PR DESCRIPTION
# fix(#1079): Skeleton pills and clean fallback for CategorySection

## Summary

When category fetch requests failed or returned an empty array,
`CategorySection` had two distinct bugs:

1. **Wrong skeleton behaviour** — `categoriesToRender` fell back to
   `defaultCategories` while `isLoading` was still `true`, so
   `CategoryChips` rendered both the skeleton pills *and* the real pill
   buttons simultaneously (the `isLoading` / `!isLoading` branches inside
   `CategoryChips` are not mutually exclusive at the data level).

2. **Render-phase side-effect** — `onError(...)` was called directly in the
   render body, firing on every re-render, not once per error.

## Changes

**`apps/web/components/events/category-section.tsx`**

- Moved `onError` call into a `useEffect` (deps: `[error, onError]`) so it
  fires exactly once each time an error first appears.
- Decoupled the `categoriesToRender` derivation from the loading state:
  - While `isLoading === true` → pass an empty array to `CategoryChips`
    together with `isLoading={true}`, letting the existing skeleton branch
    in `CategoryChips` render 6 animated placeholder pills cleanly.
  - After load resolves → use API data if non-empty, otherwise fall back to
    `defaultCategories`, ensuring the section is never blank.
- Added a `hasCategories` guard that returns `null` for the entire section
  only if loading is complete *and* `categoriesToRender` is still empty
  (defensive; unreachable today given the fallback, but prevents a blank
  layout gap if `defaultCategories` is ever removed).
- Added a matching skeleton for the "Browse by Category" heading so the
  heading line doesn't float in empty space above the pill skeletons during
  load.
- Typed `defaultCategories` explicitly as `DiscoverCategory[]` and moved the
  stray `import { CategoryChips }` to the top of the import block.

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Skeleton pills render during the loading state | ✅ |
| Empty/failed fetch does not produce a blank layout gap | ✅ |
| Section is hidden cleanly if no categories are available | ✅ |

## How to Test

1. Throttle the network to Slow 3G in DevTools — confirm 6 animated skeleton
   pills and a skeleton heading appear while the request is in-flight.
2. Block the `/api/events/discover/categories` request in DevTools — confirm
   the section falls back to the 10 default category pills with no console
   errors and no blank gap.
3. Return an empty array `[]` from the API — same result as above.

## Related

Closes #1079
