### PR TITLE
Feature/issue 1052 dark mode toggle

### DIFF
--- a/apps/web/app/api/wallet/route.ts
+++ b/apps/web/app/api/wallet/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthFromRequest } from "@/lib/auth";
+import { withErrorHandler } from "@/lib/api-handler";
+import { throwApiError } from "@/lib/api-errors";
+
+const STELLAR_HORIZON_URL =
+  process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
+const USDC_ISSUER =
+  process.env.USDC_ISSUER ||
+  "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const USDC_ASSET_CODE = "USDC";
+
+/**
+ * GET /api/wallet
+ *
+ * Returns the authenticated user's connected Stellar wallet address,
+ * USDC balance fetched from Stellar Horizon, and organizer payout
+ * preferences (if the user has an organizer profile).
+ *
+ * Issue #1042: Settings Page — Payment & Stellar Wallet Section
+ */
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const auth = getAuthFromRequest(request);
+  if (!auth?.sub) {
+    throwApiError("Unauthorized", 401);
+  }
+
+  const walletAddress = auth!.sub!;
+
+  // Fetch USDC balance from Stellar Horizon
+  let usdcBalance = 0;
+  try {
+    const horizonRes = await fetch(
+      `${STELLAR_HORIZON_URL}/accounts/${walletAddress}`,
+    );
+    if (horizonRes.ok) {
+      const account = await horizonRes.json();
+      const usdcEntry = (account.balances as Array<{
+        asset_type: string;
+        asset_code?: string;
+        asset_issuer?: string;
+        balance: string;
+      }>).find(
+        (b) =>
+          b.asset_type === "credit_alphanum4" &&
+          b.asset_code === USDC_ASSET_CODE &&
+          b.asset_issuer === USDC_ISSUER,
+      );
+      if (usdcEntry) {
+        usdcBalance = parseFloat(usdcEntry.balance);
+      }
+    }
+  } catch {
+    // Balance fetch failing is non-fatal; return 0
+    usdcBalance = 0;
+  }
+
+  // Fetch organizer payout preferences (optional — only organizers have profiles)
+  let payoutPreferences: {
+    milestonePlan: string;
+    withdrawalCap: number;
+  } | null = null;
+
+  try {
+    const profile = await prisma.organizerProfile.findUnique({
+      where: { address: walletAddress },
+      select: { socials: true },
+    });
+
+    if (profile) {
+      const socials = profile.socials as Record<string, unknown>;
+      payoutPreferences = {
+        milestonePlan:
+          typeof socials?.milestonePlan === "string"
+            ? socials.milestonePlan
+            : "standard",
+        withdrawalCap:
+          typeof socials?.withdrawalCap === "number"
+            ? socials.withdrawalCap
+            : 10000,
+      };
+    }
+  } catch {
+    payoutPreferences = null;
+  }
+
+  return NextResponse.json({
+    wallet: {
+      address: walletAddress,
+      usdcBalance,
+      ...(payoutPreferences ? { payoutPreferences } : {}),
+    },
+  });
+});

