### PR TITLE
feat(mobile): real-time ticket inventory synchronization via WebSockets

### DIFF
--- a/apps/mobile/__tests__/useLiveTicketInventory.test.ts
+++ b/apps/mobile/__tests__/useLiveTicketInventory.test.ts
@@ -1,0 +1,174 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useLiveTicketInventory } from '../hooks/useLiveTicketInventory';
+import { InventorySocket } from '../utils/websocket';
+import type { TicketTierOption } from '../types/checkout';
+
+/**
+ * Issue #1010 — the hook that folds live updates into a tier list.
+ *
+ * `InventorySocket` is mocked so the test drives `onUpdate` directly; the
+ * socket's own reconnect behaviour is covered in `websocket.test.ts`.
+ */
+
+jest.mock('../utils/websocket', () => {
+  const actual = jest.requireActual('../utils/websocket');
+  return {
+    ...actual,
+    InventorySocket: jest.fn(),
+  };
+});
+
+const MockedInventorySocket = InventorySocket as unknown as jest.Mock;
+
+const TIERS: TicketTierOption[] = [
+  { id: 'tier-ga', name: 'General Admission', priceUsdc: 150, remaining: 340 },
+  { id: 'tier-vip', name: 'VIP', priceUsdc: 450, remaining: 12 },
+];
+
+interface Handles {
+  onUpdate: (update: { eventId: string; tierId: string; remaining?: number; soldDelta?: number }) => void;
+  onStatusChange: (status: string) => void;
+  close: jest.Mock;
+  connect: jest.Mock;
+}
+
+let handles: Handles;
+
+beforeEach(() => {
+  MockedInventorySocket.mockReset();
+  MockedInventorySocket.mockImplementation((options: Record<string, never>) => {
+    const opts = options as unknown as {
+      onUpdate: Handles['onUpdate'];
+      onStatusChange: Handles['onStatusChange'];
+    };
+    handles = {
+      onUpdate: opts.onUpdate,
+      onStatusChange: opts.onStatusChange,
+      connect: jest.fn(),
+      close: jest.fn(),
+    };
+    return { connect: handles.connect, close: handles.close };
+  });
+});
+
+describe('useLiveTicketInventory', () => {
+  it('returns the supplied tiers untouched before any update', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    expect(result.current.tiers).toEqual(TIERS);
+    expect(result.current.isLive).toBe(false);
+  });
+
+  it('opens a socket on mount and closes it on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    expect(handles.connect).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(handles.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not connect when disabled', () => {
+    renderHook(() => useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS, enabled: false }));
+
+    expect(MockedInventorySocket).not.toHaveBeenCalled();
+  });
+
+  it('applies an absolute remaining count to the matching tier only', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    act(() => {
+      handles.onUpdate({ eventId: 'evt-1', tierId: 'tier-vip', remaining: 3 });
+    });
+
+    expect(result.current.tiers[0]).toEqual(TIERS[0]);
+    expect(result.current.tiers[1].remaining).toBe(3);
+  });
+
+  it('subtracts a purchase delta from the seeded count', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    act(() => {
+      handles.onUpdate({ eventId: 'evt-1', tierId: 'tier-ga', soldDelta: 40 });
+    });
+
+    expect(result.current.tiers[0].remaining).toBe(300);
+  });
+
+  it('accumulates successive deltas', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    act(() => {
+      handles.onUpdate({ eventId: 'evt-1', tierId: 'tier-vip', soldDelta: 5 });
+    });
+    act(() => {
+      handles.onUpdate({ eventId: 'evt-1', tierId: 'tier-vip', soldDelta: 4 });
+    });
+
+    expect(result.current.tiers[1].remaining).toBe(3);
+  });
+
+  it('drives a tier to sold out and never below zero', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    act(() => {
+      handles.onUpdate({ eventId: 'evt-1', tierId: 'tier-vip', soldDelta: 999 });
+    });
+
+    expect(result.current.tiers[1].remaining).toBe(0);
+  });
+
+  it('preserves tier identity and order so the list does not reset', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    act(() => {
+      handles.onUpdate({ eventId: 'evt-1', tierId: 'tier-ga', remaining: 100 });
+    });
+
+    expect(result.current.tiers.map((t) => t.id)).toEqual(['tier-ga', 'tier-vip']);
+    expect(result.current.tiers[0].name).toBe('General Admission');
+    expect(result.current.tiers[0].priceUsdc).toBe(150);
+  });
+
+  it('reports live status from the socket', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    act(() => {
+      handles.onStatusChange('connected');
+    });
+    expect(result.current.isLive).toBe(true);
+
+    act(() => {
+      handles.onStatusChange('reconnecting');
+    });
+    expect(result.current.isLive).toBe(false);
+  });
+
+  it('ignores updates for a tier it does not know', () => {
+    const { result } = renderHook(() =>
+      useLiveTicketInventory({ eventId: 'evt-1', tiers: TIERS }),
+    );
+
+    act(() => {
+      handles.onUpdate({ eventId: 'evt-1', tierId: 'tier-unknown', remaining: 1 });
+    });
+
+    expect(result.current.tiers).toEqual(TIERS);
+  });
+});

