### PR TITLE
fix(backend): cache organizer stats in Redis and validate the socials field

### DIFF
--- a/server/src/handlers/profile.rs
+++ b/server/src/handlers/profile.rs
@@ -33,12 +33,8 @@ use crate::utils::error::AppError;
 use crate::utils::pagination::{PaginatedResponse, PaginationParams};
 use crate::utils::response::success;
 
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
-use std::sync::Mutex;
-use std::time::Instant;
 
 const PROFILE_CACHE_TTL: Duration = Duration::from_secs(600);
 
@@ -55,6 +51,68 @@ pub struct ProfileState {
 
 const MAX_DISPLAY_NAME: usize = 50;
 const MAX_BIO: usize = 500;
+
+/// Social platforms accepted in the `socials` object (#877).
+///
+/// An allowlist rather than free-form keys: `socials` is typed `serde_json::Value`,
+/// so without one an organizer could store arbitrarily nested objects or arrays
+/// in a column the UI expects to render as a flat set of links.
+const ALLOWED_SOCIAL_KEYS: &[&str] = &[
+    "twitter",
+    "instagram",
+    "website",
+    "linkedin",
+    "facebook",
+    "youtube",
+    "tiktok",
+    "discord",
+    "telegram",
+    "github",
+];
+
+/// Maximum length of a single social handle or URL.
+const MAX_SOCIAL_VALUE: usize = 200;
+
+/// Validate the structure of the `socials` field (#877).
+///
+/// Must be a flat JSON object whose keys are known platforms and whose values
+/// are strings. Rejecting rather than silently stripping: an organizer who
+/// mistypes `twiter` should be told, not have the value quietly discarded and
+/// wonder later why their link never appeared.
+///
+/// `null` is allowed so a caller can clear the field.
+fn validate_socials(socials: &Value) -> Result<(), AppError> {
+    if socials.is_null() {
+        return Ok(());
+    }
+
+    let obj = socials.as_object().ok_or_else(|| {
+        AppError::ValidationError("socials must be a JSON object".to_string())
+    })?;
+
+    for (key, value) in obj {
+        if !ALLOWED_SOCIAL_KEYS.contains(&key.as_str()) {
+            return Err(AppError::ValidationError(format!(
+                "socials contains unsupported key \"{key}\" (allowed: {})",
+                ALLOWED_SOCIAL_KEYS.join(", ")
+            )));
+        }
+
+        let Some(text) = value.as_str() else {
+            return Err(AppError::ValidationError(format!(
+                "socials.{key} must be a string"
+            )));
+        };
+
+        if text.len() > MAX_SOCIAL_VALUE {
+            return Err(AppError::ValidationError(format!(
+                "socials.{key} must not exceed {MAX_SOCIAL_VALUE} characters"
+            )));
+        }
+    }
+
+    Ok(())
+}
 
 fn validate_upsert(req: &UpsertProfileRequest) -> Result<(), AppError> {
     if req.display_name.trim().is_empty() {
@@ -73,6 +131,9 @@ fn validate_upsert(req: &UpsertProfileRequest) -> Result<(), AppError> {
                 "bio must not exceed 500 characters".to_string(),
             ));
         }
+    }
+    if let Some(ref socials) = req.socials {
+        validate_socials(socials)?;
     }
     Ok(())
 }
@@ -107,6 +168,10 @@ fn validate_patch(req: &PatchProfileRequest) -> Result<(), AppError> {
                 "bio must be at most {MAX_BIO} characters"
             )));
         }
+    }
+
+    if let Some(ref socials) = req.socials {
+        validate_socials(socials)?;
     }
 
     Ok(())
@@ -206,6 +271,17 @@ pub async fn upsert_profile(
     };
 
     let cache_key = format!("profile:{address}");
+    // #828: the stats entry is derived from the same profile, so it has to be
+    // dropped here too — otherwise an updated profile keeps serving stats
+    // cached against the old one for up to 5 minutes.
+    if let Err(e) = state
+        .redis
+        .delete(&organizer_stats_cache_key(&address))
+        .await
+    {
+        tracing::warn!("Failed to invalidate organizer stats cache for {address}: {:?}", e);
+    }
+
     if let Err(e) = state.redis.delete(&cache_key).await {
         tracing::warn!("Failed to invalidate profile cache for {address}: {:?}", e);
     }
