### PR TITLE
fix: surface 500 errors to error.tsx boundary in useEventDetails

### DIFF
--- a/apps/web/__tests__/useEventDetails.test.tsx
+++ b/apps/web/__tests__/useEventDetails.test.tsx
@@ -1,10 +1,10 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useEventDetails } from '../hooks/useEventDetails';
-import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import { useEventDetails, EventApiError } from '../hooks/useEventDetails';
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { SWRConfig } from 'swr';
-import React from 'react';
+import React, { Component, type ReactNode } from 'react';
 
 const mockEvent = {
   id: '1',
@@ -15,27 +15,59 @@ const server = setupServer(
   http.get('/api/v1/events/1', () => {
     return HttpResponse.json(mockEvent);
   }),
-  http.get('/api/v1/events/2', () => {
+  http.get('/api/v1/events/not-found', () => {
+    return new HttpResponse(null, { status: 404 });
+  }),
+  http.get('/api/v1/events/server-error', () => {
     return new HttpResponse(null, { status: 500 });
-  })
+  }),
 );
 
 beforeAll(() => server.listen());
-afterEach(() => {
-  server.resetHandlers();
-});
+afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
+// Suppress React's console.error for expected thrown errors in tests
+beforeAll(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
 const createWrapper = () => {
-  return ({ children }: { children: React.ReactNode }) => (
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, errorRetryInterval: 0 }}>
+  return ({ children }: { children: ReactNode }) => (
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        errorRetryInterval: 0,
+        // Disable SWR's own retry so 500 tests don't loop
+        shouldRetryOnError: false,
+      }}
+    >
       {children}
     </SWRConfig>
   );
 };
 