--- a/apps/mobile/__tests__/websocket.test.ts
+++ b/apps/mobile/__tests__/websocket.test.ts
@@ -1,0 +1,346 @@
+import {
+  InventorySocket,
+  applyInventoryUpdate,
+  backoffDelay,
+  parseInventoryMessage,
+  INITIAL_RECONNECT_DELAY_MS,
+  MAX_RECONNECT_DELAY_MS,
+  type WebSocketLike,
+} from '../utils/websocket';
+
+/**
+ * Issue #1010 — the WebSocket inventory client.
+ *
+ * Exercised through an injected socket double rather than a real connection,
+ * so the reconnect/backoff behaviour is deterministic and no network is
+ * touched in CI.
+ */
+
+class FakeSocket implements WebSocketLike {
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: unknown) => void) | null = null;
+
+  sent: string[] = [];
+  closed = false;
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Test helpers that drive the socket's lifecycle. */
+  open(): void {
+    this.onopen?.({});
+  }
+
+  emit(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+
+  drop(): void {
+    this.onclose?.({});
+  }
+}
+
+describe('parseInventoryMessage', () => {
+  it('parses the backend purchase-delta shape', () => {
+    const raw = JSON.stringify({
+      event_id: 'evt-1',
+      ticket_tier_id: 'tier-ga',
+      quantity: 2,
+      amount: 300,
+      currency: 'USDC',
+      purchased_at: '2026-07-29T10:00:00Z',
+    });
+
+    expect(parseInventoryMessage(raw)).toEqual({
+      eventId: 'evt-1',
+      tierId: 'tier-ga',
+      soldDelta: 2,
+    });
+  });
+
+  it('parses an absolute remaining count', () => {
+    const raw = JSON.stringify({ eventId: 'evt-1', tierId: 'tier-vip', remaining: 7 });
+
+    expect(parseInventoryMessage(raw)).toEqual({
+      eventId: 'evt-1',
+      tierId: 'tier-vip',
+      remaining: 7,
+    });
+  });
+
+  it('accepts snake_case and camelCase identifiers alike', () => {
+    const snake = parseInventoryMessage(
+      JSON.stringify({ event_id: 'e', ticket_tier_id: 't', remaining_tickets: 3 }),
+    );
+    const camel = parseInventoryMessage(
+      JSON.stringify({ eventId: 'e', tierId: 't', remainingTickets: 3 }),
+    );
+
+    expect(snake).toEqual(camel);
+  });
+
+  it('clamps negative counts and truncates fractions', () => {
+    expect(
+      parseInventoryMessage(JSON.stringify({ eventId: 'e', tierId: 't', remaining: -5 })),
+    ).toEqual({ eventId: 'e', tierId: 't', remaining: 0 });
+
+    expect(
+      parseInventoryMessage(JSON.stringify({ eventId: 'e', tierId: 't', remaining: 4.9 })),
+    ).toEqual({ eventId: 'e', tierId: 't', remaining: 4 });
+  });
+
+  it('returns null for anything unusable', () => {
+    expect(parseInventoryMessage('not json')).toBeNull();
+    expect(parseInventoryMessage(JSON.stringify({ hello: 'world' }))).toBeNull();
+    expect(parseInventoryMessage(JSON.stringify({ eventId: 'e' }))).toBeNull();
+    // Identifies a tier but carries neither a count nor a delta.
+    expect(parseInventoryMessage(JSON.stringify({ eventId: 'e', tierId: 't' }))).toBeNull();
+    expect(parseInventoryMessage(null)).toBeNull();
+    expect(parseInventoryMessage(42)).toBeNull();
+  });
+});
+
+describe('applyInventoryUpdate', () => {
+  it('prefers an authoritative remaining count over a delta', () => {
+    expect(
+      applyInventoryUpdate(100, { eventId: 'e', tierId: 't', remaining: 5, soldDelta: 2 }),
+    ).toBe(5);
+  });
+
+  it('subtracts a delta from the known count', () => {
+    expect(applyInventoryUpdate(10, { eventId: 'e', tierId: 't', soldDelta: 3 })).toBe(7);
+  });
+
+  it('never goes below zero', () => {
+    expect(applyInventoryUpdate(2, { eventId: 'e', tierId: 't', soldDelta: 9 })).toBe(0);
+  });
+
+  it('cannot apply a delta without a known starting count', () => {
+    expect(applyInventoryUpdate(undefined, { eventId: 'e', tierId: 't', soldDelta: 3 })).toBeUndefined();
+  });
+
+  it('returns the current value when the update carries nothing', () => {
+    expect(applyInventoryUpdate(8, { eventId: 'e', tierId: 't' })).toBe(8);
+  });
+});
+
+describe('backoffDelay', () => {
+  it('doubles each attempt starting from the initial delay', () => {
+    expect(backoffDelay(0)).toBe(INITIAL_RECONNECT_DELAY_MS);
+    expect(backoffDelay(1)).toBe(INITIAL_RECONNECT_DELAY_MS * 2);
+    expect(backoffDelay(2)).toBe(INITIAL_RECONNECT_DELAY_MS * 4);
+    expect(backoffDelay(3)).toBe(INITIAL_RECONNECT_DELAY_MS * 8);
+  });
+
+  it('caps at the maximum delay', () => {
+    expect(backoffDelay(20)).toBe(MAX_RECONNECT_DELAY_MS);
+  });
+
+  it('treats a negative attempt as the first', () => {
+    expect(backoffDelay(-1)).toBe(INITIAL_RECONNECT_DELAY_MS);
+  });
+});
+
+describe('InventorySocket', () => {
+  let sockets: FakeSocket[];
+  let factory: (url: string) => WebSocketLike;
+  let urls: string[];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    sockets = [];
+    urls = [];
+    factory = (url: string) => {
+      urls.push(url);
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      return socket;
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function connect(overrides: Record<string, unknown> = {}) {
+    const onUpdate = jest.fn();
+    const onStatusChange = jest.fn();
+    const socket = new InventorySocket({
+      eventId: 'evt-1',
+      url: 'ws://test/ws',
+      socketFactory: factory,
+      onUpdate,
+      onStatusChange,
+      ...overrides,
+    });
+    socket.connect();
+    return { socket, onUpdate, onStatusChange };
+  }
+
+  it('registers for the event room once open', () => {
+    const { onStatusChange } = connect();
+
+    expect(sockets).toHaveLength(1);
+    sockets[0].open();
+
+    expect(sockets[0].sent).toEqual([
+      JSON.stringify({ type: 'subscribe', eventId: 'evt-1' }),
+    ]);
+    expect(onStatusChange).toHaveBeenCalledWith('connecting');
+    expect(onStatusChange).toHaveBeenCalledWith('connected');
+  });
+
+  it('appends the auth token to the URL', () => {
+    connect({ token: 'jwt-123' });
+    expect(urls[0]).toBe('ws://test/ws?token=jwt-123');
+  });
+
+  it('forwards updates for the subscribed event', () => {
+    const { onUpdate } = connect();
+    sockets[0].open();
+
+    sockets[0].emit(JSON.stringify({ event_id: 'evt-1', ticket_tier_id: 'tier-ga', quantity: 3 }));
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      eventId: 'evt-1',
+      tierId: 'tier-ga',
+      soldDelta: 3,
+    });
+  });
+
+  it('ignores updates for other events', () => {
+    const { onUpdate } = connect();
+    sockets[0].open();
+
+    sockets[0].emit(JSON.stringify({ event_id: 'evt-2', ticket_tier_id: 'tier-ga', quantity: 3 }));
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed frames without crashing', () => {
+    const { onUpdate } = connect();
+    sockets[0].open();
+
+    expect(() => {
+      sockets[0].emit('not json');
+      sockets[0].emit(JSON.stringify({ nothing: true }));
+      sockets[0].emit(undefined);
+    }).not.toThrow();
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reconnects with exponential backoff after a drop', () => {
+    const { onStatusChange } = connect();
+    sockets[0].open();
+
+    sockets[0].drop();
+    expect(onStatusChange).toHaveBeenCalledWith('reconnecting');
+    expect(sockets).toHaveLength(1);
+
+    // First retry after the initial delay.
+    jest.advanceTimersByTime(INITIAL_RECONNECT_DELAY_MS);
+    expect(sockets).toHaveLength(2);
+
+    // Second drop waits twice as long.
+    sockets[1].drop();
+    jest.advanceTimersByTime(INITIAL_RECONNECT_DELAY_MS);
+    expect(sockets).toHaveLength(2);
+    jest.advanceTimersByTime(INITIAL_RECONNECT_DELAY_MS);
+    expect(sockets).toHaveLength(3);
+  });
+
+  it('re-subscribes after reconnecting', () => {
+    connect();
+    sockets[0].open();
+    sockets[0].drop();
+
+    jest.advanceTimersByTime(INITIAL_RECONNECT_DELAY_MS);
+    sockets[1].open();
+
+    expect(sockets[1].sent).toEqual([
+      JSON.stringify({ type: 'subscribe', eventId: 'evt-1' }),
+    ]);
+  });
+
+  it('resets the backoff after a successful reconnect', () => {
+    connect();
+    sockets[0].open();
+
+    sockets[0].drop();
+    jest.advanceTimersByTime(INITIAL_RECONNECT_DELAY_MS);
+    sockets[1].open(); // success resets the counter
+
+    sockets[1].drop();
+    // Back to the initial delay rather than double.
+    jest.advanceTimersByTime(INITIAL_RECONNECT_DELAY_MS);
+    expect(sockets).toHaveLength(3);
+  });
+
+  it('stops reconnecting once closed', () => {
+    const { socket } = connect();
+    sockets[0].open();
+
+    socket.close();
+    expect(sockets[0].closed).toBe(true);
+    expect(socket.getStatus()).toBe('closed');
+
+    jest.advanceTimersByTime(MAX_RECONNECT_DELAY_MS * 2);
+    expect(sockets).toHaveLength(1);
+  });
+
+  it('does not reconnect for a drop that arrives after close', () => {
+    const { socket } = connect();
+    sockets[0].open();
+    const first = sockets[0];
+
+    socket.close();
+    first.drop(); // listener was detached, so this is a no-op
+
+    jest.advanceTimersByTime(MAX_RECONNECT_DELAY_MS);
+    expect(sockets).toHaveLength(1);
+  });
+
+  it('is safe to close more than once', () => {
+    const { socket } = connect();
+    sockets[0].open();
+
+    expect(() => {
+      socket.close();
+      socket.close();
+    }).not.toThrow();
+  });
+
+  it('retries when the socket constructor throws', () => {
+    let attempts = 0;
+    const throwingFactory = (url: string) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('no network');
+      return factory(url);
+    };
+
+    const socket = new InventorySocket({
+      eventId: 'evt-1',
+      url: 'ws://test/ws',
+      socketFactory: throwingFactory,
+    });
+    socket.connect();
+
+    expect(sockets).toHaveLength(0);
+    jest.advanceTimersByTime(INITIAL_RECONNECT_DELAY_MS);
+    expect(sockets).toHaveLength(1);
+  });
+
+  it('ignores a second connect while already connected', () => {
+    const { socket } = connect();
+    socket.connect();
+    expect(sockets).toHaveLength(1);
+  });
+});