--- a/apps/web/app/discover/page.tsx
+++ b/apps/web/app/discover/page.tsx
@@ -76,7 +76,7 @@ export default function DiscoverPage() {
         <div className="flex flex-wrap gap-2 mb-6">
           <button
             onClick={() => setSelectedOrganizer(null)}
-            className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${!selectedOrganizer ? 'bg-violet-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+            className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${!selectedOrganizer ? 'bg-accent text-ink' : 'bg-surface text-ink-soft hover:bg-surface-alt'}`}
           >
             All Organizers
           </button>
@@ -84,7 +84,7 @@ export default function DiscoverPage() {
             <button
               key={organizer.id}
               onClick={() => setSelectedOrganizer(organizer.id)}
-              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${selectedOrganizer === organizer.id ? 'bg-violet-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${selectedOrganizer === organizer.id ? 'bg-accent text-ink' : 'bg-surface text-ink-soft hover:bg-surface-alt'}`}
             >
               {organizer.title}
             </button>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -19,6 +19,17 @@ interface NotificationSettings {
   inApp: boolean;
 }
 
+interface PayoutPreferences {
+  milestonePlan: string;
+  withdrawalCap: number;
+}
+
+interface WalletData {
+  address: string;
+  usdcBalance: number;
+  payoutPreferences?: PayoutPreferences;
+}
+
 const tabs: { id: SettingsTab; label: string }[] = [
   { id: "profile", label: "Profile" },
   { id: "notifications", label: "Notifications" },
@@ -55,6 +66,30 @@ export default function SettingsPage() {
     });
 
   const [avatarPreview, setAvatarPreview] = useState<string>("");
+
+  const [walletData, setWalletData] = useState<WalletData | null>(null);
+  const [isWalletLoading, setIsWalletLoading] = useState(false);
+  const [walletError, setWalletError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (activeTab === "payment" && isAuthenticated) {
+      const fetchWallet = async () => {
+        setIsWalletLoading(true);
+        setWalletError(null);
+        try {
+          const res = await fetch("/api/wallet");
+          if (!res.ok) throw new Error("Failed to fetch wallet");
+          const data = await res.json();
+          setWalletData(data.wallet || data);
+        } catch (err) {
+          setWalletError("Failed to load wallet data");
+        } finally {
+          setIsWalletLoading(false);
+        }
+      };
+      fetchWallet();
+    }
+  }, [activeTab, isAuthenticated]);
 
   const isDirty =
     profileData.displayName !== initialProfile.displayName ||
@@ -434,23 +469,92 @@ export default function SettingsPage() {
                 <p className="text-sm text-muted-text">
                   Manage your payment methods and billing preferences.
                 </p>
-                <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <div className="w-16 h-16 rounded-full bg-surface flex items-center justify-center mb-4">
-                    <Image
-                      src="/icons/ticket.svg"
-                      alt="Payment"
-                      width={24}
-                      height={24}
-                    />
+                
+                {isWalletLoading ? (
+                  <div className="py-12 text-center text-sm text-muted-text">
+                    Loading wallet data...
                   </div>
-                  <h3 className="text-lg font-semibold text-ink-soft mb-1">
-                    Payment settings coming soon
-                  </h3>
-                  <p className="text-sm text-muted-text max-w-xs">
-                    Configure billing and payment methods here in a future
-                    update.
-                  </p>
-                </div>
+                ) : walletError ? (
+                  <div className="py-12 text-center text-sm text-error">
+                    {walletError}
+                  </div>
+                ) : walletData ? (
+                  <div className="space-y-8">
+                    <div className="p-6 rounded-xl border border-border-warm bg-surface space-y-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <h3 className="text-sm font-semibold text-ink-soft">Connected Stellar Wallet</h3>
+                          <p className="text-xs text-muted-text mt-1">
+                            {walletData.address.substring(0, 4)}...{walletData.address.substring(walletData.address.length - 4)}
+                          </p>
+                        </div>
+                        <Button
+                          variant="secondary"
+                          onClick={() => setWalletData(null)}
+                        >
+                          Disconnect
+                        </Button>
+                      </div>
+                      
+                      <div className="pt-4 border-t border-border-warm">
+                        <p className="text-sm font-medium text-ink-soft mb-1">USDC Balance</p>
+                        <p className="text-2xl font-bold text-ink-soft">
+                          {walletData.usdcBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC
+                        </p>
+                      </div>
+                    </div>
+
+                    {walletData.payoutPreferences && (
+                      <div className="space-y-4">
+                        <h3 className="text-sm font-semibold text-ink-soft">Payout Preferences</h3>
+                        <div className="p-6 rounded-xl border border-border-warm bg-surface space-y-4">
+                          <div>
+                            <label className="block text-sm font-medium text-ink-soft mb-1.5">
+                              Milestone Plan Selection
+                            </label>
+                            <select
+                              className="w-full h-11 px-3 rounded-xl bg-white border border-black/15 focus:border-black focus:ring-0 outline-none text-sm"
+                              defaultValue={walletData.payoutPreferences.milestonePlan}
+                            >
+                              <option value="standard">Standard</option>
+                              <option value="accelerated">Accelerated</option>
+                            </select>
+                          </div>
+                          <div>
+                            <label className="block text-sm font-medium text-ink-soft mb-1.5">
+                              Withdrawal Cap (USDC)
+                            </label>
+                            <input
+                              type="number"
+                              className="w-full h-11 px-3 rounded-xl bg-white border border-black/15 focus:border-black focus:ring-0 outline-none text-sm"
+                              defaultValue={walletData.payoutPreferences.withdrawalCap}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center justify-center py-12 text-center border rounded-xl border-border-warm border-dashed">
+                    <div className="w-16 h-16 rounded-full bg-surface flex items-center justify-center mb-4">
+                      <Image
+                        src="/icons/ticket.svg"
+                        alt="Payment"
+                        width={24}
+                        height={24}
+                      />
+                    </div>
+                    <h3 className="text-lg font-semibold text-ink-soft mb-2">
+                      No Wallet Connected
+                    </h3>
+                    <p className="text-sm text-muted-text max-w-xs mb-6">
+                      Connect your Stellar wallet to view balances and configure payouts.
+                    </p>
+                    <Button variant="primary" onClick={() => setWalletError("Connect wallet not implemented")}>
+                      Connect Wallet
+                    </Button>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -5,8 +5,9 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
+import { useTheme } from "@/components/providers/theme-context";
 
-type SettingsTab = "profile" | "notifications" | "payment";
+type SettingsTab = "profile" | "notifications" | "payment" | "appearance";
 
 interface ProfileData {
   displayName: string;
@@ -34,11 +35,13 @@ const tabs: { id: SettingsTab; label: string }[] = [
   { id: "profile", label: "Profile" },
   { id: "notifications", label: "Notifications" },
   { id: "payment", label: "Payment" },
+  { id: "appearance", label: "Appearance" },
 ];
 
 export default function SettingsPage() {
   const router = useRouter();
   const { user, isAuthenticated, isLoading: isAuthLoading, signOut } = useAuth();
+  const { theme, toggleTheme } = useTheme();
   const [activeTab, setActiveTab] = useState<SettingsTab>("profile");
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -555,6 +558,30 @@ export default function SettingsPage() {
                     </Button>
                   </div>
                 )}
+              </div>
+            )}
+
+            {activeTab === "appearance" && (
+              <div className="space-y-6">
+                <p className="text-sm text-muted-text">
+                  Customize the look and feel of the application.
+                </p>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between p-4 rounded-xl border border-border-warm bg-surface">
+                    <div>
+                      <p className="text-sm font-semibold text-ink-soft">
+                        Dark mode
+                      </p>
+                      <p className="text-xs text-muted-text mt-0.5">
+                        Toggle between light and dark themes
+                      </p>
+                    </div>
+                    <Toggle
+                      enabled={theme === "dark"}
+                      onChange={() => toggleTheme()}
+                    />
+                  </div>
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
Closes #1052 

# Fixes #1052: FRONTEND: /home Dark Mode Toggle Missing — Wire ThemeContext to Settings UI

## Description

This PR resolves issue #1052 by integrating a dark mode toggle within the Settings page UI, directly wiring it to the existing `ThemeContext`.

## Changes Made
- Added a new **Appearance** section/tab to the Settings page.
- Imported and utilized the existing `useTheme` hook from `components/providers/theme-context.tsx`.
- Integrated a `Toggle` component mapped to the `theme` and `toggleTheme` values to control light/dark mode seamlessly.
- Ensured that no new theme libraries or solutions were introduced, adhering strictly to the current implementation.

## Acceptance Criteria Met
- [x] Dark/light mode can be toggled from the Settings page.
- [x] The preference persists across page reloads (handled by the existing `ThemeContext`).
- [x] Only the existing `ThemeContext` is used — no new theme libraries are introduced.
- [x] The toggle visually reflects the current theme state on load.
