### PR TITLE
feat: wallet experience — ticket aggregation, QR payloads, wallet pag…

### DIFF
--- a/apps/web/app/api/v1/profile/tickets/route.ts
+++ b/apps/web/app/api/v1/profile/tickets/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthFromRequest } from "@/lib/auth";
+import { withErrorHandler } from "@/lib/api-handler";
+import { throwApiError } from "@/lib/api-errors";
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+/**
+ * GET /api/v1/profile/tickets
+ *
+ * Proxies the request to the Rust backend's wallet ticket aggregation
+ * endpoint and returns the grouped upcoming / past ticket collections.
+ *
+ * Issue #1122
+ */
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const auth = getAuthFromRequest(request);
+  if (!auth?.sub) {
+    throwApiError("Unauthorized", 401);
+  }
+
+  const backendRes = await fetch(`${BACKEND_URL}/api/v1/profile/tickets`, {
+    headers: {
+      Authorization: request.headers.get("Authorization") ?? "",
+      "Content-Type": "application/json",
+      Cookie: request.headers.get("Cookie") ?? "",
+    },
+    cache: "no-store",
+  });
+
+  if (!backendRes.ok) {
+    const text = await backendRes.text().catch(() => "");
+    throwApiError(text || "Failed to fetch wallet tickets", backendRes.status);
+  }
+
+  const data = await backendRes.json();
+  return NextResponse.json(data);
+});

