### PR TITLE
fix: resolve issues #888, #875, #841, and #876

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -110,6 +110,26 @@ impl EventRegistry {
     ) -> Option<SeriesPass> {
         storage::get_holder_series_pass(&env, &holder, series_id)
     }
+
+    /// Check if a holder has a valid pass for a given series.
+    /// Returns true only if a pass exists, usage limit has not been reached, and the pass has not expired.
+    pub fn has_valid_series_pass(
+        env: Env,
+        holder: Address,
+        series_id: String,
+    ) -> bool {
+        if let Some(pass) = storage::get_holder_series_pass(&env, &holder, series_id) {
+            if pass.usage_limit > 0 && pass.usage_count >= pass.usage_limit {
+                return false;
+            }
+            if pass.expires_at > 0 && env.ledger().timestamp() >= pass.expires_at {
+                return false;
+            }
+            true
+        } else {
+            false
+        }
+    }
     /// Initializes the contract configuration. Can only be called once.
     /// Sets up initial admin with multi-sig configuration (threshold = 1 for single admin).
     /// The `usdc_token` address is automatically added to the payment token whitelist.

--- a/contract/contracts/event_registry/src/test_issue_fixes.rs
+++ b/contract/contracts/event_registry/src/test_issue_fixes.rs
@@ -459,3 +459,94 @@ fn test_set_resale_cap_bps_none_clears_cap() {
         .unwrap();
     assert_eq!(info.resale_cap_bps, None);
 }
+
+// ── Issue #888: has_valid_series_pass tests ─────────────────────────────────────
+
+#[test]
+fn test_has_valid_series_pass_returns_true_for_valid_pass() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let organizer = Address::generate(&env);
+    let series_id = String::from_str(&env, "series_valid");
+
+    let args = create_series_args(&env, "series_valid", &organizer);
+    client.create_series(&args);
+
+    let pass_id = String::from_str(&env, "pass_valid");
+    let holder = Address::generate(&env);
+    let usage_limit = 5u32;
+    let expires_at = env.ledger().timestamp() + 1000;
+
+    client.issue_series_pass(&pass_id, &series_id, &holder, &usage_limit, &expires_at);
+
+    assert!(client.has_valid_series_pass(&holder, &series_id));
+}
+
+#[test]
+fn test_has_valid_series_pass_returns_false_if_no_pass() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let holder = Address::generate(&env);
+    let series_id = String::from_str(&env, "non_existent_series");
+
+    assert!(!client.has_valid_series_pass(&holder, &series_id));
+}
+
+#[test]
+fn test_has_valid_series_pass_returns_false_if_usage_limit_exceeded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let organizer = Address::generate(&env);
+    let series_id = String::from_str(&env, "series_usage_test");
+
+    let args = create_series_args(&env, "series_usage_test", &organizer);
+    client.create_series(&args);
+
+    let pass_id = String::from_str(&env, "pass_usage");
+    let holder = Address::generate(&env);
+    let usage_limit = 1u32;
+    let expires_at = env.ledger().timestamp() + 1000;
+
+    client.issue_series_pass(&pass_id, &series_id, &holder, &usage_limit, &expires_at);
+    assert!(client.has_valid_series_pass(&holder, &series_id));
+
+    // Increment usage to reach the limit
+    client.increment_series_pass_usage(&pass_id);
+    assert!(!client.has_valid_series_pass(&holder, &series_id));
+}
+
+#[test]
+fn test_has_valid_series_pass_returns_false_if_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let organizer = Address::generate(&env);
+    let series_id = String::from_str(&env, "series_expire_test");
+
+    let args = create_series_args(&env, "series_expire_test", &organizer);
+    client.create_series(&args);
+
+    let pass_id = String::from_str(&env, "pass_expired");
+    let holder = Address::generate(&env);
+    let usage_limit = 10u32;
+    let expires_at = 100u64;
+
+    // Set ledger timestamp past expires_at
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: 500u64,
+        protocol_version: 20,
+        sequence_number: 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 10000,
+    });
+
+    client.issue_series_pass(&pass_id, &series_id, &holder, &usage_limit, &expires_at);
+
+    assert!(!client.has_valid_series_pass(&holder, &series_id));
+}

--- a/contract/contracts/pro_subscription/src/test.rs
+++ b/contract/contracts/pro_subscription/src/test.rs
@@ -653,3 +653,171 @@ fn test_cancel_subscription_unauthorized() {
 
     client.cancel_subscription(&organizer);
 }