@@ -272,6 +348,17 @@ pub async fn patch_profile(
     };
 
     let cache_key = format!("profile:{address}");
+    // #828: the stats entry is derived from the same profile, so it has to be
+    // dropped here too — otherwise an updated profile keeps serving stats
+    // cached against the old one for up to 5 minutes.
+    if let Err(e) = state
+        .redis
+        .delete(&organizer_stats_cache_key(&address))
+        .await
+    {
+        tracing::warn!("Failed to invalidate organizer stats cache for {address}: {:?}", e);
+    }
+
     if let Err(e) = state.redis.delete(&cache_key).await {
         tracing::warn!("Failed to invalidate profile cache for {address}: {:?}", e);
     }
@@ -322,6 +409,17 @@ pub async fn delete_profile(State(mut state): State<ProfileState>, headers: Head
     }
 
     let cache_key = format!("profile:{address}");
+    // #828: the stats entry is derived from the same profile, so it has to be
+    // dropped here too — otherwise an updated profile keeps serving stats
+    // cached against the old one for up to 5 minutes.
+    if let Err(e) = state
+        .redis
+        .delete(&organizer_stats_cache_key(&address))
+        .await
+    {
+        tracing::warn!("Failed to invalidate organizer stats cache for {address}: {:?}", e);
+    }
+
     if let Err(e) = state.redis.delete(&cache_key).await {
         tracing::warn!("Failed to invalidate profile cache for {address}: {:?}", e);
     }
@@ -493,8 +591,13 @@ struct OrganizerStats {
     pub average_event_rating: f64,
 }
 
-static STATS_CACHE: Lazy<Mutex<HashMap<String, (Instant, OrganizerStats)>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+/// Redis key for an organizer's cached stats (#828).
+///
+/// Namespaced so the entry is identifiable in Redis and can be invalidated by
+/// exact key on profile update.
+fn organizer_stats_cache_key(address: &str) -> String {
+    format!("organizer_stats:{address}")
+}
 
 const STATS_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
@@ -515,20 +618,26 @@ fn organizer_stats_query() -> &'static str {
 /// `GET /api/v1/profile/:address/stats`
 ///
 /// Returns aggregate stats for an organizer: total events created, total tickets sold,
