### PR TITLE
Fix multiple bugs: event validation, ticket race condition, private e…

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -609,8 +609,9 @@ impl EventRegistry {
     }
 
     /// Retrieves all event IDs for an organizer.
-    pub fn get_organizer_events(env: Env, organizer: Address) -> Vec<String> {
-        storage::get_organizer_events(&env, &organizer)
+    /// If the caller is not the organizer, private events are filtered out (Issue #880).
+    pub fn get_organizer_events(env: Env, organizer: Address, caller: Address) -> Vec<String> {
+        storage::get_organizer_events(&env, &organizer, &caller)
     }
 
     /// Updates the platform fee percentage. Only callable by the administrator.
@@ -2220,7 +2221,8 @@ fn suspend_organizer_events(
     env: Env,
     organizer_address: Address,
 ) -> Result<(), EventRegistryError> {
-    let organizer_events = storage::get_organizer_events(&env, &organizer_address);
+    // Pass organizer as both organizer and caller since this is an internal operation
+    let organizer_events = storage::get_organizer_events(&env, &organizer_address, &organizer_address);
     let mut suspended_count = 0u32;
 
     for event_id in organizer_events.iter() {

--- a/contract/contracts/event_registry/src/storage.rs
+++ b/contract/contracts/event_registry/src/storage.rs
@@ -634,10 +634,12 @@ pub fn has_organizer_receipt(env: &Env, organizer: &Address, event_id: String) -
 }
 
 /// Retrieves all event_ids associated with an organizer by iterating through shards.
+/// If the caller is not the organizer, private events are filtered out (Issue #880).
 /// NOTE: For very large lists, this may exceed gas limits. Use shard-based iteration for scale.
-pub fn get_organizer_events(env: &Env, organizer: &Address) -> Vec<String> {
+pub fn get_organizer_events(env: &Env, organizer: &Address, caller: &Address) -> Vec<String> {
     let count = get_organizer_event_count(env, organizer);
     let mut all_events = vec![env];
+    let is_owner = organizer == caller;
 
     if count == 0 {
         return all_events;
@@ -651,7 +653,16 @@ pub fn get_organizer_events(env: &Env, organizer: &Address) -> Vec<String> {
             .get(&DataKey::OrganizerEventShard(organizer.clone(), i))
             .unwrap_or_else(|| vec![env]);
         for id in shard.iter() {
-            all_events.push_back(id);
+            // Filter out private events if caller is not the organizer
+            if is_owner {
+                all_events.push_back(id);
+            } else {
+                if let Some(event_info) = get_event(env, id.clone()) {
+                    if !event_info.is_private {
+                        all_events.push_back(id);
+                    }
+                }
+            }
         }
     }
     all_events

--- a/contract/contracts/event_registry/src/test.rs
+++ b/contract/contracts/event_registry/src/test.rs
@@ -397,7 +397,7 @@ fn test_organizer_events_list() {
     client.store_event(&event_1);
     client.store_event(&event_2);
 
-    let organizer_events = client.get_organizer_events(&organizer);
+    let organizer_events = client.get_organizer_events(&organizer, &organizer);
     assert_eq!(organizer_events.len(), 2);
     assert_eq!(organizer_events.get(0).unwrap(), event_1.event_id);
     assert_eq!(organizer_events.get(1).unwrap(), event_2.event_id);
@@ -472,7 +472,7 @@ fn test_organizer_events_shard_boundary() {
         client.store_event(&event_info);
     }
 
-    let organizer_events = client.get_organizer_events(&organizer);
+    let organizer_events = client.get_organizer_events(&organizer, &organizer);
     assert_eq!(organizer_events.len(), 51);
     for i in 0..51 {
         assert_eq!(organizer_events.get(i).unwrap(), String::from_str(&env, format!("event_{}", i).as_str()));
@@ -961,7 +961,7 @@ fn test_complete_event_lifecycle() {
     assert_eq!(payment_info.payment_address, payment_addr);
     assert_eq!(payment_info.platform_fee_percent, 600);
 
-    let org_events = client.get_organizer_events(&organizer);
+    let org_events = client.get_organizer_events(&organizer, &organizer);
     assert_eq!(org_events.len(), 1);
     assert!(org_events.contains(&event_id));
 
@@ -4638,7 +4638,114 @@ fn test_add_tier_exceeds_max_supply() {
         max_per_user: 0,
     };
 
-    let res = client.try_add_tier(&event_id, &new_tier_id, &overflow_tier);
-    assert_eq!(res, Err(Ok(EventRegistryError::TierLimitExceeds)));
+    let result = client.try_add_tier(&event_id, &new_tier_id, &overflow_tier);
+    assert_eq!(result, Err(Ok(EventRegistryError::TierLimitExceeds)));
 }
 
+#[test]
+fn test_get_organizer_events_filters_private_for_third_party() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let organizer = Address::generate(&env);
+    let third_party = Address::generate(&env);
+    let payment_address = Address::generate(&env);
+    let contract_id = env.register(EventRegistry, ());
+    let client = EventRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    client.initialize(&admin, &platform_wallet, &500, &usdc_token);
+
+    // Create a public event
+    let public_event_id = String::from_str(&env, "public_event");
+    let public_event = EventInfo {
+        event_id: public_event_id.clone(),
+        name: String::from_str(&env, "Public Event"),
+        organizer_address: organizer.clone(),
+        payment_address: payment_address.clone(),
+        platform_fee_percent: 500,
+        is_active: true,
+        status: EventStatus::Active,
+        created_at: env.ledger().timestamp(),
+        metadata_cid: String::from_str(&env, "ipfs://public"),
+        max_supply: 100,
+        current_supply: 0,
+        milestone_plan: None,
+        tiers: Map::new(&env),
+        refund_deadline: 0,
+        restocking_fee: None,
+        resale_cap_bps: None,
+        is_postponed: false,
+        grace_period_end: 0,
+        min_sales_target: 0,
+        target_deadline: 0,
+        goal_met: false,
+        custom_fee_bps: None,
+        banner_cid: None,
+        tags: None,
+        category_ids: soroban_sdk::vec![&env],
+        start_time: 0,
+        is_private: false,
+        end_time: 0,
+        transfer_lock_duration: 0,
+        accepted_tokens: soroban_sdk::vec![&env],
+        use_global_whitelist: true,
+        feedback_cid: None,
+        cancellation_reason: None,
+        referral_rate_bps: 0,
+    };
+    client.store_event(&public_event);
+
+    // Create a private event
+    let private_event_id = String::from_str(&env, "private_event");
+    let private_event = EventInfo {
+        event_id: private_event_id.clone(),
+        name: String::from_str(&env, "Private Event"),
+        organizer_address: organizer.clone(),
+        payment_address: payment_address.clone(),
+        platform_fee_percent: 500,
+        is_active: true,
+        status: EventStatus::Active,
+        created_at: env.ledger().timestamp(),
+        metadata_cid: String::from_str(&env, "ipfs://private"),
+        max_supply: 100,
+        current_supply: 0,
+        milestone_plan: None,
+        tiers: Map::new(&env),
+        refund_deadline: 0,
+        restocking_fee: None,
+        resale_cap_bps: None,
+        is_postponed: false,
+        grace_period_end: 0,
+        min_sales_target: 0,
+        target_deadline: 0,
+        goal_met: false,
+        custom_fee_bps: None,
+        banner_cid: None,
+        tags: None,
+        category_ids: soroban_sdk::vec![&env],
+        start_time: 0,
+        is_private: true,
+        end_time: 0,
+        transfer_lock_duration: 0,
+        accepted_tokens: soroban_sdk::vec![&env],
+        use_global_whitelist: true,
+        feedback_cid: None,
+        cancellation_reason: None,
+        referral_rate_bps: 0,
+    };
+    client.store_event(&private_event);
+
+    // Organizer sees both events
+    let organizer_events = client.get_organizer_events(&organizer, &organizer);
+    assert_eq!(organizer_events.len(), 2);
+    assert!(organizer_events.contains(&public_event_id));
+    assert!(organizer_events.contains(&private_event_id));
+
+    // Third party sees only public events
+    let third_party_events = client.get_organizer_events(&organizer, &third_party);
+    assert_eq!(third_party_events.len(), 1);
+    assert!(third_party_events.contains(&public_event_id));
+    assert!(!third_party_events.contains(&private_event_id));
+}

--- a/server/migrations/20260728000001_add_ticket_tiers_check_constraint.sql
+++ b/server/migrations/20260728000001_add_ticket_tiers_check_constraint.sql
@@ -1,0 +1,5 @@
+-- Add CHECK constraint to prevent negative available_quantity (Issue #834)
+-- This prevents race conditions from causing negative inventory
+ALTER TABLE ticket_tiers 
+    ADD CONSTRAINT check_available_quantity_non_negative 
+    CHECK (available_quantity >= 0);

--- a/server/migrations/20260728000002_add_tickets_unique_indexes.sql
+++ b/server/migrations/20260728000002_add_tickets_unique_indexes.sql
@@ -1,0 +1,8 @@
+-- Add explicit unique indexes for tickets table (Issue #835)
+-- These indexes ensure efficient upserts and joins for on-chain sync
+
+-- Unique index on stellar_id for efficient conflict detection in upserts
+CREATE UNIQUE INDEX IF NOT EXISTS tickets_stellar_id_idx ON tickets (stellar_id);
+
+-- Index on event_id for efficient joins and filters
+CREATE INDEX IF NOT EXISTS tickets_event_id_idx ON tickets (event_id);

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -981,6 +981,73 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_event_timestamps_end_time_before_start_time() {
+        let start = Utc::now();
+        let end = start - chrono::Duration::hours(1); // end before start
+        let result = validate_event_timestamps(start, Some(end));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("end_time must be strictly after start_time"));
+    }
+
+    #[test]
+    fn test_validate_event_timestamps_end_time_equals_start_time() {
+        let start = Utc::now();
+        let end = start; // end equals start
+        let result = validate_event_timestamps(start, Some(end));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("end_time must be strictly after start_time"));
+    }
+
+    #[test]
+    fn test_validate_event_timestamps_start_time_in_past() {
+        let start = Utc::now() - chrono::Duration::minutes(10); // 10 minutes ago
+        let end = Some(start + chrono::Duration::hours(2));
+        let result = validate_event_timestamps(start, end);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("start_time must be in the future"));
+    }
+
+    #[test]
+    fn test_validate_event_timestamps_start_time_in_grace_period() {
+        let start = Utc::now() - chrono::Duration::seconds(200); // 3.3 minutes ago (within grace period)
+        let end = Some(start + chrono::Duration::hours(2));
+        let result = validate_event_timestamps(start, end);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_event_timestamps_valid_future_timestamps() {
+        let start = Utc::now() + chrono::Duration::hours(1);
+        let end = Some(start + chrono::Duration::hours(3));
+        let result = validate_event_timestamps(start, end);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_event_timestamps_no_end_time() {
+        let start = Utc::now() + chrono::Duration::hours(1);
+        let result = validate_event_timestamps(start, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_event_timestamps_duration_exceeds_max() {
+        let start = Utc::now() + chrono::Duration::hours(1);
+        let end = Some(start + chrono::Duration::days(31)); // 31 days exceeds max
+        let result = validate_event_timestamps(start, end);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("event duration must not exceed"));
+    }
+
+    #[test]
+    fn test_validate_event_timestamps_duration_at_max() {
+        let start = Utc::now() + chrono::Duration::hours(1);
+        let end = Some(start + chrono::Duration::days(30)); // exactly 30 days
+        let result = validate_event_timestamps(start, end);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_ratings_summary_average_computed() {
         // 1×4 + 1×5 = 9 / 2 = 4.5
         let rows: Vec<(i16, i64)> = vec![(4, 1), (5, 1)];
@@ -1870,6 +1937,13 @@ fn is_valid_email(email: &str) -> bool {
 
 const MAX_LOCATION_LENGTH: usize = 500;
 
+/// Maximum allowed event duration in days (30 days).
+const MAX_EVENT_DURATION_DAYS: i64 = 30;
+
+/// Grace period in seconds for start_time validation (5 minutes).
+/// Allows organizers to create events that start slightly in the past.
+const START_TIME_GRACE_PERIOD_SECONDS: i64 = 300;
+
 fn validate_event_location(location: &str) -> Result<(), AppError> {
     if location.trim().is_empty() {
         return Err(AppError::ValidationError(
@@ -1881,6 +1955,42 @@ fn validate_event_location(location: &str) -> Result<(), AppError> {
             "location must be at most {MAX_LOCATION_LENGTH} characters"
         )));
     }
+    Ok(())
+}
+
+/// Validates event timestamps for create/update requests.
+/// Ensures start_time is not too far in the past, end_time > start_time (if provided),
+/// and event duration does not exceed the maximum allowed.
+fn validate_event_timestamps(start_time: DateTime<Utc>, end_time: Option<DateTime<Utc>>) -> Result<(), AppError> {
+    let now = Utc::now();
+    
+    // Check that start_time is not too far in the past (with grace period)
+    let grace_period = chrono::Duration::seconds(START_TIME_GRACE_PERIOD_SECONDS);
+    if start_time + grace_period < now {
+        return Err(AppError::ValidationError(
+            "start_time must be in the future or within the grace period".to_string(),
+        ));
+    }
+    
+    // If end_time is provided, validate it
+    if let Some(end) = end_time {
+        // end_time must be strictly after start_time
+        if end <= start_time {
+            return Err(AppError::ValidationError(
+                "end_time must be strictly after start_time".to_string(),
+            ));
+        }
+        
+        // Check event duration does not exceed maximum
+        let max_duration = chrono::Duration::days(MAX_EVENT_DURATION_DAYS);
+        if end - start_time > max_duration {
+            return Err(AppError::ValidationError(format!(
+                "event duration must not exceed {} days",
+                MAX_EVENT_DURATION_DAYS
+            )));
+        }
+    }
+    
     Ok(())
 }
 
@@ -1914,6 +2024,11 @@ pub async fn create_event(
 
     if let Err(message) = validate_event_title(&payload.title) {
         return AppError::ValidationError(message).into_response();
+    }
+
+    // Validate event timestamps
+    if let Err(e) = validate_event_timestamps(payload.start_time, payload.end_time) {
+        return e.into_response();
     }
 
     let event = match sqlx::query_as::<_, Event>(


### PR DESCRIPTION
…vents, and indexes

- #833: Add validation for event timestamps in create_event handler
  - Validate end_time > start_time
  - Validate start_time is not too far in past (5-min grace period)
  - Validate event duration does not exceed 30 days
  - Add unit tests for all validation cases

- #834: Add CHECK constraint to prevent negative available_quantity
  - Add database migration with CHECK (available_quantity >= 0)
  - Prevents race conditions from causing negative inventory
  - Smart contract already handles atomic decrement with underflow protection

- #835: Add database indexes for efficient ticket operations
  - Add unique index on tickets.stellar_id for efficient upsert conflict detection
  - Add index on tickets.event_id for joins and filters
  - Improves performance of on-chain sync operations

- #880: Add authorization check to get_organizer_events
  - Modify get_organizer_events to accept caller parameter
  - Filter out private events when caller is not the organizer
  - Prevents third parties from enumerating private events
  - Add test for third-party access control

Closes #833, 
Closes #834, 
Closes #835, 
Closes #880