+
+// ── Issue #876: Explicit Pro Subscription Test Suite ──────────────────────────
+
+#[test]
+fn test_issue_876_subscribe_success() {
+    let (env, client, _admin, _platform_wallet, usdc) = setup();
+    let organizer = Address::generate(&env);
+    let monthly_price = 1_000_000i128;
+    let months = 3u32;
+    let total_cost = monthly_price * (months as i128);
+
+    token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &total_cost);
+    token::Client::new(&env, &usdc).approve(&organizer, &client.address, &total_cost, &99999);
+
+    client.subscribe_pro(&organizer, &months);
+
+    let sub = client.get_subscription(&organizer).unwrap();
+    assert_eq!(sub.tier, SubscriptionTier::Pro);
+    assert!(sub.is_active);
+    assert_eq!(sub.amount_paid, total_cost);
+    assert_eq!(sub.expires_at, env.ledger().timestamp() + SECONDS_PER_MONTH * (months as u64));
+    assert!(client.is_pro_member(&organizer));
+}
+
+#[test]
+fn test_issue_876_renew_active_subscription() {
+    let (env, client, _admin, _platform_wallet, usdc) = setup();
+    let organizer = Address::generate(&env);
+    let monthly_price = 1_000_000i128;
+
+    token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &(monthly_price * 2));
+    token::Client::new(&env, &usdc).approve(&organizer, &client.address, &(monthly_price * 2), &99999);
+
+    client.subscribe_pro(&organizer, &1u32);
+    let initial_expiry = client.get_subscription_expiry(&organizer).unwrap();
+
+    client.renew_subscription(&organizer, &1u32);
+    let renewed_expiry = client.get_subscription_expiry(&organizer).unwrap();
+
+    assert_eq!(renewed_expiry, initial_expiry + SECONDS_PER_MONTH);
+}
+
+#[test]
+fn test_issue_876_renew_expired_subscription() {
+    let (env, client, _admin, _platform_wallet, usdc) = setup();
+    let organizer = Address::generate(&env);
+    let monthly_price = 1_000_000i128;
+
+    token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &(monthly_price * 2));
+    token::Client::new(&env, &usdc).approve(&organizer, &client.address, &(monthly_price * 2), &99999);
+
+    client.subscribe_pro(&organizer, &1u32);
+    let initial_sub = client.get_subscription(&organizer).unwrap();
+
+    // Advance time past initial expiry
+    env.ledger().set(LedgerInfo {
+        timestamp: initial_sub.expires_at + 1000,
+        protocol_version: 23,
+        sequence_number: 20,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 3110400,
+    });
+
+    client.renew_subscription(&organizer, &1u32);
+    let renewed_sub = client.get_subscription(&organizer).unwrap();
+
+    assert_eq!(renewed_sub.expires_at, env.ledger().timestamp() + SECONDS_PER_MONTH);
+    assert!(client.is_pro_member(&organizer));
+}
+
+#[test]
+fn test_issue_876_is_pro_member_active() {
+    let (env, client, _admin, _platform_wallet, usdc) = setup();
+    let organizer = Address::generate(&env);
+    let monthly_price = 1_000_000i128;
+
+    token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &monthly_price);
+    token::Client::new(&env, &usdc).approve(&organizer, &client.address, &monthly_price, &99999);
+
+    client.subscribe_pro(&organizer, &1u32);
+    assert!(client.is_pro_member(&organizer));
+}
+
+#[test]
+fn test_issue_876_is_pro_member_expired() {
+    let (env, client, _admin, _platform_wallet, usdc) = setup();
+    let organizer = Address::generate(&env);
+    let monthly_price = 1_000_000i128;
+
+    token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &monthly_price);
+    token::Client::new(&env, &usdc).approve(&organizer, &client.address, &monthly_price, &99999);
+
+    client.subscribe_pro(&organizer, &1u32);
+    let sub = client.get_subscription(&organizer).unwrap();
+
+    env.ledger().set(LedgerInfo {
+        timestamp: sub.expires_at + 1,
+        protocol_version: 23,
+        sequence_number: 30,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 3110400,
+    });
+
+    assert!(!client.is_pro_member(&organizer));
+}
+
+#[test]
+fn test_issue_876_admin_cancel_subscription() {
+    let (env, client, _admin, _platform_wallet, usdc) = setup();
+    let organizer = Address::generate(&env);
+    let monthly_price = 1_000_000i128;
+
+    token::StellarAssetClient::new(&env, &usdc).mint(&organizer, &monthly_price);
+    token::Client::new(&env, &usdc).approve(&organizer, &client.address, &monthly_price, &99999);
+
+    client.subscribe_pro(&organizer, &1u32);
+    assert!(client.is_pro_member(&organizer));
+
+    client.cancel_subscription(&organizer);
+    assert!(!client.is_pro_member(&organizer));
+
+    let sub = client.get_subscription(&organizer).unwrap();
+    assert!(!sub.is_active);
+}
+
+#[test]
+fn test_issue_876_admin_update_price() {
+    let (_env, client, _admin, _platform_wallet, _usdc) = setup();
+    let new_price = 5_000_000i128;
+
+    client.update_pro_price(&new_price);
+    assert_eq!(client.get_pro_monthly_price(), new_price);
+}
+
+#[test]
+fn test_issue_876_admin_update_admin() {
+    let (env, client, _admin, _platform_wallet, _usdc) = setup();
+    let new_admin = Address::generate(&env);
+
+    client.update_admin(&new_admin);
+    assert_eq!(client.get_admin(), Some(new_admin));
+}
+
+#[test]
+fn test_issue_876_admin_update_platform_wallet() {
+    let (env, client, _admin, _platform_wallet, _usdc) = setup();
+    let new_wallet = Address::generate(&env);
+
+    client.update_platform_wallet(&new_wallet);
+    assert_eq!(client.get_platform_wallet(), Some(new_wallet));
+}
+
+#[test]
+fn test_issue_876_admin_update_payment_token() {
+    let (env, client, _admin, _platform_wallet, _usdc) = setup();
+    let new_token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    client.update_payment_token(&new_token);
+    assert_eq!(client.get_payment_token(), Some(new_token));
+}

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -94,6 +94,12 @@ pub struct Config {
     /// Optional static bearer token required to access admin APIs.
     /// Set via `ADMIN_TOKEN` environment variable.
     pub admin_token: Option<String>,
+
+    /// Rate limit threshold for auth/nonce endpoint in requests per minute (default: 10).
+    pub auth_rate_limit_per_minute: usize,
+
+    /// Allowed MIME types for uploaded files.
+    pub allowed_upload_mime_types: Vec<String>,
 }
 
 /// A collection of configuration errors found during [`Config::validate`].