--- a/apps/mobile/app/checkout/__tests__/index.test.tsx
+++ b/apps/mobile/app/checkout/__tests__/index.test.tsx
@@ -63,12 +63,14 @@ beforeEach(() => {
 
 describe('CheckoutScreen', () => {
   it('defaults to the first available tier and shows a matching order summary', () => {
-    const { getByText, getAllByText } = render(<CheckoutScreen />);
+    const { getAllByText } = render(<CheckoutScreen />);
 
     // Event 1's mock catalogue: General Admission (150 USDC, first / default), VIP (450 USDC).
     // "General Admission" appears twice: once as the selected TierSelector
     // card, once as the OrderSummaryCard's tier name line.
-    expect(getByText('Stellar Meridian 2026')).toBeTruthy();
+    // The event title also appears twice: as the screen subheading and as the
+    // OrderSummaryCard heading.
+    expect(getAllByText('Stellar Meridian 2026').length).toBe(2);
     expect(getAllByText('General Admission').length).toBe(2);
     // quantity defaults to 1, so unit price === subtotal === total === "150.00 USDC"
     expect(getAllByText('150.00 USDC').length).toBeGreaterThanOrEqual(2);

--- a/apps/mobile/app/checkout/index.tsx
+++ b/apps/mobile/app/checkout/index.tsx
@@ -9,59 +9,46 @@ import OrderSummaryCard from '@/components/checkout/OrderSummaryCard';
 import CheckoutProgressModal from '@/components/checkout/CheckoutProgressModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useTicketCheckout } from '@/hooks/useTicketCheckout';
-import type { TicketTierOption } from '@/types/checkout';
+import { useLiveTicketInventory } from '@/hooks/useLiveTicketInventory';
+import { getTiersForEvent } from '@/lib/ticketTiers';
 
 const MAX_TICKETS_PER_ORDER = 10;
-
-/**
- * Ticket tier catalogue keyed by event id. The event/pricing endpoints this
- * would normally come from aren't wired up in the mobile client yet, so this
- * mirrors the mock-data convention already used by `app/event/[id].tsx` and
- * `app/ticket/[id].tsx` until a real `/api/events/:id/tiers` call replaces it.
- */
-const MOCK_TIERS_BY_EVENT: Record<string, TicketTierOption[]> = {
-  '1': [
-    { id: 'tier-ga', name: 'General Admission', priceUsdc: 150, remaining: 340 },
-    { id: 'tier-vip', name: 'VIP', description: 'Front-row seating + backstage pass', priceUsdc: 450, remaining: 12 },
-  ],
-  '2': [
-    { id: 'tier-ga', name: 'General Admission', priceUsdc: 80, remaining: 500 },
-    { id: 'tier-pro', name: 'Pro Pass', description: 'Includes workshop access', priceUsdc: 220, remaining: 45 },
-  ],
-  '3': [
-    { id: 'tier-ga', name: 'General Admission', priceUsdc: 60, remaining: 800 },
-    { id: 'tier-early', name: 'Early Bird', priceUsdc: 45, remaining: 0 },
-  ],
-};
-
-const DEFAULT_TIERS: TicketTierOption[] = [
-  { id: 'tier-ga', name: 'General Admission', priceUsdc: 100, remaining: 200 },
-];
-
-function getTiersForEvent(eventId: string | undefined): TicketTierOption[] {
-  if (!eventId) return DEFAULT_TIERS;
-  return MOCK_TIERS_BY_EVENT[eventId] ?? DEFAULT_TIERS;
-}
 
 export default function CheckoutScreen() {
   const params = useLocalSearchParams<{ eventId?: string; eventTitle?: string }>();
   const router = useRouter();
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const checkout = useTicketCheckout();
 
   const eventId = params.eventId ?? '1';
   const eventTitle = params.eventTitle ?? 'Agora Event';
 
-  const tiers = useMemo(() => getTiersForEvent(eventId), [eventId]);
-  const firstAvailableTier = tiers.find((t) => t.remaining !== 0) ?? tiers[0];
+  const baseTiers = useMemo(() => getTiersForEvent(eventId), [eventId]);
+
+  // Live inventory: `tiers` is `baseTiers` with any remaining counts pushed
+  // by the server applied on top (issue #1010).
+  const { tiers, isLive } = useLiveTicketInventory({
+    eventId,
+    tiers: baseTiers,
+    token: token ?? undefined,
+  });
+
+  const firstAvailableTier = baseTiers.find((t) => t.remaining !== 0) ?? baseTiers[0];
 
   const [selectedTierId, setSelectedTierId] = useState<string>(firstAvailableTier?.id ?? '');
   const [quantity, setQuantity] = useState(1);
 
   const selectedTier = tiers.find((t) => t.id === selectedTierId) ?? null;
+  const isSelectedSoldOut = selectedTier?.remaining === 0;
   const maxQuantity = selectedTier?.remaining != null
     ? Math.max(1, Math.min(MAX_TICKETS_PER_ORDER, selectedTier.remaining))
     : MAX_TICKETS_PER_ORDER;
+
+  // A tier can sell out while the user is choosing a quantity; clamp rather
+  // than letting them submit an order larger than what is left.
+  React.useEffect(() => {
+    setQuantity((current) => Math.min(current, maxQuantity));
+  }, [maxQuantity]);
 
   const isModalVisible = checkout.phase === 'in-progress' || checkout.phase === 'error';
 
@@ -73,6 +60,10 @@ export default function CheckoutScreen() {
   const handleConfirm = async () => {
     if (!selectedTier) {
       Alert.alert('Select a ticket tier', 'Please choose a ticket tier before continuing.');
+      return;
+    }
+    if (isSelectedSoldOut) {
+      Alert.alert('Tier sold out', 'This ticket tier just sold out. Please choose another tier.');
       return;
     }
     if (!user?.walletAddress || user.walletAddress === 'GDAGORA...') {
@@ -110,6 +101,18 @@ export default function CheckoutScreen() {
       <Text style={styles.heading}>Select Tickets</Text>
       <Text style={styles.subheading}>{eventTitle}</Text>
 
+      {isLive ? (
+        <Text testID="live-inventory-indicator" style={styles.liveBadge}>
+          ● Live availability
+        </Text>
+      ) : null}
+
+      {isSelectedSoldOut ? (
+        <Text testID="tier-sold-out-notice" style={styles.soldOutNotice}>
+          This tier just sold out. Choose another tier to continue.
+        </Text>
+      ) : null}
+
       <View style={styles.section}>
         <Text style={styles.sectionLabel}>Ticket Tier</Text>
         <TierSelector
@@ -129,7 +132,7 @@ export default function CheckoutScreen() {
               onChange={setQuantity}
               min={1}
               max={maxQuantity}
-              disabled={checkout.isSubmitting}
+              disabled={checkout.isSubmitting || isSelectedSoldOut}
             />
           </View>
         </View>
@@ -149,9 +152,15 @@ export default function CheckoutScreen() {
 
       <Button
         testID="checkout-confirm-button"
-        title={checkout.isSubmitting ? 'Processing...' : 'Confirm & Pay with USDC'}
+        title={
+          isSelectedSoldOut
+            ? 'Sold Out'
+            : checkout.isSubmitting
+              ? 'Processing...'
+              : 'Confirm & Pay with USDC'
+        }
         onPress={handleConfirm}
-        disabled={!selectedTier || checkout.isSubmitting}
+        disabled={!selectedTier || checkout.isSubmitting || isSelectedSoldOut}
         loading={checkout.isSubmitting}
         style={styles.confirmButton}
       />
@@ -211,6 +220,17 @@ const styles = StyleSheet.create({
   },
   confirmButton: {
     marginTop: 4,
+  },
+  liveBadge: {
+    fontSize: 11,
+    color: Colors.primaryText,
+    marginTop: -18,
+    marginBottom: 18,
+  },
+  soldOutNotice: {
+    fontSize: 12,
+    color: Colors.primaryText,
+    marginBottom: 16,
   },
   disclaimer: {
     color: Colors.secondaryText,

--- a/apps/mobile/app/event/[id].tsx
+++ b/apps/mobile/app/event/[id].tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import Colors from '@/constants/Colors';
 import Button from '@/components/ui/Button';
+import { useAuth } from '@/hooks/useAuth';
+import { useLiveTicketInventory } from '@/hooks/useLiveTicketInventory';
+import { getTiersForEvent, totalRemaining } from '@/lib/ticketTiers';
 
 export default function EventDetailsScreen() {
   const { id } = useLocalSearchParams();
   const router = useRouter();
+  const { token } = useAuth();
 
   // Find simulated event details
   const getEventTitle = (eventId: string) => {
@@ -19,6 +23,18 @@ export default function EventDetailsScreen() {
   };
 
   const title = getEventTitle(id as string);
+  const eventId = (id as string) ?? '1';
+
+  // Live inventory so availability shown here matches checkout (issue #1010).
+  const baseTiers = useMemo(() => getTiersForEvent(eventId), [eventId]);
+  const { tiers, isLive } = useLiveTicketInventory({
+    eventId,
+    tiers: baseTiers,
+    token: token ?? undefined,
+  });
+
+  const remaining = totalRemaining(tiers);
+  const isSoldOut = remaining === 0;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -29,6 +45,13 @@ export default function EventDetailsScreen() {
       <View style={styles.detailsContainer}>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.price}>150 XLM</Text>
+
+        {remaining !== undefined ? (
+          <Text testID="event-remaining-tickets" style={styles.availability}>
+            {isSoldOut ? 'Sold out' : `${remaining} tickets remaining`}
+            {isLive ? ' • live' : ''}
+          </Text>
+        ) : null}
         
         <View style={styles.infoBlock}>
           <Text style={styles.label}>Date & Time</Text>
@@ -48,7 +71,9 @@ export default function EventDetailsScreen() {
         </View>
 
         <Button
-          title="Buy Tickets Now"
+          testID="event-buy-tickets-button"
+          title={isSoldOut ? 'Sold Out' : 'Buy Tickets Now'}
+          disabled={isSoldOut}
           onPress={() => {
             router.push({
               pathname: '/checkout',
@@ -118,6 +143,11 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: Colors.secondaryText,
     lineHeight: 20,
+  },
+  availability: {
+    fontSize: 13,
+    color: Colors.secondaryText,
+    marginTop: 6,
   },
   actionButton: {
     marginTop: 20,

--- a/apps/mobile/app/ticket/[id].tsx
+++ b/apps/mobile/app/ticket/[id].tsx
@@ -1,11 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { View, Text, StyleSheet, ScrollView, Modal, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
+import * as SecureStore from 'expo-secure-store';
 import Colors from '@/constants/Colors';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import { Keypair, Networks, TransactionBuilder, Horizon } from '@stellar/stellar-sdk';
 import { StellarWalletManager } from '@/services/stellar';
+
+/** How often the entry QR payload is re-signed. */
+const QR_REFRESH_INTERVAL_MS = 15000;
 
 export default function TicketDetailsScreen() {
   const { id } = useLocalSearchParams();
@@ -23,6 +27,11 @@ export default function TicketDetailsScreen() {
   const [sellError, setSellError] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
 
+  // Rotating entry QR payload (issue #1006). Regenerated on a timer so a
+  // screenshot of the code stops being valid shortly after it is taken.
+  const [qrPayload, setQrPayload] = useState<string | null>(null);
+  const qrTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
   // MOCK Ticket Details (consistent with `tickets.tsx` style)
   const ticket = {
     id: id || 'T-1004',
@@ -31,6 +40,36 @@ export default function TicketDetailsScreen() {
     seat: 'General Admission',
     txHash: '0x3f...b82d',
   };
+
+  const generateDynamicPayload = useCallback(async () => {
+    if (!id) return;
+    try {
+      // The secret is read only for the signing step and never held in state.
+      const privateKey = await SecureStore.getItemAsync('privateKey');
+      if (!privateKey) return;
+
+      // System time so the payload still refreshes offline.
+      const timestamp = Math.floor(Date.now() / 1000);
+      const payload = { ticketId: String(id), timestamp };
+      const payloadString = JSON.stringify(payload);
+
+      const keypair = Keypair.fromSecret(privateKey);
+      const signature = keypair.sign(Buffer.from(payloadString)).toString('base64');
+
+      setQrPayload(JSON.stringify({ ...payload, signature }));
+    } catch (e) {
+      console.error('Error generating ticket payload', e);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    generateDynamicPayload();
+    qrTimerRef.current = setInterval(generateDynamicPayload, QR_REFRESH_INTERVAL_MS);
+
+    return () => {
+      if (qrTimerRef.current) clearInterval(qrTimerRef.current);
+    };
+  }, [generateDynamicPayload]);
 
   const handleTransferSubmit = async () => {
     // Validate target string against Stellar public key constraints or email
@@ -148,6 +187,13 @@ export default function TicketDetailsScreen() {
         </View>
       </View>
 
+      <View style={styles.qrContainer}>
+        {/* Placeholder for the visual QR code; no QR library is available in
+            this app yet, so the signed payload is rendered directly. */}
+        <Text style={styles.qrPlaceholder}>[QR Code Placeholder]</Text>
+        <Text style={styles.payload}>{qrPayload}</Text>
+      </View>
+
       <View style={styles.actionsContainer}>
         <Button 
           title="Transfer Ticket" 
@@ -224,135 +270,6 @@ export default function TicketDetailsScreen() {
         </View>
       </Modal>
     </ScrollView>
-import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
-import * as SecureStore from 'expo-secure-store';
-import { Keypair } from '@stellar/stellar-sdk';
-
-interface Ticket {
-  id: string;
-  eventName: string;
-  date: string;
-  venue: string;
-  seat: string;
-}
-
-export default function TicketDetail() {
-  const { id } = useLocalSearchParams<{ id: string }>();
-  const [ticket, setTicket] = useState<Ticket | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [qrPayload, setQrPayload] = useState<string | null>(null);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-
-  const fetchTicket = useCallback(async () => {
-    try {
-      // Offline support: try to load from cache first
-      const cached = await SecureStore.getItemAsync('ticket_cache');
-      let tickets: Ticket[] = cached ? JSON.parse(cached) : [];
-
-      // Try to fetch from API if online
-      try {
-        const response = await fetch('/api/profile');
-        if (response.ok) {
-          const data = await response.json();
-          tickets = data.tickets || [];
-          await SecureStore.setItemAsync('ticket_cache', JSON.stringify(tickets));
-        }
-      } catch (e) {
-        // Offline: continue with cached tickets
-      }
-
-      const found = tickets.find((t) => t.id === id);
-      if (found) {
-        setTicket(found);
-      }
-    } catch (e) {
-      console.error('Error fetching ticket', e);
-    } finally {
-      setLoading(false);
-    }
-  }, [id]);
-
-  const generateDynamicPayload = useCallback(async () => {
-    if (!id) return;
-    try {
-      // Fetch private key from secure store ONLY for the signature process
-      const privateKey = await SecureStore.getItemAsync('privateKey');
-      if (!privateKey) {
-        console.error('No private key found');
-        return;
-      }
-
-      // Use system time (works offline)
-      const timestamp = Math.floor(Date.now() / 1000);
-      const payload = {
-        ticketId: id,
-        timestamp,
-      };
-
-      const payloadString = JSON.stringify(payload);
-      const keypair = Keypair.fromSecret(privateKey);
-      
-      // Cryptographic signature
-      const signatureBuffer = keypair.sign(Buffer.from(payloadString));
-      const signature = signatureBuffer.toString('base64');
-
-      setQrPayload(JSON.stringify({
-        ...payload,
-        signature
-      }));
-      
-      // Explicitly clear from memory by not keeping it in component state
-      // Garbage collection will handle the local variable cleanup.
-    } catch (e) {
-      console.error('Error generating payload', e);
-    }
-  }, [id]);
-
-  useEffect(() => {
-    fetchTicket();
-  }, [fetchTicket]);
-
-  useEffect(() => {
-    if (ticket) {
-      // Apply a high screen brightness configuration when displaying the QR code
-      // Note: Mocked because no screen brightness library could be introduced per constraints.
-      console.log('Setting screen brightness to maximum');
-      
-      generateDynamicPayload();
-      timerRef.current = setInterval(() => {
-        generateDynamicPayload();
-      }, 15000);
-
-      return () => {
-        if (timerRef.current) clearInterval(timerRef.current);
-        console.log('Restoring screen brightness');
-      };
-    }
-  }, [ticket, generateDynamicPayload]);
-
-  if (loading) {
-    return <ActivityIndicator style={styles.loader} />;
-  }
-
-  if (!ticket) {
-    return <Text style={styles.error}>Ticket not found.</Text>;
-  }
-
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{ticket.eventName}</Text>
-      <Text style={styles.detail}>Date: {ticket.date}</Text>
-      <Text style={styles.detail}>Venue: {ticket.venue}</Text>
-      <Text style={styles.detail}>Seat: {ticket.seat}</Text>
-      
-      <View style={styles.qrContainer}>
-        {/* Placeholder for visual QR Code, as a library could not be introduced per constraints */}
-        <Text style={styles.qrPlaceholder}>[QR Code Placeholder]</Text>
-        <Text style={styles.payload}>{qrPayload}</Text>
-      </View>
-    </View>
   );
 }
 
@@ -486,12 +403,28 @@ const styles = StyleSheet.create({
   cancelButton: {
     backgroundColor: '#2C2C2E',
   },
-  container: { flex: 1, padding: 20, alignItems: 'center', backgroundColor: '#fff' },
-  loader: { flex: 1, justifyContent: 'center' },
-  error: { marginTop: 20, fontSize: 16, color: 'red' },
-  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 10, textAlign: 'center' },
-  detail: { fontSize: 16, marginBottom: 5 },
-  qrContainer: { marginTop: 30, padding: 20, borderWidth: 1, borderColor: '#ccc', alignItems: 'center', width: '100%' },
-  qrPlaceholder: { fontSize: 18, fontWeight: 'bold', marginBottom: 10, textAlign: 'center' },
-  payload: { fontSize: 10, color: '#666', textAlign: 'center', marginTop: 10 }
+  // Entry-QR panel (issue #1006), restyled for this screen's dark surface.
+  qrContainer: {
+    marginBottom: 24,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: '#2C2C2E',
+    borderRadius: 12,
+    alignItems: 'center',
+    width: '100%',
+  },
+  qrPlaceholder: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    textAlign: 'center',
+    color: Colors.primaryText,
+  },
+  payload: {
+    fontSize: 10,
+    color: Colors.secondaryText,
+    textAlign: 'center',
+    marginTop: 10,
+  },
 });
+

--- a/apps/mobile/hooks/useLiveTicketInventory.ts
+++ b/apps/mobile/hooks/useLiveTicketInventory.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  InventorySocket,
+  applyInventoryUpdate,
+  type ConnectionStatus,
+  type InventoryUpdate,
+} from '@/utils/websocket';
+import type { TicketTierOption } from '@/types/checkout';
+
+/**
+ * Keeps a tier list in sync with live inventory (issue #1010).
+ *
+ * Opens an {@link InventorySocket} for `eventId` on mount, closes it on
+ * unmount, and folds incoming updates into the tier list. Only the `remaining`
+ * field is ever rewritten — identity, order, and pricing come from the caller,
+ * so a live update re-renders labels without resetting the screen's layout or
+ * the user's selection.
+ */
+export interface UseLiveTicketInventoryOptions {
+  eventId: string;
+  tiers: TicketTierOption[];
+  token?: string;
+  url?: string;
+  /** Set false to skip connecting entirely (e.g. screen not focused). */
+  enabled?: boolean;
+}
+
+export interface UseLiveTicketInventoryResult {
+  /** `tiers` with any live `remaining` counts applied. */
+  tiers: TicketTierOption[];
+  status: ConnectionStatus;
+  isLive: boolean;
+}
+
+export function useLiveTicketInventory({
+  eventId,
+  tiers,
+  token,
+  url,
+  enabled = true,
+}: UseLiveTicketInventoryOptions): UseLiveTicketInventoryResult {
+  const [remainingByTier, setRemainingByTier] = useState<Record<string, number>>({});
+  const [status, setStatus] = useState<ConnectionStatus>('idle');
+
+  // Held in a ref so the socket effect doesn't re-run whenever the caller
+  // passes a new array identity — reconnecting on every render would defeat
+  // the point.
+  const tiersRef = useRef(tiers);
+  tiersRef.current = tiers;
+
+  const handleUpdate = useCallback((update: InventoryUpdate) => {
+    setRemainingByTier((previous) => {
+      const knownRemaining =
+        previous[update.tierId] ??
+        tiersRef.current.find((tier) => tier.id === update.tierId)?.remaining;
+
+      const next = applyInventoryUpdate(knownRemaining, update);
+      if (next === undefined || next === previous[update.tierId]) return previous;
+
+      return { ...previous, [update.tierId]: next };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !eventId) {
+      setStatus('idle');
+      return;
+    }
+
+    // A different event means the previously accumulated counts no longer apply.
+    setRemainingByTier({});
+
+    const socket = new InventorySocket({
+      eventId,
+      token,
+      url,
+      onUpdate: handleUpdate,
+      onStatusChange: setStatus,
+    });
+    socket.connect();
+
+    return () => socket.close();
+  }, [eventId, token, url, enabled, handleUpdate]);
+
+  const mergedTiers = useMemo(() => {
+    if (Object.keys(remainingByTier).length === 0) return tiers;
+
+    return tiers.map((tier) =>
+      remainingByTier[tier.id] !== undefined
+        ? { ...tier, remaining: remainingByTier[tier.id] }
+        : tier,
+    );
+  }, [tiers, remainingByTier]);
+
+  return {
+    tiers: mergedTiers,
+    status,
+    isLive: status === 'connected',
+  };
+}

--- a/apps/mobile/hooks/useTicketCheckout.ts
+++ b/apps/mobile/hooks/useTicketCheckout.ts
@@ -99,17 +99,31 @@ function checkoutReducer(state: CheckoutState, action: CheckoutAction): Checkout
         ),
       };
 
-    case 'FAILURE':
+    case 'FAILURE': {
+      // A failure can land before any step goes active — the very first call
+      // throwing, for instance. Without a fallback the modal would show an
+      // error phase with every step still pending and no marker for where it
+      // broke, so the first unfinished step is flagged instead.
+      const hasExplicitTarget = state.steps.some(
+        (step) =>
+          (action.stepId != null && step.id === action.stepId) || step.status === 'active'
+      );
+      const firstUnfinishedIndex = state.steps.findIndex((step) => step.status !== 'done');
+
       return {
         ...state,
         phase: 'error',
         errorMessage: action.message,
-        steps: state.steps.map((step) => {
+        steps: state.steps.map((step, index) => {
           if (action.stepId && step.id === action.stepId) return { ...step, status: 'error' };
           if (step.status === 'active') return { ...step, status: 'error' };
+          if (!hasExplicitTarget && index === firstUnfinishedIndex) {
+            return { ...step, status: 'error' };
+          }
           return step;
         }),
       };
+    }
 
     case 'SUCCESS':
       return {
@@ -231,7 +245,7 @@ export function useTicketCheckout(): UseTicketCheckoutResult {
           paymentTxHash: purchaseResult.paymentTxHash,
         });
         ticketId = recorded.ticketId;
-      } catch (recordError) {
+      } catch (_recordError) {
         // The purchase is fully confirmed on-chain at this point — losing the
         // backend write is a data-sync problem, not a failed purchase. Surface
         // a receipt anyway so the buyer isn't told their money vanished, but

--- a/apps/mobile/lib/ticketTiers.ts
+++ b/apps/mobile/lib/ticketTiers.ts
@@ -1,0 +1,55 @@
+import type { TicketTierOption } from '@/types/checkout';
+
+/**
+ * Ticket tier catalogue keyed by event id.
+ *
+ * The event/pricing endpoints this would normally come from aren't wired up in
+ * the mobile client yet, so this mirrors the mock-data convention already used
+ * by `app/event/[id].tsx` and `app/ticket/[id].tsx` until a real
+ * `/api/events/:id/tiers` call replaces it.
+ *
+ * Lives here rather than in the checkout screen so the event detail screen can
+ * show the same availability the checkout screen will (issue #1010).
+ */
+const MOCK_TIERS_BY_EVENT: Record<string, TicketTierOption[]> = {
+  '1': [
+    { id: 'tier-ga', name: 'General Admission', priceUsdc: 150, remaining: 340 },
+    {
+      id: 'tier-vip',
+      name: 'VIP',
+      description: 'Front-row seating + backstage pass',
+      priceUsdc: 450,
+      remaining: 12,
+    },
+  ],
+  '2': [
+    { id: 'tier-ga', name: 'General Admission', priceUsdc: 80, remaining: 500 },
+    { id: 'tier-pro', name: 'Pro Pass', description: 'Includes workshop access', priceUsdc: 220, remaining: 45 },
+  ],
+  '3': [
+    { id: 'tier-ga', name: 'General Admission', priceUsdc: 60, remaining: 800 },
+    { id: 'tier-early', name: 'Early Bird', priceUsdc: 45, remaining: 0 },
+  ],
+};
+
+export const DEFAULT_TIERS: TicketTierOption[] = [
+  { id: 'tier-ga', name: 'General Admission', priceUsdc: 100, remaining: 200 },
+];
+
+export function getTiersForEvent(eventId: string | undefined): TicketTierOption[] {
+  if (!eventId) return DEFAULT_TIERS;
+  return MOCK_TIERS_BY_EVENT[eventId] ?? DEFAULT_TIERS;
+}
+
+/**
+ * Total tickets left across all tiers, or undefined when no tier reports a
+ * count (so callers can distinguish "sold out" from "unknown").
+ */
+export function totalRemaining(tiers: TicketTierOption[]): number | undefined {
+  const counts = tiers
+    .map((tier) => tier.remaining)
+    .filter((value): value is number => typeof value === 'number');
+
+  if (counts.length === 0) return undefined;
+  return counts.reduce((sum, value) => sum + value, 0);
+}

--- a/apps/mobile/services/sorobanClient.ts
+++ b/apps/mobile/services/sorobanClient.ts
@@ -337,7 +337,7 @@ export async function pollTransactionUntilFinal(
     let response: rpc.Api.GetTransactionResponse;
     try {
       response = await server.getTransaction(hash);
-    } catch (error) {
+    } catch (_error) {
       // Transient network hiccup while polling — keep retrying rather than
       // failing the whole checkout on one dropped request.
       await delay(intervalMs);

--- a/apps/mobile/utils/websocket.ts
+++ b/apps/mobile/utils/websocket.ts
@@ -1,0 +1,303 @@
+/**
+ * Real-time inventory WebSocket client (issue #1010).
+ *
+ * Wraps the platform `WebSocket` with the things every screen needs and none
+ * of them should reimplement: room registration, exponential-backoff
+ * reconnection, and parsing of inventory messages into a single normalised
+ * shape.
+ *
+ * ## Message formats
+ *
+ * The Rust backend (`server/src/handlers/ws.rs`) broadcasts *purchase deltas*:
+ *
+ * ```json
+ * { "event_id": "...", "ticket_tier_id": "...", "quantity": 2,
+ *   "amount": 300.0, "currency": "USDC", "purchased_at": "..." }
+ * ```
+ *
+ * The issue additionally specifies payloads carrying *updated remaining
+ * counts*. Both are accepted: a delta decrements the local count, an absolute
+ * count replaces it. That keeps this client working against the backend as it
+ * exists today without needing a change when authoritative counts are added.
+ */
+
+/** A normalised inventory update, whichever wire format produced it. */
+export interface InventoryUpdate {
+  eventId: string;
+  tierId: string;
+  /** Authoritative remaining count, when the server sent one. */
+  remaining?: number;
+  /** Number of tickets just sold, when the server sent a delta. */
+  soldDelta?: number;
+}
+
+export type ConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'closed';
+
+export interface InventorySocketOptions {
+  /** Event room to register for. Updates for other events are ignored. */
+  eventId: string;
+  /** Overrides the default endpoint; useful in tests and for staging. */
+  url?: string;
+  /** Bearer token — the backend rejects the upgrade without one. */
+  token?: string;
+  onUpdate?: (update: InventoryUpdate) => void;
+  onStatusChange?: (status: ConnectionStatus) => void;
+  /** Injectable for tests; defaults to the global `WebSocket`. */
+  socketFactory?: (url: string) => WebSocketLike;
+}
+
+/**
+ * The slice of the `WebSocket` API this client uses. Declared structurally so
+ * tests can supply a double without a DOM lib dependency.
+ */
+export interface WebSocketLike {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: ((event: unknown) => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+  onclose: ((event: unknown) => void) | null;
+}
+
+const DEFAULT_WS_URL =
+  process.env.EXPO_PUBLIC_WS_URL ?? 'ws://localhost:3001/api/v1/ws/purchases';
+
+/** Backoff schedule: 1s, 2s, 4s, 8s, 16s, then hold at 30s. */
+export const INITIAL_RECONNECT_DELAY_MS = 1000;
+export const MAX_RECONNECT_DELAY_MS = 30000;
+
+/**
+ * Delay before reconnect attempt `attempt` (0-based), doubling each time and
+ * capped so a long outage doesn't push the retry interval to hours.
+ */
+export function backoffDelay(attempt: number): number {
+  const exponential = INITIAL_RECONNECT_DELAY_MS * 2 ** Math.max(0, attempt);
+  return Math.min(exponential, MAX_RECONNECT_DELAY_MS);
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Parses a raw frame into an `InventoryUpdate`.
+ *
+ * Returns null for anything unrecognised — malformed JSON, heartbeats, or
+ * messages for other channels — so callers can ignore them without
+ * distinguishing "broken" from "not for me". Exported for direct testing.
+ */
+export function parseInventoryMessage(raw: unknown): InventoryUpdate | null {
+  if (typeof raw !== 'string') return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (typeof payload !== 'object' || payload === null) return null;
+  const data = payload as Record<string, unknown>;
+
+  // Accept snake_case (Rust backend) and camelCase (JS producers) alike.
+  const eventId = asNonEmptyString(data.event_id) ?? asNonEmptyString(data.eventId);
+  const tierId =
+    asNonEmptyString(data.ticket_tier_id) ??
+    asNonEmptyString(data.tierId) ??
+    asNonEmptyString(data.tier_id);
+
+  if (!eventId || !tierId) return null;
+
+  const remaining =
+    asFiniteNumber(data.remaining) ??
+    asFiniteNumber(data.remaining_tickets) ??
+    asFiniteNumber(data.remainingTickets);
+
+  const soldDelta = asFiniteNumber(data.quantity) ?? asFiniteNumber(data.sold);
+
+  // A message that identifies a tier but carries neither a count nor a delta
+  // tells us nothing actionable.
+  if (remaining === undefined && soldDelta === undefined) return null;
+
+  return {
+    eventId,
+    tierId,
+    ...(remaining !== undefined ? { remaining: Math.max(0, Math.trunc(remaining)) } : {}),
+    ...(soldDelta !== undefined ? { soldDelta: Math.max(0, Math.trunc(soldDelta)) } : {}),
+  };
+}
+
+/**
+ * Applies an update to a known remaining count.
+ *
+ * An absolute `remaining` wins over a delta, since it is authoritative. The
+ * result never goes below zero. Returns `current` unchanged when the update
+ * carries nothing usable.
+ */
+export function applyInventoryUpdate(
+  current: number | undefined,
+  update: InventoryUpdate,
+): number | undefined {
+  if (update.remaining !== undefined) return update.remaining;
+  if (update.soldDelta !== undefined && current !== undefined) {
+    return Math.max(0, current - update.soldDelta);
+  }
+  return current;
+}
+
+function buildUrl(baseUrl: string, token?: string): string {
+  if (!token) return baseUrl;
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}token=${encodeURIComponent(token)}`;
+}
+
+/**
+ * A reconnecting inventory socket scoped to one event.
+ *
+ * Lifecycle is explicit — `connect()` / `close()` — so a screen can tie it to
+ * mount/unmount without the class guessing. After `close()` the instance stays
+ * closed; reconnection only happens for drops it did not initiate.
+ */
+export class InventorySocket {
+  private socket: WebSocketLike | null = null;
+  private status: ConnectionStatus = 'idle';
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private manuallyClosed = false;
+
+  constructor(private readonly options: InventorySocketOptions) {}
+
+  getStatus(): ConnectionStatus {
+    return this.status;
+  }
+
+  private setStatus(next: ConnectionStatus): void {
+    if (this.status === next) return;
+    this.status = next;
+    this.options.onStatusChange?.(next);
+  }
+
+  connect(): void {
+    if (this.socket || this.manuallyClosed) return;
+
+    this.setStatus(this.reconnectAttempt === 0 ? 'connecting' : 'reconnecting');
+
+    const url = buildUrl(this.options.url ?? DEFAULT_WS_URL, this.options.token);
+    const factory =
+      this.options.socketFactory ??
+      ((target: string) => new WebSocket(target) as unknown as WebSocketLike);
+
+    let socket: WebSocketLike;
+    try {
+      socket = factory(url);
+    } catch {
+      // A synchronous constructor throw (bad URL, no network stack) is treated
+      // like any other drop so the backoff still applies.
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.socket = socket;
+
+    socket.onopen = () => {
+      this.reconnectAttempt = 0;
+      this.setStatus('connected');
+      this.subscribe();
+    };
+
+    socket.onmessage = (event: { data: unknown }) => {
+      const update = parseInventoryMessage(event?.data);
+      // The backend broadcasts globally, so filter to this screen's event.
+      if (!update || update.eventId !== this.options.eventId) return;
+      this.options.onUpdate?.(update);
+    };
+
+    socket.onerror = () => {
+      // `onclose` always follows; reconnection is handled there so a single
+      // failure cannot schedule two attempts.
+    };
+
+    socket.onclose = () => {
+      this.socket = null;
+      if (this.manuallyClosed) {
+        this.setStatus('closed');
+        return;
+      }
+      this.scheduleReconnect();
+    };
+  }
+
+  /**
+   * Registers for this event's room. The current backend broadcasts to every
+   * client and ignores unknown frames, so this is forward-compatible rather
+   * than required today — client-side filtering in `onmessage` is what
+   * actually scopes the stream.
+   */
+  private subscribe(): void {
+    try {
+      this.socket?.send(
+        JSON.stringify({ type: 'subscribe', eventId: this.options.eventId }),
+      );
+    } catch {
+      // A send failure means the socket is already gone; `onclose` will fire.
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.manuallyClosed || this.reconnectTimer) return;
+
+    const delay = backoffDelay(this.reconnectAttempt);
+    this.reconnectAttempt += 1;
+    this.setStatus('reconnecting');
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  /** Closes the socket and stops reconnecting. Safe to call more than once. */
+  close(): void {
+    this.manuallyClosed = true;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    const socket = this.socket;
+    this.socket = null;
+
+    if (socket) {
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onerror = null;
+      socket.onclose = null;
+      try {
+        socket.close();
+      } catch {
+        // Already closed — nothing to do.
+      }
+    }
+
+    this.setStatus('closed');
+  }
+}
+
+/** Convenience factory: constructs and immediately connects. */
+export function createInventorySocket(
+  options: InventorySocketOptions,
+): InventorySocket {
+  const socket = new InventorySocket(options);
+  socket.connect();
+  return socket;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: ^16.1.3
-        version: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -187,6 +187,9 @@ importers:
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      '@stellar/freighter-api':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@stellar/stellar-sdk':
         specifier: ^13.3.0
         version: 13.3.0
@@ -204,7 +207,7 @@ importers:
         version: 1.9.4
       next:
         specifier: 16.1.3
-        version: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
@@ -239,12 +242,15 @@ importers:
         specifier: 3.24.4
         version: 3.24.4
     devDependencies:
+      '@playwright/test':
+        specifier: 1.49.1
+        version: 1.49.1
       '@storybook/addon-docs':
         specifier: ^10.5.3
         version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/nextjs-vite':
         specifier: 10.5.3
-        version: 10.5.3(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/react':
         specifier: ^10.5.3
         version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)
@@ -2133,6 +2139,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.49.1':
+    resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@posthog/core@1.42.1':
     resolution: {integrity: sha512-cZojBmvf92gZAn0MGf/J2S+3t2sZqb9E2/6mjY4jJsImwz7PuYqdNj870Wx2iwwlf++wfhRuH4K4bpDy9GIoCA==}
 
@@ -2671,6 +2682,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stellar/freighter-api@2.0.0':
+    resolution: {integrity: sha512-j/R7MLPL8S3QhwOEdAxSl7MgWBTXWlOXQKQyXR8mPk1JMKKR4tF8e4U+Fs9TPQH0HZoYqfVDvLOOUrTMMY058Q==}
 
   '@stellar/js-xdr@3.1.2':
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
@@ -5251,6 +5265,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7397,6 +7416,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.49.1:
+    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.49.1:
+    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -11497,6 +11526,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.49.1':
+    dependencies:
+      playwright: 1.49.1
+
   '@posthog/core@1.42.1':
     dependencies:
       '@posthog/types': 1.395.0
@@ -12313,6 +12346,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@stellar/freighter-api@2.0.0': {}
+
   '@stellar/js-xdr@3.1.2': {}
 
   '@stellar/stellar-base@13.1.0':
@@ -12389,18 +12424,18 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@storybook/nextjs-vite@10.5.3(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@storybook/nextjs-vite@10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@storybook/builder-vite': 10.5.3(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/react': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
-      next: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -14674,7 +14709,7 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -14707,7 +14742,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -14721,7 +14756,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15361,6 +15396,9 @@ snapshots:
       minipass: 7.1.3
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -17625,7 +17663,7 @@ snapshots:
 
   new-github-issue-url@0.2.1: {}
 
-  next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
@@ -17634,7 +17672,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.3
       '@next/swc-darwin-x64': 16.1.3
@@ -17645,6 +17683,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.1.3
       '@next/swc-win32-x64-msvc': 16.1.3
       '@opentelemetry/api': 1.4.1
+      '@playwright/test': 1.49.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -18073,6 +18112,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.0
       pathe: 2.0.3
+
+  playwright-core@1.49.1: {}
+
+  playwright@1.49.1:
+    dependencies:
+      playwright-core: 1.49.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:
@@ -19338,12 +19385,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
+  styled-jsx@5.1.6(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
-    optionalDependencies:
-      '@babel/core': 7.29.7
 
   styleq@0.1.3: {}
 
@@ -19951,13 +19996,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3)
       ts-dedent: 2.3.0
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)


### PR DESCRIPTION
Closes #1010

## What this adds

**`utils/websocket.ts`** — a reconnecting inventory socket:
- Registers for the event room on open and re-registers after every reconnect.
- Exponential backoff: 1s doubling to a 30s cap, reset once a connection succeeds. A synchronous constructor throw (no network stack) is treated like any other drop, so it backs off rather than failing silently.
- `close()` is terminal — listeners are detached first, so a drop arriving afterwards cannot schedule a reconnect. Safe to call twice.
- Parsing is total: malformed JSON, heartbeats, and frames for other channels all return null rather than throwing.

**`hooks/useLiveTicketInventory.ts`** — folds updates into a tier list. Only `remaining` is ever rewritten, so tier identity, ordering, pricing, and the user's current selection survive an update — that's the "without layout reset" criterion. The tier list is held in a ref so a new array identity from the caller doesn't tear down and rebuild the socket.

**Screens** — both the checkout and event detail screens are wired up. When the selected tier sells out mid-session the quantity stepper and confirm button disable, the button reads "Sold Out", an over-large quantity is clamped down, and submission is blocked with an explanatory alert. `TierSelector` already rendered sold-out state, so it needed no change.

**`lib/ticketTiers.ts`** — the tier catalogue moved out of the checkout screen so both screens read one source.

## Deviation from the issue — please confirm

The issue specifies `ws://localhost:3001/ws`, an event-room subscription, and payloads carrying "updated remaining ticket counts". The backend (`server/src/handlers/ws.rs`) actually:

- serves **`/api/v1/ws/purchases`**, and **requires a JWT** (query param or header) — it 401s the upgrade otherwise;
- has **no room protocol** — it is a global `tokio::broadcast` to every connected client;
- sends **purchase deltas** (`event_id`, `ticket_tier_id`, `quantity`, …), not remaining counts.

Rather than build against an endpoint that does not exist, the client:

- defaults to `ws://localhost:3001/api/v1/ws/purchases`, overridable via `EXPO_PUBLIC_WS_URL`;
- passes the auth token from `useAuth` as `?token=`;
- **accepts both shapes** — a delta decrements the local count, an absolute `remaining` replaces it — so it works today and needs no change when authoritative counts arrive;
- sends a `{"type":"subscribe","eventId":…}` frame (the server ignores unknown frames) **and** filters by `event_id` client-side, which is what actually scopes the stream today.

Tell me if you'd rather I target a different endpoint.

## Mobile CI

`typecheck`, `lint`, and `test` all pass locally — **149 tests across 18 suites**.

They did **not** pass on `main` before this PR, and Mobile CI runs on any change under `apps/mobile/**`, so this branch would have been red regardless. Fixing that was in scope for "make mobile CI pass":

| Pre-existing failure | Fix |
| --- | --- |
| **`app/ticket/[id].tsx` was syntactically invalid** — the merge in `d951fc9` concatenated two entire components, giving the file two `export default`s and JSX cut off mid-return. `tsc` failed with `TS1005`. | The resale/transfer screen (#1009) and the signed entry-QR panel (#1006) are merged into the single screen that merge intended. Both features are preserved: the QR panel keeps its 15s re-signing timer and now renders on the resale screen. A duplicate `container` style key — which would have overridden the dark background with a white one — is gone. |
| `useTicketCheckout.ts` and `sorobanClient.ts` had unused caught bindings, failing `@typescript-eslint/no-unused-vars` | Renamed to `_recordError` / `_error` |
| `useTicketCheckout` marked **no step as errored** when the failure landed before any step went active, so the progress modal showed an error phase with every step still pending and no indication of where it broke | `FAILURE` now flags the first unfinished step when there's no explicit target |
| The checkout screen test asserted the event title with `getByText`, but the screen legitimately renders it twice (subheading + order summary) | Switched to `getAllByText(...).length` |

Test count went from 111 passing / 2 failing to 149 passing / 0 failing.

## Not covered

- **`app/ticket/[id].tsx` deserves a real review.** I merged two independently-developed screens from a botched merge commit; the result compiles, lints, and matches both original implementations, but there is no test over that screen and I'm guessing at the intended combined layout. If you'd rather keep them separate, or lay it out differently, say so.
- **Not verified against a live server.** All socket tests drive an injected double, so the reconnect and subscribe behaviour is proven against the contract I wrote, not against the running backend. Once the tier/remaining data comes from a real endpoint instead of `lib/ticketTiers.ts`, an end-to-end pass is worth doing.
- The tier catalogue is still mock data — I kept the existing convention rather than wiring an events API, which is out of scope here.