-/// and average event rating. Cached in-process for 5 minutes to avoid repeated DB hits.
+/// and average event rating.
+///
+/// Cached in Redis for 5 minutes (#828). Previously this used a process-local
+/// `HashMap` that was never pruned, so it grew without bound as distinct
+/// organizer addresses were queried — and behind a load balancer each process
+/// held its own copy, so an invalidation in one was invisible to the others and
+/// stale stats kept being served. Redis makes the cache shared and gives it a
+/// real eviction policy.
 pub async fn get_organizer_stats(
-    State(pool): State<PgPool>,
+    State(state): State<ProfileState>,
     Path(address): Path<String>,
 ) -> Response {
-    // Check in-memory cache first
-    {
-        let cache = STATS_CACHE.lock().unwrap();
-        if let Some((expiry, stats)) = cache.get(&address) {
-            if Instant::now() < *expiry {
-                return success(stats.clone(), "Organizer stats retrieved from cache")
-                    .into_response();
-            }
-        }
+    let mut redis = state.redis.clone();
+    let pool = state.pool;
+    let cache_key = organizer_stats_cache_key(&address);
+
+    // A cache read failure is not a request failure: fall through to the
+    // database rather than 500ing because Redis is briefly unavailable.
+    if let Ok(Some(stats)) = redis.get::<OrganizerStats>(&cache_key).await {
+        return success(stats, "Organizer stats retrieved from cache").into_response();
     }
 
     let stats: OrganizerStats = match sqlx::query_as(organizer_stats_query())
@@ -543,13 +652,10 @@ pub async fn get_organizer_stats(
         }
     };
 
-    // store in cache
-    {
-        let mut cache = STATS_CACHE.lock().unwrap();
-        cache.insert(
-            address.clone(),
-            (Instant::now() + STATS_CACHE_TTL, stats.clone()),
-        );
+    // Best-effort write: a cache miss on the next request is cheaper than
+    // failing a request that already has its answer.
+    if let Err(e) = redis.set(&cache_key, &stats, STATS_CACHE_TTL).await {
+        tracing::warn!("Failed to cache organizer stats for {address}: {e:?}");
     }
 
     success(stats, "Organizer stats retrieved successfully").into_response()
@@ -867,37 +973,54 @@ mod tests {
         assert!(query.contains("e.is_flagged = FALSE"));
     }
 
-    #[tokio::test]
-    async fn test_get_organizer_stats_cache_hit() {
-        use axum::extract::{Path, State};
-        // create a lazy pool; it won't hit the DB because the cache will short-circuit
-        let pool = sqlx::PgPool::connect_lazy("postgres://localhost/fake").unwrap();
-        let addr = "TEST-ADDR".to_string();
-        {
-            let mut cache = STATS_CACHE.lock().unwrap();
-            cache.insert(
-                addr.clone(),
-                (
-                    Instant::now() + Duration::from_secs(300),
-                    OrganizerStats {
-                        total_events: 2,
-                        total_tickets_sold: 100,
-                        average_event_rating: 4.5,
-                    },
-                ),
-            );
-        }
+    #[test]
+    fn test_validate_socials_accepts_known_string_keys() {
+        let v = serde_json::json!({ "twitter": "@agora", "website": "https://agora.dev" });
+        assert!(validate_socials(&v).is_ok());
+    }
 
-        let resp = get_organizer_stats(State(pool), Path(addr.clone())).await;
-        let http = resp.into_response();
-        let bytes = axum::body::to_bytes(http.into_body(), 1024 * 1024)
-            .await
-            .unwrap();
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert!(v["success"].as_bool().unwrap());
-        assert_eq!(v["data"]["total_events"].as_i64().unwrap(), 2);
-        assert_eq!(v["data"]["total_tickets_sold"].as_i64().unwrap(), 100);
-        assert!((v["data"]["average_event_rating"].as_f64().unwrap() - 4.5).abs() < 1e-6);
+    #[test]
+    fn test_validate_socials_allows_null_to_clear() {
+        assert!(validate_socials(&serde_json::Value::Null).is_ok());
+    }
+
+    #[test]
+    fn test_validate_socials_rejects_non_object() {
+        // Previously any JSON was accepted, including arrays and scalars.
+        assert!(validate_socials(&serde_json::json!(["twitter"])).is_err());
+        assert!(validate_socials(&serde_json::json!("twitter")).is_err());
+    }
+
+    #[test]
+    fn test_validate_socials_rejects_unknown_key() {
+        // A mistyped platform is reported rather than silently dropped.
+        let err = validate_socials(&serde_json::json!({ "twiter": "@agora" })).unwrap_err();
+        assert!(format!("{err:?}").contains("twiter"));
+    }
+
+    #[test]
+    fn test_validate_socials_rejects_non_string_value() {
+        assert!(validate_socials(&serde_json::json!({ "twitter": 42 })).is_err());
+        // Nested objects were the main thing the untyped Value permitted.
+        assert!(validate_socials(&serde_json::json!({ "twitter": { "url": "x" } })).is_err());
+    }
+
+    #[test]
+    fn test_validate_socials_rejects_overlong_value() {
+        let long = "a".repeat(MAX_SOCIAL_VALUE + 1);
+        assert!(validate_socials(&serde_json::json!({ "website": long })).is_err());
+    }
+
+    #[test]
+    fn test_organizer_stats_cache_key_is_namespaced() {
+        // #828: the previous cache-hit test seeded a process-local HashMap,
+        // which no longer exists. Verifying a Redis hit needs a live Redis and
+        // belongs in an integration test, so what stays unit-testable is the
+        // key: it must be namespaced and address-scoped, since invalidation on
+        // profile update deletes by exact key.
+        let key = organizer_stats_cache_key("GABC123");
+        assert_eq!(key, "organizer_stats:GABC123");
+        assert_ne!(key, organizer_stats_cache_key("GXYZ789"));
     }
 
     #[test]

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -139,7 +139,6 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
     };
 
     // Organizer profile routes (Issue #486)
-    // Routes that use Redis caching use ProfileState; stats route keeps PgPool.
     let profile_routes = Router::new()
         .route(
             "/",
@@ -151,12 +150,10 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/transactions", get(list_my_transactions))
         .route("/:address", get(get_profile_by_address))
         .route("/:address/events", get(list_events_by_organizer))
-        .with_state(profile_state)
-        .merge(
-            Router::new()
-                .route("/:address/stats", get(get_organizer_stats))
-                .with_state(pool.clone()),
-        );
+        // #828: stats now caches in Redis, so it uses ProfileState like the
+        // rest of the profile routes rather than a PgPool-only sub-router.
+        .route("/:address/stats", get(get_organizer_stats))
+        .with_state(profile_state);
 
     // Admin sub-router — every request is recorded in audit_logs and requires admin auth.
     let admin_auth_state = AdminAuthState {


### PR DESCRIPTION
Closes #828
Closes #877

Backend companion to #1100 (mobile). Scoped to `server/` so the two don't share a CI surface.

---

## #828 — organizer stats cache

`get_organizer_stats` kept results in a process-local `Lazy<Mutex<HashMap<String, (Instant, OrganizerStats)>>>` that was **never pruned**. Every distinct organizer address queried added an entry that stayed for the life of the process, so memory grew without bound on a long-running server.

Behind a load balancer it was also **wrong, not merely leaky**: each process held its own copy, so the invalidation already performed on profile update was invisible to every other process, and stale stats kept being served.

Moved to Redis under `organizer_stats:{address}` with the same 5-minute TTL — shared across instances, eviction handed to Redis.

**No new state plumbing was needed.** `ProfileState` already carried both the pool and the `RedisCache`; the stats route was simply the one profile route still wired to a `PgPool`-only sub-router. It now uses `ProfileState` like its neighbours.

Cache failures degrade rather than propagate: a read error falls through to the database instead of 500ing because Redis blinked, and a write error is logged and ignored — a miss on the next request is cheaper than failing a request that already has its answer.

Stats are invalidated at **all three** profile write paths, alongside the existing profile-cache invalidation. The stats derive from the same profile, so without that an updated profile keeps serving stats computed from the old one for up to five minutes.

**One test had to change.** The previous cache-hit test seeded the in-process HashMap directly and couldn't survive the move. Verifying a Redis hit needs a live Redis and belongs in an integration test, so it's replaced by a test of the key format — which is what invalidation actually depends on, since deletes are by exact key.

## #877 — socials validation

`socials` is typed `serde_json::Value`, so **any** JSON was accepted: nested objects, arrays, numbers, arbitrarily deep structures — in a column the UI expects to render as a flat set of links.

`validate_socials` is wired into both `upsert` and `patch`. The value must be a flat object whose keys are known platforms (twitter, instagram, website, linkedin, facebook, youtube, tiktok, discord, telegram, github) and whose values are strings under 200 characters. `null` is still accepted so the field can be cleared.

The issue offered two options — reject unknown keys, or strip them silently. **I chose reject:** an organizer who types `twiter` should be told, not have the value quietly discarded and be left wondering why their link never appeared.

Six tests: valid payloads, null, non-objects, unknown keys, non-string and nested values, and the length bound.

## Also

Drops the `once_cell` / `HashMap` / `Mutex` / `Instant` imports left orphaned by the cache change — they'd fail the build as unused.

## Verification

**Not compiled** — no Rust toolchain run in this checkout, so `cargo check`/`clippy`/`cargo test` are unexecuted. The route rewiring in `routes/mod.rs` and the `State<ProfileState>` extractor change are the two spots most worth a compile check.