@@ -156,6 +162,23 @@ impl Config {
         let monitoring_token = env::var("MONITORING_TOKEN").ok();
         let admin_token = env::var("ADMIN_TOKEN").ok();
 
+        let auth_rate_limit_per_minute = env::var("AUTH_RATE_LIMIT_PER_MINUTE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10);
+
+        let allowed_upload_mime_types = env::var("ALLOWED_UPLOAD_MIME_TYPES")
+            .or_else(|_| env::var("ALLOWED_MIME_TYPES"))
+            .map(|s| s.split(',').map(|m| m.trim().to_string()).collect())
+            .unwrap_or_else(|_| {
+                vec![
+                    "image/jpeg".to_string(),
+                    "image/png".to_string(),
+                    "image/webp".to_string(),
+                    "image/gif".to_string(),
+                ]
+            });
+
         Ok(Self {
             database_url,
             port,
@@ -174,6 +197,8 @@ impl Config {
             jwt_secret,
             monitoring_token,
             admin_token,
+            auth_rate_limit_per_minute,
+            allowed_upload_mime_types,
         })
     }
 

--- a/server/src/handlers/upload.rs
+++ b/server/src/handlers/upload.rs
@@ -15,10 +15,25 @@ struct UploadResponse {
     url: String,
 }
 
+/// Inspect first few bytes to detect image MIME type (JPEG, PNG, GIF, WebP).
+pub fn detect_mime_type(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.len() >= 3 && bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF {
+        Some("image/jpeg")
+    } else if bytes.len() >= 8 && bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("image/png")
+    } else if bytes.len() >= 6 && (bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")) {
+        Some("image/gif")
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else {
+        None
+    }
+}
+
 /// POST /upload/image
 ///
 /// Accepts a `multipart/form-data` request with a single `file` field.
-/// Validates content-type (JPEG/PNG) and size (≤ 5 MB), then uploads to
+/// Validates file magic bytes (JPEG/PNG/WebP/GIF) and size (≤ 5 MB), then uploads to
 /// S3/R2 under a UUID-based key and returns the public URL.
 pub async fn upload_image(
     Extension(config): Extension<Config>,
@@ -35,18 +50,6 @@ pub async fn upload_image(
         }
     };
 
-    // Validate content-type
-    let content_type = field.content_type().unwrap_or("").to_string();
-
-    let ext = match content_type.as_str() {
-        "image/jpeg" => "jpg",
-        "image/png" => "png",
-        _ => {
-            return AppError::ValidationError("Only JPEG and PNG images are accepted".to_string())
-                .into_response()
-        }
-    };
-
     // Read bytes with size cap
     let data = match field.bytes().await {
         Ok(b) => b,
@@ -59,6 +62,38 @@ pub async fn upload_image(
         return AppError::ValidationError("File exceeds the 5 MB size limit".to_string())
             .into_response();
     }
+
+    // Inspect magic bytes to detect actual MIME type
+    let detected_mime = match detect_mime_type(&data) {
+        Some(mime) => mime,
+        None => {
+            return AppError::ValidationError(
+                "Invalid or unsupported file format. Magic bytes do not match safe image types."
+                    .to_string(),
+            )
+            .into_response();
+        }
+    };
+
+    // Validate against allowed MIME types configuration
+    if !config
+        .allowed_upload_mime_types
+        .iter()
+        .any(|m| m.eq_ignore_ascii_case(detected_mime))
+    {
+        return AppError::ValidationError(format!(
+            "MIME type '{detected_mime}' is not allowed"
+        ))
+        .into_response();
+    }
+
+    let ext = match detected_mime {
+        "image/jpeg" => "jpg",
+        "image/png" => "png",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        _ => "bin",
+    };
 
     // Build S3 client
     let creds = Credentials::new(
@@ -87,7 +122,7 @@ pub async fn upload_image(
         .put_object()
         .bucket(&config.s3_bucket)
         .key(&key)
-        .content_type(&content_type)
+        .content_type(detected_mime)
         .body(ByteStream::from(data))
         .send()
         .await;
@@ -99,4 +134,45 @@ pub async fn upload_image(
 
     let url = format!("{}/{}", config.s3_public_url.trim_end_matches('/'), key);
     success(UploadResponse { url }, "Image uploaded successfully").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_jpeg_magic_bytes() {
+        let bytes = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        assert_eq!(detect_mime_type(&bytes), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn test_detect_png_magic_bytes() {
+        let bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00];
+        assert_eq!(detect_mime_type(&bytes), Some("image/png"));
+    }
+
+    #[test]
+    fn test_detect_gif_magic_bytes() {
+        let bytes = b"GIF89a\x01\x00\x01\x00";
+        assert_eq!(detect_mime_type(bytes), Some("image/gif"));
+    }
+
+    #[test]
+    fn test_detect_webp_magic_bytes() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&[0, 0, 0, 0]);
+        bytes.extend_from_slice(b"WEBP");
+        assert_eq!(detect_mime_type(&bytes), Some("image/webp"));
+    }
+
+    #[test]
+    fn test_reject_php_script_or_svg() {
+        let php_script = b"<?php echo 'malicious'; ?>";
+        assert_eq!(detect_mime_type(php_script), None);
+
+        let svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script></svg>";
+        assert_eq!(detect_mime_type(svg), None);
+    }
 }

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -126,12 +126,16 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
     let listener_config = ListenerConfig::from_env();
     spawn_listener(pool.clone(), Some(redis.clone()), listener_config);
 
-    // Auth routes — challenge-response JWT flow (Issue #484)
+    // Auth routes — challenge-response JWT flow (Issue #484, #875)
     let auth_routes = Router::new()
         .route("/nonce", post(request_nonce))
         .route("/verify", post(verify_signature))
         .route("/logout", post(logout))
-        .with_state(pool.clone());
+        .with_state(pool.clone())
+        .layer(RateLimitLayer::new(
+            config.auth_rate_limit_per_minute,
+            Duration::from_secs(60),
+        ));
 
     let profile_state = ProfileState {
         pool: pool.clone(),


### PR DESCRIPTION
- Issue #888 (Contract: predicate function for valid series pass):
  Added has_valid_series_pass(env: Env, holder: Address, series_id: String) -> bool to event_registry contract in lib.rs. It evaluates whether a series pass exists for the holder, has not exceeded its usage limit (usage_count < usage_limit), and has not expired (ledger.timestamp < expires_at). Added unit tests in test_issue_fixes.rs covering valid pass, non-existent pass, limit exceeded, and expired pass scenarios.

- Issue #875 (Backend: rate limiting for POST /api/v1/auth/nonce): Added per-IP sliding window rate limiting to auth routes in server/src/routes/mod.rs using RateLimitLayer. Added AUTH_RATE_LIMIT_PER_MINUTE env configuration in server/src/config/mod.rs (defaulting to 10 req/min). Requests exceeding the limit receive HTTP 429 and Retry-After header.

- Issue #841 (Backend: magic byte MIME type validation for uploads): Implemented detect_mime_type in server/src/handlers/upload.rs to inspect raw file header magic bytes for JPEG, PNG, GIF, and WebP. Added validation against ALLOWED_UPLOAD_MIME_TYPES config. Rejected unsafe or fake files (e.g., PHP scripts or SVG files) with HTTP 400. Added unit tests verifying magic byte detection.

- Issue #876 (Contract: pro_subscription test coverage): Added 10 unit tests to contract/contracts/pro_subscription/src/test.rs covering subscribing, renewing active and expired subscriptions, checking status, and admin management functions (updating price, admin address, platform wallet, and payment token).

Closes #888
Closes #875
Closes #841
Closes #876