+/** Minimal error boundary to catch errors thrown by the hook under test. */
+class ErrorBoundary extends Component<
+  { children: ReactNode; onError: (e: Error) => void },
+  { caught: boolean }
+> {
+  state = { caught: false };
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+    this.setState({ caught: true });
+  }
+  render() {
+    return this.state.caught ? null : this.props.children;
+  }
+}
+
 describe('useEventDetails', () => {
-  it('should return pending state initially', async () => {
+  it('returns pending state initially', async () => {
     const { result } = renderHook(() => useEventDetails('1'), {
       wrapper: createWrapper(),
     });
@@ -43,29 +75,30 @@ describe('useEventDetails', () => {
     expect(result.current.event).toBeUndefined();
   });
 
-  it('should fetch event data successfully', async () => {
+  it('fetches event data successfully', async () => {
     const { result } = renderHook(() => useEventDetails('1'), {
       wrapper: createWrapper(),
     });
-    
+
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
-    
+
     expect(result.current.event).toEqual(mockEvent);
     expect(result.current.isError).toBeUndefined();
   });
 
-  it('should return failure with retry on error', async () => {
-    let callCount = 0;
-    server.use(
-      http.get('/api/v1/events/2', () => {
-        callCount++;
-        return new HttpResponse(null, { status: 500 });
-      })
-    );
+  it('exposes a retry function', async () => {
+    const { result } = renderHook(() => useEventDetails('1'), {
+      wrapper: createWrapper(),
+    });
 
-    const { result } = renderHook(() => useEventDetails('2'), {
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(typeof result.current.retry).toBe('function');
+  });
+
+  it('returns isError (EventApiError with status 404) for not-found — does not throw', async () => {
+    const { result } = renderHook(() => useEventDetails('not-found'), {
       wrapper: createWrapper(),
     });
 
@@ -73,8 +106,36 @@ describe('useEventDetails', () => {
       expect(result.current.isError).toBeDefined();
     }, { timeout: 4000 });
 
-    // SWR retries errors by default
-    expect(callCount).toBeGreaterThan(1);
+    expect(result.current.isError).toBeInstanceOf(EventApiError);
+    expect((result.current.isError as EventApiError).status).toBe(404);
     expect(result.current.event).toBeUndefined();
+  });
+
+  it('throws EventApiError with status 500 so it reaches the error boundary', async () => {
+    let caughtError: Error | null = null;
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          dedupingInterval: 0,
+          errorRetryInterval: 0,
+          shouldRetryOnError: false,
+        }}
+      >
+        <ErrorBoundary onError={(e) => { caughtError = e; }}>
+          {children}
+        </ErrorBoundary>
+      </SWRConfig>
+    );
+
+    renderHook(() => useEventDetails('server-error'), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(caughtError).not.toBeNull();
+    }, { timeout: 4000 });
+
+    expect(caughtError).toBeInstanceOf(EventApiError);
+    expect((caughtError as unknown as EventApiError).status).toBe(500);
   });
 });

--- a/apps/web/hooks/useEventDetails.ts
+++ b/apps/web/hooks/useEventDetails.ts
@@ -1,26 +1,56 @@
 "use client";
 
+import useSWR from "swr";
 
-import useSWR from 'swr';
+/**
+ * Typed API error that carries the HTTP status code.
+ * Allows callers to distinguish 404 (not-found) from 5xx (server fault).
+ */
+export class EventApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EventApiError";
+  }
+}
 
-const fetcher = (url: string) => fetch(url).then((res) => {
-  if (!res.ok) throw new Error('Failed to fetch event details');
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new EventApiError(
+      res.status,
+      `Failed to fetch event details (HTTP ${res.status})`,
+    );
+  }
   return res.json();
-});
+};
 
 export function useEventDetails(id?: string) {
   const { data, error, isLoading, mutate } = useSWR(
     id ? `/api/v1/events/${id}` : null,
     fetcher,
     {
+      // Only retry on non-404 errors — there is no point retrying a not-found.
+      shouldRetryOnError: (err: unknown) =>
+        !(err instanceof EventApiError && err.status === 404),
       errorRetryCount: 3,
-    }
+    },
   );
+
+  // Re-throw 5xx errors so they escape the React render and reach the nearest
+  // error.tsx boundary.  404s are returned via isError so the page can call
+  // notFound() itself — that behaviour is unchanged.
+  if (error instanceof EventApiError && error.status >= 500) {
+    throw error;
+  }
 
   return {
     event: data,
     isLoading,
     isError: error,
-    mutate,
+    /** Re-invoke the fetch — pass as the retry callback to the error boundary. */
+    retry: () => mutate(),
   };
 }


### PR DESCRIPTION
# fix(#1080): Surface 500 errors to error.tsx boundary in useEventDetails

## Summary

`useEventDetails` previously threw a generic `Error` for every non-OK response.
Both 404 and 500 landed in SWR's `error` field, leaving the page in an
indefinite loading state on server errors because nothing re-threw the error
into React's render tree.

## Changes

### `apps/web/hooks/useEventDetails.ts`

- Added exported `EventApiError` class that extends `Error` and carries the
  HTTP `status` code — allows callers to distinguish 404 from 5xx without
  string-parsing the message.
- Updated `fetcher` to throw `EventApiError(res.status, ...)` instead of a
  plain `Error`.
- Added `shouldRetryOnError` option to SWR: skips retries for 404 (pointless)
  while still retrying 5xx up to `errorRetryCount: 3`.
- **Re-throws any `EventApiError` with `status >= 500` during render**, so the
  error escapes React's reconciler and triggers the nearest `error.tsx`
  boundary. The existing `error.tsx` already has a "Try again" button that
  calls `reset()`, which re-renders the component tree and re-invokes the hook.
- 404 errors continue to surface via `isError` so pages can call `notFound()`
  unchanged.
- Renamed `mutate` → `retry` in the return value to make the intent explicit
  (`retry: () => mutate()`).

### `apps/web/__tests__/useEventDetails.test.tsx`

- Updated mock handlers to use semantic IDs (`not-found`, `server-error`)
  instead of opaque integers.
- Added `EventApiError` import and assertions on `.status`.
- Added minimal `ErrorBoundary` class component to the test file so the 500
  throw-path can be tested without a real React tree.
- Replaced the old 500 `isError` test with one that asserts the error reaches
  the boundary via `componentDidCatch`.
- Added explicit test for 404 returning via `isError` (not throwing).
- Added test that `retry` is a function on a successful fetch.
- Suppressed React's `console.error` for the expected thrown-error test to
  keep CI output clean.

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| 500 response triggers the nearest error.tsx boundary | ✅ |
| Error boundary retry button re-invokes the hook via `reset()` | ✅ |
| 404 responses continue to render the existing not-found UI | ✅ |

## How to Test

1. Point the event API to return 500 (or use the DevTools override) — the
   `error.tsx` boundary should appear with "Something went wrong" and a
   "Try again" button.
2. Click "Try again" — SWR re-fetches; on a successful retry the event page
   renders normally.
3. Point the event API to return 404 — the page calls `notFound()` and renders
   the 404 UI as before.

## Related

Closes #1080