--- a/apps/web/app/wallet/layout.tsx
+++ b/apps/web/app/wallet/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "My Wallet · Agora",
+  description: "View your upcoming and past event tickets in one place.",
+};
+
+export default function WalletLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/apps/web/app/wallet/page.tsx
+++ b/apps/web/app/wallet/page.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { Suspense } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Navbar } from "@/components/layout/navbar";
+import { Footer } from "@/components/layout/footer";
+import { TicketCard } from "@/components/wallet/TicketCard";
+import { EventCardSkeleton } from "@/components/events/event-card-skeleton";
+import { useWalletTickets } from "@/hooks/useWalletTickets";
+import { useAuth } from "@/hooks/useAuth";
+import type { WalletTicket } from "@/hooks/useWalletTickets";
+
+// ---------------------------------------------------------------------------
+// Skeletons
+// ---------------------------------------------------------------------------
+
+function TicketCardSkeleton() {
+  return (
+    <div className="flex items-stretch gap-4 rounded-xl border border-border-warm bg-white p-4 shadow-[-4px_4px_0_rgba(0,0,0,0.08)] animate-pulse">
+      <div className="flex-shrink-0 w-20 h-20 sm:w-24 sm:h-24 rounded-lg bg-surface" />
+      <div className="flex-1 min-w-0 flex flex-col justify-between gap-2">
+        <div className="space-y-2">
+          <div className="h-4 bg-surface rounded w-3/4" />
+          <div className="h-3 bg-surface rounded w-1/2" />
+          <div className="h-3 bg-surface rounded w-2/5" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-5 w-16 bg-surface rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionSkeleton() {
+  return (
+    <div className="space-y-4">
+      <TicketCardSkeleton />
+      <TicketCardSkeleton />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyTickets({
+  heading,
+  subtext,
+}: {
+  heading: string;
+  subtext: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-14 px-6 text-center">
+      <div className="w-16 h-16 rounded-full bg-surface flex items-center justify-center mb-4">
+        <Image
+          src="/icons/ticket.svg"
+          width={28}
+          height={28}
+          alt="Ticket"
+          className="opacity-60"
+        />
+      </div>
+      <h3 className="font-semibold text-ink-soft mb-1">{heading}</h3>
+      <p className="text-sm text-muted-text max-w-xs mb-5">{subtext}</p>
+      <Link
+        href="/discover"
+        className="inline-flex items-center gap-2 bg-accent text-ink-soft text-sm font-semibold px-5 py-2.5 rounded-full hover:bg-accent-hover transition-colors"
+      >
+        Discover Events
+      </Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section component
+// ---------------------------------------------------------------------------
+
+function TicketSection({
+  title,
+  subtitle,
+  tickets,
+  isLoading,
+  emptyHeading,
+  emptySubtext,
+}: {
+  title: string;
+  subtitle: string;
+  tickets: WalletTicket[];
+  isLoading: boolean;
+  emptyHeading: string;
+  emptySubtext: string;
+}) {
+  return (
+    <section className="bg-white rounded-2xl border border-border-warm shadow-sm overflow-hidden">
+      {/* Header */}
+      <div className="px-6 pt-6 pb-4 border-b border-border-warm">
+        <h2 className="text-lg font-semibold text-ink-soft">{title}</h2>
+        <p className="text-sm text-muted-text mt-0.5">{subtitle}</p>
+      </div>
+
+      {/* Body */}
+      <div className="p-6">
+        {isLoading ? (
+          <SectionSkeleton />
+        ) : tickets.length === 0 ? (
+          <EmptyTickets heading={emptyHeading} subtext={emptySubtext} />
+        ) : (
+          <ul className="space-y-4" aria-label={title}>
+            {tickets.map((ticket) => (
+              <li key={ticket.id}>
+                <TicketCard
+                  id={ticket.id}
+                  status={ticket.status}
+                  ticketType={ticket.ticket_tier_name ?? undefined}
+                  price={
+                    ticket.ticket_price !== null
+                      ? ticket.ticket_price === "0.00" ||
+                        ticket.ticket_price === "0"
+                        ? "Free"
+                        : ticket.ticket_price
+                      : undefined
+                  }
+                  event={{
+                    id: ticket.event_id ?? undefined,
+                    title: ticket.event_title ?? "Unknown Event",
+                    startTime: ticket.event_start_time ?? undefined,
+                    location: ticket.event_location ?? undefined,
+                    imageUrl: ticket.event_image_url ?? undefined,
+                  }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Wallet content (requires auth context)
+// ---------------------------------------------------------------------------
+
+function WalletContent() {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const { upcoming, past, isLoading: ticketsLoading } = useWalletTickets();
+
+  const isLoading = authLoading || ticketsLoading;
+
+  // Unauthenticated state
+  if (!authLoading && !isAuthenticated) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center py-24 px-4 text-center">
+        <div className="w-20 h-20 rounded-full bg-surface flex items-center justify-center mb-6">
+          <Image
+            src="/icons/ticket.svg"
+            width={36}
+            height={36}
+            alt="Wallet"
+            className="opacity-60"
+          />
+        </div>
+        <h2 className="text-xl font-bold text-ink-soft mb-2">
+          Sign in to view your tickets
+        </h2>
+        <p className="text-muted-text text-sm max-w-sm mb-6">
+          Connect your wallet to see your upcoming events and past tickets.
+        </p>
+        <Link
+          href="/auth"
+          className="inline-flex items-center gap-2 bg-accent text-ink-soft text-sm font-semibold px-6 py-3 rounded-full hover:bg-accent-hover transition-colors"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 w-full max-w-3xl mx-auto px-4 py-10 space-y-6">
+      {/* Page heading */}
+      <header>
+        <h1 className="text-2xl font-bold text-ink-soft">My Wallet</h1>
+        {user?.displayName && (
+          <p className="text-sm text-muted-text mt-1">
+            Welcome back,{" "}
+            <span className="font-medium text-ink-soft">{user.displayName}</span>
+          </p>
+        )}
+      </header>
+
+      {/* Upcoming tickets */}
+      <TicketSection
+        title="Upcoming Tickets"
+        subtitle="Events you're attending soon"
+        tickets={upcoming}
+        isLoading={isLoading}
+        emptyHeading="No upcoming tickets"
+        emptySubtext="You don't have any upcoming events. Discover what's on near you."
+      />
+
+      {/* Past events */}
+      <TicketSection
+        title="Past Events"
+        subtitle="Events you've already attended"
+        tickets={past}
+        isLoading={isLoading}
+        emptyHeading="No past events"
+        emptySubtext="Tickets for events you've attended will appear here."
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+/**
+ * /wallet
+ *
+ * Main attendee dashboard for viewing upcoming and past tickets.
+ * Issue #1123
+ */
+export default function WalletPage() {
+  return (
+    <main className="flex flex-col min-h-screen bg-base">
+      <Navbar />
+      <Suspense>
+        <WalletContent />
+      </Suspense>
+      <Footer />
+    </main>
+  );
+}

--- a/apps/web/components/layout/navbar/user-nav.tsx
+++ b/apps/web/components/layout/navbar/user-nav.tsx
@@ -20,6 +20,12 @@ const USER_NAV_ITEMS: NavItem[] = [
     isActive: (p) => p === "/discover" || p.startsWith("/events"),
   },
   {
+    href: "/wallet",
+    icon: "/icons/ticket.svg",
+    text: "My Wallet",
+    isActive: (p) => p === "/wallet",
+  },
+  {
     href: "/organizers",
     icon: "/icons/user-group.svg",
     text: "Organizers",

--- a/apps/web/components/wallet/TicketCard.tsx
+++ b/apps/web/components/wallet/TicketCard.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import Image from "next/image";
+import { LazyImage } from "@/components/ui/LazyImage";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Status values that a ticket can carry. */
+export type TicketStatus = "active" | "used" | "cancelled" | string;
+
+export interface TicketCardProps {
+  /** Unique ticket identifier. */
+  id: string;
+  /** Event the ticket belongs to. */
+  event: {
+    id?: string;
+    title: string;
+    /** ISO date-time string for the event start. */
+    startTime?: string;
+    location?: string;
+    imageUrl?: string;
+  };
+  /** Name of the ticket tier, e.g. "General Admission" or "VIP". */
+  ticketType?: string;
+  /** Lifecycle status of the ticket. */
+  status: TicketStatus;
+  /** Optional price label, e.g. "25.00" or "Free". */
+  price?: string;
+  /** Called when the user taps/clicks the card. */
+  onClick?: () => void;
+  /** Additional Tailwind classes applied to the outer wrapper. */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; className: string }
+> = {
+  active: {
+    label: "Active",
+    className: "bg-accent text-ink-soft",
+  },
+  used: {
+    label: "Used",
+    className: "bg-surface text-muted-text",
+  },
+  cancelled: {
+    label: "Cancelled",
+    className: "bg-error/10 text-error",
+  },
+};
+
+function getStatusConfig(status: TicketStatus) {
+  return (
+    STATUS_CONFIG[status] ?? {
+      label: status.charAt(0).toUpperCase() + status.slice(1),
+      className: "bg-surface text-muted-text",
+    }
+  );
+}
+
+function formatEventDate(iso?: string): string {
+  if (!iso) return "";
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * TicketCard
+ *
+ * Displays a single ticket's summary — event image, title, date, venue, ticket
+ * type, and status badge. Designed to be reused across the Wallet dashboard and
+ * anywhere else tickets need to be listed.
+ *
+ * @example
+ * ```tsx
+ * <TicketCard
+ *   id="abc-123"
+ *   event={{ title: "Stellar Summit", startTime: "2026-09-01T10:00:00Z", location: "San Francisco" }}
+ *   ticketType="General Admission"
+ *   status="active"
+ * />
+ * ```
+ */
+export function TicketCard({
+  id,
+  event,
+  ticketType,
+  status,
+  price,
+  onClick,
+  className = "",
+}: TicketCardProps) {
+  const statusCfg = getStatusConfig(status);
+  const formattedDate = formatEventDate(event.startTime);
+  const isUsedOrCancelled = status === "used" || status === "cancelled";
+
+  return (
+    <article
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      aria-label={`Ticket for ${event.title}`}
+      onClick={onClick}
+      onKeyDown={onClick ? (e) => e.key === "Enter" && onClick() : undefined}
+      data-ticket-id={id}
+      className={[
+        "flex items-stretch gap-4 rounded-xl border border-border-warm bg-white p-4",
+        "shadow-[-4px_4px_0_rgba(0,0,0,0.08)]",
+        "transition-transform duration-150",
+        onClick ? "cursor-pointer hover:scale-[1.01] focus-visible:outline" : "",
+        isUsedOrCancelled ? "opacity-60" : "",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {/* ── Event thumbnail ── */}
+      <div className="flex-shrink-0 w-20 h-20 sm:w-24 sm:h-24 rounded-lg overflow-hidden bg-surface">
+        {event.imageUrl ? (
+          <LazyImage
+            src={event.imageUrl}
+            alt={event.title}
+            width={96}
+            height={96}
+            className="object-cover w-full h-full"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-surface-alt">
+            <Image
+              src="/icons/ticket.svg"
+              width={32}
+              height={32}
+              alt=""
+              aria-hidden="true"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* ── Content ── */}
+      <div className="flex-1 min-w-0 flex flex-col justify-between">
+        <div>
+          {/* Title */}
+          <p className="font-semibold text-sm sm:text-base text-ink-soft leading-snug line-clamp-2">
+            {event.title}
+          </p>
+
+          {/* Date */}
+          {formattedDate && (
+            <p className="mt-1 flex items-center gap-1 text-xs text-muted-text">
+              <Image
+                src="/icons/calendar.svg"
+                width={12}
+                height={12}
+                alt=""
+                aria-hidden="true"
+              />
+              <span>{formattedDate}</span>
+            </p>
+          )}
+
+          {/* Venue */}
+          {event.location && (
+            <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-text">
+              <Image
+                src={
+                  event.location.toLowerCase().includes("discord")
+                    ? "/icons/discord.svg"
+                    : "/icons/location.svg"
+                }
+                width={12}
+                height={12}
+                alt=""
+                aria-hidden="true"
+              />
+              <span className="truncate">{event.location}</span>
+            </p>
+          )}
+
+          {/* Ticket type */}
+          {ticketType && (
+            <p className="mt-1 text-xs text-muted-text">
+              <span className="font-medium text-ink-soft">{ticketType}</span>
+            </p>
+          )}
+        </div>
+
+        {/* Footer: status badge + price */}
+        <div className="mt-2 flex items-center justify-between flex-wrap gap-2">
+          <span
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold ${statusCfg.className}`}
+          >
+            {statusCfg.label}
+          </span>
+
+          {price !== undefined && (
+            <span className="text-xs font-semibold text-ink-soft">
+              {price === "0" || price?.toLowerCase() === "free"
+                ? "Free"
+                : `$${price}`}
+            </span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default TicketCard;

--- a/apps/web/components/wallet/index.ts
+++ b/apps/web/components/wallet/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Wallet feature components.
+ *
+ * Re-export every component from this barrel so consumers can import from a
+ * single path:
+ *
+ * ```ts
+ * import { TicketCard } from "@/components/wallet";
+ * ```
+ */
+
+export { TicketCard } from "./TicketCard";
+export type { TicketCardProps, TicketStatus } from "./TicketCard";

--- a/apps/web/hooks/useWalletTickets.ts
+++ b/apps/web/hooks/useWalletTickets.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import useSWR from "swr";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WalletTicket {
+  id: string;
+  status: string;
+  ticket_tier_id: string | null;
+  ticket_tier_name: string | null;
+  ticket_price: string | null;
+  event_id: string | null;
+  event_title: string | null;
+  event_location: string | null;
+  event_start_time: string | null;
+  event_image_url: string | null;
+  created_at: string;
+}
+
+export interface WalletTicketsData {
+  upcoming: WalletTicket[];
+  past: WalletTicket[];
+}
+
+interface ApiResponse {
+  data: WalletTicketsData;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchWalletTickets(url: string): Promise<WalletTicketsData> {
+  const res = await fetch(url, { credentials: "same-origin" });
+  if (res.status === 401) {
+    throw new Error("Unauthorized");
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to load wallet tickets (${res.status})`);
+  }
+  const json: ApiResponse = await res.json();
+  return json.data;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the authenticated user's wallet tickets, split into upcoming and
+ * past collections.
+ *
+ * @example
+ * const { upcoming, past, isLoading, error } = useWalletTickets();
+ */
+export function useWalletTickets() {
+  const { data, error, isLoading, mutate } = useSWR<WalletTicketsData>(
+    "/api/v1/profile/tickets",
+    fetchWalletTickets,
+    {
+      revalidateOnFocus: false,
+      shouldRetryOnError: false,
+    },
+  );
+
+  return {
+    upcoming: data?.upcoming ?? [],
+    past: data?.past ?? [],
+    isLoading,
+    error: error as Error | undefined,
+    mutate,
+  };
+}

--- a/server/src/handlers/profile.rs
+++ b/server/src/handlers/profile.rs
@@ -1095,3 +1095,120 @@ mod tests {
         assert!(value.get("created_at").is_some());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Wallet Ticket Aggregation (#1122)
+// ---------------------------------------------------------------------------
+
+/// A single ticket enriched with its event details, returned by
+/// `GET /api/v1/profile/tickets`.
+#[derive(Debug, Clone, Serialize, FromRow)]
+pub struct WalletTicket {
+    pub id: Uuid,
+    pub status: String,
+    pub ticket_tier_id: Option<Uuid>,
+    pub ticket_tier_name: Option<String>,
+    pub ticket_price: Option<rust_decimal::Decimal>,
+    pub event_id: Option<Uuid>,
+    pub event_title: Option<String>,
+    pub event_location: Option<String>,
+    pub event_start_time: Option<DateTime<Utc>>,
+    pub event_image_url: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response shape for `GET /api/v1/profile/tickets`.
+///
+/// Tickets are split into two collections:
+/// - `upcoming` – tickets for events that have not yet started, sorted
+///   soonest-first.
+/// - `past` – tickets for events that have already started, sorted most-recent
+///   first.
+///
+/// Empty wallets receive `{ "upcoming": [], "past": [] }` with a 200 status.
+#[derive(Debug, Serialize)]
+pub struct WalletTicketsResponse {
+    pub upcoming: Vec<WalletTicket>,
+    pub past: Vec<WalletTicket>,
+}
+
+/// `GET /api/v1/profile/tickets`
+///
+/// Aggregates all tickets that belong to the authenticated wallet address and
+/// groups them into upcoming and past collections.
+///
+/// # Authentication
+/// Requires a valid JWT (`Authorization: Bearer <token>` or `auth_token` cookie).
+///
+/// # Response
+/// ```json
+/// {
+///   "upcoming": [ { "id": "...", "status": "active", "event_title": "...", ... } ],
+///   "past":     [ { "id": "...", "status": "used",   "event_title": "...", ... } ]
+/// }
+/// ```
+pub async fn get_wallet_tickets(
+    State(state): State<ProfileState>,
+    headers: HeaderMap,
+) -> Response {
+    let address = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    // Single query: fetch all tickets for this wallet address joined with their
+    // event and ticket-tier information. We bring back everything in one round
+    // trip and split on the application side.
+    let tickets = match sqlx::query_as::<_, WalletTicket>(
+        r#"
+        SELECT
+            t.id,
+            t.status,
+            t.ticket_tier_id,
+            tt.name        AS ticket_tier_name,
+            tt.price       AS ticket_price,
+            t.event_id,
+            e.title        AS event_title,
+            e.location     AS event_location,
+            e.start_time   AS event_start_time,
+            e.image_url    AS event_image_url,
+            t.created_at
+        FROM tickets t
+        LEFT JOIN ticket_tiers tt ON tt.id = t.ticket_tier_id
+        LEFT JOIN events        e  ON e.id  = t.event_id
+        WHERE
+            t.owner_wallet = $1
+            OR t.buyer_wallet = $1
+        ORDER BY e.start_time ASC NULLS LAST
+        "#,
+    )
+    .bind(&address)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to fetch wallet tickets for {address}: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let now = Utc::now();
+
+    let (mut upcoming, mut past): (Vec<WalletTicket>, Vec<WalletTicket>) =
+        tickets.into_iter().partition(|t| {
+            t.event_start_time
+                .map(|start| start >= now)
+                .unwrap_or(true) // tickets without an event date are treated as upcoming
+        });
+
+    // Upcoming: soonest first (already ordered by query).
+    // Past: most-recent first — reverse the chronological order.
+    past.sort_by(|a, b| {
+        b.event_start_time
+            .cmp(&a.event_start_time)
+    });
+
+    let response = WalletTicketsResponse { upcoming, past };
+    success(response, "Wallet tickets retrieved successfully").into_response()
+}

--- a/server/src/handlers/qr_payload.rs
+++ b/server/src/handlers/qr_payload.rs
@@ -677,3 +677,171 @@ mod tests {
         assert_eq!(test_uuid, parsed);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Attendee Ticket QR Generation (#1121)
+// ---------------------------------------------------------------------------
+
+/// Request body for generating a secure attendee ticket QR code.
+///
+/// The payload is signed with a fresh Ed25519 keypair so it cannot be
+/// forged or replayed after expiry.
+#[derive(Debug, Deserialize)]
+pub struct AttendeeQrRequest {
+    /// Stellar wallet address of the attendee.
+    pub wallet_address: String,
+    /// The UUID of the ticket being presented.
+    pub ticket_id: Uuid,
+    /// Lifetime of the QR code in seconds (default: 300 = 5 minutes).
+    pub expires_in_seconds: Option<i64>,
+}
+
+/// The signed QR payload returned to the attendee client.
+#[derive(Debug, Serialize)]
+pub struct AttendeeQrResponse {
+    /// Unique ID of the generated QR record.
+    pub qr_id: String,
+    /// Structured payload that is encoded into the QR code.
+    pub payload: QrPayload,
+    /// Base64-encoded Ed25519 signature over the serialised payload.
+    pub signature: String,
+    /// Hex-encoded Ed25519 public key – shared with the organiser app to
+    /// verify the signature without a network call.
+    pub public_key: String,
+    /// UTC timestamp after which the payload must be rejected.
+    pub expires_at: DateTime<Utc>,
+}
+
+/// `POST /api/v1/qr/attendee`
+///
+/// Generate a short-lived, signed QR payload for an attendee to present at
+/// event check-in.
+///
+/// The payload embeds the attendee's `wallet_address` and `ticket_id`. It is
+/// signed with a one-shot Ed25519 keypair so that:
+/// - Screenshot sharing is mitigated (the code expires quickly).
+/// - Replay attacks are mitigated (the nonce and expiry are part of the
+///   signed payload, so a valid code cannot be recycled after it expires).
+///
+/// # Request
+/// ```json
+/// {
+///   "wallet_address": "GABC...XYZ",
+///   "ticket_id": "550e8400-e29b-41d4-a716-446655440000",
+///   "expires_in_seconds": 300
+/// }
+/// ```
+///
+/// # Response
+/// Returns a signed `QrPayload` together with the signature and public key
+/// required for offline verification by the organiser scanner.
+pub async fn generate_attendee_qr(
+    State(pool): State<PgPool>,
+    Json(request): Json<AttendeeQrRequest>,
+) -> Response {
+    // Basic input validation
+    if request.wallet_address.trim().is_empty() {
+        return AppError::ValidationError("wallet_address cannot be empty".to_string())
+            .into_response();
+    }
+
+    // Confirm the ticket exists and belongs to the claimed wallet address
+    let ticket_ok = match sqlx::query_scalar::<_, bool>(
+        r#"
+        SELECT EXISTS(
+            SELECT 1 FROM tickets
+            WHERE id = $1
+              AND (owner_wallet = $2 OR buyer_wallet = $2)
+              AND status != 'cancelled'
+        )
+        "#,
+    )
+    .bind(request.ticket_id)
+    .bind(request.wallet_address.trim())
+    .fetch_one(&pool)
+    .await
+    {
+        Ok(exists) => exists,
+        Err(e) => {
+            tracing::error!("Failed to validate ticket ownership: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    if !ticket_ok {
+        return AppError::NotFound(
+            "Ticket not found or does not belong to this wallet address".to_string(),
+        )
+        .into_response();
+    }
+
+    // Build the signed payload
+    let qr_id = Uuid::new_v4().to_string();
+    let nonce = Uuid::new_v4().to_string();
+    let created_at = Utc::now();
+    let lifetime_secs = request.expires_in_seconds.unwrap_or(300).max(60).min(86400);
+    let expires_at = created_at + Duration::seconds(lifetime_secs);
+
+    let payload = QrPayload {
+        id: qr_id.clone(),
+        qr_type: "ticket".to_string(),
+        data: serde_json::json!({
+            "wallet_address": request.wallet_address.trim(),
+            "ticket_id": request.ticket_id.to_string(),
+        }),
+        created_at,
+        expires_at,
+        nonce,
+    };
+
+    let payload_json = match serde_json::to_string(&payload) {
+        Ok(j) => j,
+        Err(e) => {
+            return AppError::InternalServerError(format!("Failed to serialise payload: {e}"))
+                .into_response();
+        }
+    };
+
+    // Sign with a fresh ephemeral key so verification can happen offline
+    let mut csprng = OsRng;
+    let signing_key = SigningKey::generate(&mut csprng);
+    let verifying_key = signing_key.verifying_key();
+    let signature = signing_key.sign(payload_json.as_bytes());
+    let signature_b64 = general_purpose::STANDARD.encode(signature.to_bytes());
+    let public_key_hex = hex::encode(verifying_key.to_bytes());
+
+    // Persist in qr_payloads so the organiser app can mark it used on scan
+    if let Err(e) = sqlx::query(
+        r#"
+        INSERT INTO qr_payloads (
+            id, qr_type, payload_data, signature, public_key,
+            created_at, expires_at, is_used, ticket_id
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, false, $8)
+        "#,
+    )
+    .bind(&qr_id)
+    .bind("ticket")
+    .bind(&payload.data)
+    .bind(&signature_b64)
+    .bind(&public_key_hex)
+    .bind(created_at)
+    .bind(expires_at)
+    .bind(request.ticket_id)
+    .execute(&pool)
+    .await
+    {
+        tracing::error!("Failed to persist attendee QR payload: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    let response = AttendeeQrResponse {
+        qr_id,
+        payload,
+        signature: signature_b64,
+        public_key: public_key_hex,
+        expires_at,
+    };
+
+    success(response, "Attendee QR payload generated successfully").into_response()
+}

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -59,11 +59,12 @@ use crate::handlers::{
     },
     profile::{
         delete_profile, get_my_profile, get_organizer_stats, get_profile_by_address,
-        list_events_by_organizer, list_my_transactions, patch_profile, upsert_profile, ProfileState,
+        get_wallet_tickets, list_events_by_organizer, list_my_transactions, patch_profile,
+        upsert_profile, ProfileState,
     },
     qr_payload::{
-        delete_qr_payload, generate_qr_payload, list_event_qr_codes, list_qr_payloads,
-        mark_qr_used, verify_qr_payload,
+        delete_qr_payload, generate_attendee_qr, generate_qr_payload, list_event_qr_codes,
+        list_qr_payloads, mark_qr_used, verify_qr_payload,
     },
     rates::{get_rates, RatesState},
     soroban_listener::{spawn_listener, ListenerConfig},
@@ -142,6 +143,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
                 .delete(delete_profile),
         )
         .route("/transactions", get(list_my_transactions))
+        .route("/tickets", get(get_wallet_tickets))
         .route("/:address", get(get_profile_by_address))
         .route("/:address/events", get(list_events_by_organizer))
         .route("/:address/stats", get(get_organizer_stats))
@@ -171,6 +173,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
     // QR payload routes for cryptographically signed QR codes
     let qr_routes = Router::new()
         .route("/generate", post(generate_qr_payload))
+        .route("/attendee", post(generate_attendee_qr))
         .route("/verify", post(verify_qr_payload))
         .route("/mark-used/:id", post(mark_qr_used))
         .route("/list", get(list_qr_payloads))


### PR DESCRIPTION
…e & TicketCard

Closes #1121
Closes #1122 
Closes #1123 
Closes #1124

## #1122 — BACKEND: Wallet Ticket Aggregation Endpoint
- Added `GET /api/v1/profile/tickets` handler in `server/src/handlers/profile.rs`
- Queries all tickets for the authenticated wallet (owner_wallet OR buyer_wallet), left-joins event and ticket-tier data in a single round trip
- Partitions results into `upcoming` (start_time >= now) and `past` (start_time < now) collections; upcoming sorted soonest-first, past sorted most-recent-first
- Empty wallets return `{ upcoming: [], past: [] }` with HTTP 200
- Registered route `/tickets` on the existing `profile_routes` sub-router

## #1121 — INTEGRATION: Secure Attendee QR Payloads
- Added `POST /api/v1/qr/attendee` in `server/src/handlers/qr_payload.rs`
- Validates that the requested ticket belongs to the claiming wallet address before signing (prevents generating codes for other users' tickets)
- Payload includes `wallet_address`, `ticket_id`, a UUID nonce, and an expiration timestamp (default 5 min, clamped 60 s–24 h)
- Signed with a fresh ephemeral Ed25519 keypair per request — the public key is returned alongside the payload so the organiser scanner can verify offline without a network call
- QR record persisted to `qr_payloads` table (with `ticket_id` FK) so the organiser app can call `mark-used` on scan to prevent replay

## #1123 — FRONTEND: Wallet Route & Layout
- Created `/wallet` page (`apps/web/app/wallet/page.tsx`) and its layout
- Page renders two sections: Upcoming Tickets and Past Events, each with loading skeletons, empty states with a CTA to Discover Events, and a live list of TicketCard components fed from useWalletTickets
- Unauthenticated users see a sign-in prompt instead of ticket data
- Added `apps/web/app/api/v1/profile/tickets/route.ts` as a Next.js proxy that forwards authenticated requests to the Rust backend
- Added `apps/web/hooks/useWalletTickets.ts` — SWR hook that fetches and exposes `{ upcoming, past, isLoading, error }`
- Added "My Wallet" link to the authenticated user navbar

## #1124 — FRONTEND: Reusable TicketCard Component
- Created `apps/web/components/wallet/TicketCard.tsx`
- Displays event image (with LazyImage + fallback), title, formatted date, venue, ticket type, status badge, and optional price
- Status badge variants: active (accent yellow), used (muted), cancelled (red)
- Fully responsive; supports optional onClick handler with keyboard a11y
- Exported via `apps/web/components/wallet/index.ts` barrel