### PR TITLE
health(redis): add redis check; rating timing & uniqueness; expose global event count

### DIFF
--- a/contract/contracts/event_registry/src/lib.rs
+++ b/contract/contracts/event_registry/src/lib.rs
@@ -341,7 +341,12 @@ impl EventRegistry {
         }
     }
 
-    /// Update event status (only by organizer)
+        /// Returns the cumulative number of events ever registered on the platform.
+        pub fn get_global_event_count(env: Env) -> u32 {
+            storage::get_global_event_count(&env)
+        }
+
+        /// Update event status (only by organizer)
     pub fn update_event_status(
         env: Env,
         event_id: String,

--- a/server/migrations/20260729000000_add_unique_rating_ticket_id.sql
+++ b/server/migrations/20260729000000_add_unique_rating_ticket_id.sql
@@ -1,0 +1,3 @@
+-- Ensure a ticket may only have one rating
+ALTER TABLE event_ratings
+    ADD CONSTRAINT IF NOT EXISTS unique_event_ratings_ticket_id UNIQUE (ticket_id);

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -2248,10 +2248,8 @@ pub async fn submit_event_rating(
 
     if already_rated {
         log_if_slow("submit_event_rating", start.elapsed());
-        return AppError::ValidationError(
-            "Each attendee may only submit one rating per event".to_string(),
-        )
-        .into_response();
+        return AppError::Conflict("Rating already submitted for this ticket".to_string())
+            .into_response();
     }
 
     if let Err(e) = sqlx::query(

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -2190,6 +2190,38 @@ pub async fn submit_event_rating(
         .into_response();
     }
 
+    // Verify event has ended (if end_time is set). Ratings are only allowed after event end.
+    let maybe_end_time = match sqlx::query_scalar::<_, Option<chrono::DateTime<Utc>>>(
+        "SELECT end_time FROM events WHERE id = $1 AND is_flagged = FALSE",
+    )
+    .bind(event_id)
+    .fetch_optional(&state.pool)
+    .await
+    {
+        Ok(opt) => opt,
+        Err(e) => {
+            log_if_slow("submit_event_rating", start.elapsed());
+            tracing::error!("Failed to fetch event end_time for rating: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    if maybe_end_time.is_none() {
+        // event not found or flagged
+        log_if_slow("submit_event_rating", start.elapsed());
+        return AppError::NotFound(format!("Event with id '{}' not found", event_id)).into_response();
+    }
+
+    if let Some(end_time) = maybe_end_time.unwrap() {
+        if end_time > Utc::now() {
+            log_if_slow("submit_event_rating", start.elapsed());
+            return AppError::ValidationError(
+                "Ratings may only be submitted after the event has ended".to_string(),
+            )
+            .into_response();
+        }
+    }
+
     let mut tx = match state.pool.begin().await {
         Ok(tx) => tx,
         Err(e) => {

--- a/server/src/handlers/health.rs
+++ b/server/src/handlers/health.rs
@@ -22,6 +22,8 @@ pub struct HealthResponse {
     status: &'static str,
     timestamp: String,
     category_sync: bool,
+    database: &'static str,
+    redis: &'static str,
 }
 
 #[derive(Serialize)]
@@ -57,26 +59,34 @@ struct HealthBlockchainResponse {
         (status = 200, description = "API is healthy", body = HealthResponse)
     )
 )]
-pub async fn health_check(State(pool): State<PgPool>) -> Response {
+pub async fn health_check(State(pool): State<PgPool>, State(mut redis): State<crate::cache::RedisCache>) -> Response {
     let category_sync = *CATEGORY_SYNC_STATUS.lock().unwrap();
-    
-    match sqlx::query("SELECT 1").fetch_one(&pool).await {
-        Ok(_) => {
-            let payload = HealthResponse {
-                status: "ok",
-                timestamp: Utc::now().to_rfc3339(),
-                category_sync,
-            };
-            success(payload, "API is healthy").into_response()
-        }
-        Err(e) => {
-            tracing::error!("Health check failed: {:?}", e);
-            AppError::ExternalServiceError(format!(
-                "API is not ready: database is unreachable ({e})"
-            ))
-            .into_response()
-        }
+
+    // Probe database
+    let db_ok = sqlx::query("SELECT 1").fetch_one(&pool).await.is_ok();
+    // Probe redis
+    let redis_ok = redis.ping().await.is_ok();
+
+    if db_ok && redis_ok {
+        let payload = HealthResponse {
+            status: "ok",
+            timestamp: Utc::now().to_rfc3339(),
+            category_sync,
+            database: "ok",
+            redis: "ok",
+        };
+        return success(payload, "API is healthy").into_response();
     }
+
+    let db_status = if db_ok { "ok" } else { "unreachable" };
+    let redis_status = if redis_ok { "ok" } else { "unreachable" };
+
+    tracing::error!("Health check failed: database={}, redis={}", db_status, redis_status);
+    AppError::ExternalServiceError(format!(
+        "Service is not ready: database={}, redis={}",
+        db_status, redis_status
+    ))
+    .into_response()
 }
 
 /// GET /health/db – Database connectivity check.


### PR DESCRIPTION
This PR implements four focused fixes:\n\n- Health: /health now checks Redis in addition to PostgreSQL and returns 503 if either dependency is unhealthy. The JSON payload includes "database" and "redis" status fields. (closes #837)\n- Ratings: rating submissions are rejected if the event's end_time is in the future. Ratings are only allowed after the event has ended. (closes #838)\n- Duplicate ratings: database migration adds a UNIQUE constraint on event_ratings.ticket_id; the API returns HTTP 409 (Conflict) when a rating already exists for a ticket. (closes #839)\n- Contract: adds EventRegistry::get_global_event_count to expose the on-chain cumulative event counter. (closes #846)\n\nEach issue addressed in its own commit. Changes are minimal and restricted to the relevant files and a small migration.