### PR TITLE
feat: add USDC price converter utility and PriceTag component

### DIFF
--- a/apps/web/__tests__/price-tag.test.tsx
+++ b/apps/web/__tests__/price-tag.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PriceTag } from "@/components/ui/PriceTag";
+import * as usdcRateModule from "@/utils/usdc-rate";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockRate(
+  rate: number,
+  isFallback = false,
+  currency: usdcRateModule.FiatCurrency = "usd",
+) {
+  vi.spyOn(usdcRateModule, "fetchUsdcRate").mockResolvedValue({
+    rate,
+    isFallback,
+    currency,
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PriceTag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  // ── USDC display ────────────────────────────────────────────────────────────
+
+  it("displays the USDC amount formatted to 2 decimal places", async () => {
+    mockRate(1.0);
+    render(<PriceTag amountUsdc={25} />);
+    expect(screen.getByText(/25\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/USDC/)).toBeInTheDocument();
+  });
+
+  it("formats zero USDC correctly", async () => {
+    mockRate(1.0);
+    render(<PriceTag amountUsdc={0} />);
+    expect(screen.getByText(/0\.00/)).toBeInTheDocument();
+  });
+
+  it("formats fractional USDC amounts correctly", async () => {
+    mockRate(1.0);
+    render(<PriceTag amountUsdc={9.5} />);
+    expect(screen.getByText(/9\.50/)).toBeInTheDocument();
+  });
+
+  // ── Fiat conversion display ─────────────────────────────────────────────────
+
+  it("displays converted USD amount after rate loads", async () => {
+    mockRate(1.001, false, "usd");
+    render(<PriceTag amountUsdc={25} currency="usd" />);
+    await waitFor(() =>
+      expect(screen.getByText(/\$25\.03/)).toBeInTheDocument(),
+    );
+    // The fiat span contains "USD" (not "USDC"), check via the aria-label on the root
+    expect(screen.getByLabelText(/approximately \$25\.03 USD/i)).toBeInTheDocument();
+  });
+
+  it("displays converted EUR amount after rate loads", async () => {
+    mockRate(0.924, false, "eur");
+    render(<PriceTag amountUsdc={100} currency="eur" />);
+    await waitFor(() =>
+      expect(screen.getByText(/€92\.40/)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/EUR/)).toBeInTheDocument();
+  });
+
+  it("rounds rounding-error-prone values safely", async () => {
+    // 10 * 0.333 = 3.33, not 3.330000000000001
+    mockRate(0.333, false, "usd");
+    render(<PriceTag amountUsdc={10} currency="usd" />);
+    await waitFor(() =>
+      expect(screen.getByText(/\$3\.33/)).toBeInTheDocument(),
+    );
+  });
+
+  // ── Loading skeleton ─────────────────────────────────────────────────────────
+
+  it("shows a loading state before the rate resolves", () => {
+    // Never-resolving promise simulates a slow network
+    vi.spyOn(usdcRateModule, "fetchUsdcRate").mockReturnValue(
+      new Promise(() => {}),
+    );
+    render(<PriceTag amountUsdc={25} />);
+    // The skeleton is inside an aria-hidden span, so we need hidden:true
+    expect(
+      screen.getByRole("status", { hidden: true }),
+    ).toBeInTheDocument();
+  });
+
+  // ── Fallback notice ─────────────────────────────────────────────────────────
+
+  it("shows (est.) indicator when rate is a fallback", async () => {
+    mockRate(1.0, true, "usd");
+    render(<PriceTag amountUsdc={25} currency="usd" />);
+    await waitFor(() =>
+      expect(screen.getByText(/\(est\.\)/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("does not show (est.) indicator when rate is live", async () => {
+    mockRate(1.001, false, "usd");
+    render(<PriceTag amountUsdc={25} currency="usd" />);
+    await waitFor(() =>
+      expect(screen.queryByText(/\(est\.\)/i)).not.toBeInTheDocument(),
+    );
+  });
+
+  // ── Accessible label ─────────────────────────────────────────────────────────
+
+  it("includes an accessible aria-label with the full price information", async () => {
+    mockRate(1.001, false, "usd");
+    render(<PriceTag amountUsdc={25} currency="usd" />);
+    await waitFor(() => {
+      const el = screen.getByLabelText(/25\.00 USDC/i);
+      expect(el).toBeInTheDocument();
+    });
+  });
+
+  // ── className forwarding ─────────────────────────────────────────────────────
+
+  it("applies custom className to the root element", async () => {
+    mockRate(1.0);
+    const { container } = render(
+      <PriceTag amountUsdc={10} className="my-custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("my-custom-class");
+  });
+});

--- a/apps/web/__tests__/usdc-rate.test.ts
+++ b/apps/web/__tests__/usdc-rate.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { convertUsdcToFiat } from "@/utils/usdc-rate";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const MOCK_API_RESPONSE = {
+  "usd-coin": { usd: 1.001, eur: 0.924 },
+};
+
+function mockFetch(
+  response: unknown,
+  status = 200,
+  ok = true,
+): ReturnType<typeof vi.fn> {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Internal Server Error",
+    json: async () => response,
+  }));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("convertUsdcToFiat", () => {
+  it("converts USDC to USD using provided rate", () => {
+    expect(convertUsdcToFiat(25, 1.0)).toBe(25.0);
+    expect(convertUsdcToFiat(25, 1.001)).toBe(25.03);
+  });
+
+  it("converts USDC to EUR using provided rate", () => {
+    expect(convertUsdcToFiat(100, 0.924)).toBe(92.4);
+  });
+
+  it("rounds correctly to 2 decimal places", () => {
+    // 10 * 0.333 = 3.33 (not 3.330000000000001)
+    expect(convertUsdcToFiat(10, 0.333)).toBe(3.33);
+  });
+
+  it("supports custom decimal precision", () => {
+    expect(convertUsdcToFiat(10, 1.0, 4)).toBe(10.0);
+    expect(convertUsdcToFiat(10, 1.001, 3)).toBe(10.01);
+  });
+
+  it("returns 0 for 0 USDC input", () => {
+    expect(convertUsdcToFiat(0, 1.001)).toBe(0);
+  });
+});
+
+describe("fetchUsdcRate", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Reset the module-level cache between tests by re-importing fresh
+    vi.stubGlobal("fetch", mockFetch(MOCK_API_RESPONSE));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns USD rate from CoinGecko API", async () => {
+    vi.stubGlobal("fetch", mockFetch(MOCK_API_RESPONSE));
+
+    // Use dynamic import to bypass the module-level cache
+    const { fetchUsdcRate: freshFetch } = await import("@/utils/usdc-rate");
+    const result = await freshFetch("usd");
+
+    expect(result.currency).toBe("usd");
+    expect(result.isFallback).toBe(false);
+    expect(typeof result.rate).toBe("number");
+  });
+
+  it("returns EUR rate from CoinGecko API", async () => {
+    vi.stubGlobal("fetch", mockFetch(MOCK_API_RESPONSE));
+
+    const { fetchUsdcRate: freshFetch } = await import("@/utils/usdc-rate");
+    const result = await freshFetch("eur");
+
+    expect(result.currency).toBe("eur");
+    expect(result.isFallback).toBe(false);
+    expect(typeof result.rate).toBe("number");
+  });
+
+  it("falls back to USD rate of 1.0 when fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("Network Error");
+      }),
+    );
+
+    const { fetchUsdcRate: freshFetch } = await import("@/utils/usdc-rate");
+    const result = await freshFetch("usd");
+
+    expect(result.isFallback).toBe(true);
+    expect(result.rate).toBe(1.0);
+    expect(result.currency).toBe("usd");
+  });
+
+  it("falls back to EUR rate of 0.92 when fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("Network Error");
+      }),
+    );
+
+    const { fetchUsdcRate: freshFetch } = await import("@/utils/usdc-rate");
+    const result = await freshFetch("eur");
+
+    expect(result.isFallback).toBe(true);
+    expect(result.rate).toBe(0.92);
+    expect(result.currency).toBe("eur");
+  });
+
+  it("falls back when API returns non-ok response", async () => {
+    vi.stubGlobal("fetch", mockFetch({}, 503, false));
+
+    const { fetchUsdcRate: freshFetch } = await import("@/utils/usdc-rate");
+    const result = await freshFetch("usd");
+
+    expect(result.isFallback).toBe(true);
+  });
+
+  it("falls back when API returns unexpected shape", async () => {
+    vi.stubGlobal("fetch", mockFetch({ unexpected: "shape" }));
+
+    const { fetchUsdcRate: freshFetch } = await import("@/utils/usdc-rate");
+    const result = await freshFetch("usd");
+
+    expect(result.isFallback).toBe(true);
+  });
+
+  it("re-throws AbortError so callers can handle cancellation", async () => {
+    const abortError = new DOMException("Aborted", "AbortError");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw abortError;
+      }),
+    );
+
+    const { fetchUsdcRate: freshFetch } = await import("@/utils/usdc-rate");
+    await expect(freshFetch("usd")).rejects.toThrow("Aborted");
+  });
+});

--- a/apps/web/components/ui/PriceTag.tsx
+++ b/apps/web/components/ui/PriceTag.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  convertUsdcToFiat,
+  fetchUsdcRate,
+  type FiatCurrency,
+} from "@/utils/usdc-rate";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PriceTagProps {
+  /** Amount expressed in USDC (e.g. 25 for 25 USDC). */
+  amountUsdc: number;
+  /**
+   * Fiat currency to display alongside the USDC price.
+   * Defaults to "usd".
+   */
+  currency?: FiatCurrency;
+  /**
+   * Additional Tailwind classes to apply to the root wrapper element.
+   * Useful for spacing in parent layouts.
+   */
+  className?: string;
+}
+
+// ─── Currency symbols ─────────────────────────────────────────────────────────
+
+const CURRENCY_SYMBOL: Record<FiatCurrency, string> = {
+  usd: "$",
+  eur: "€",
+};
+
+const CURRENCY_LABEL: Record<FiatCurrency, string> = {
+  usd: "USD",
+  eur: "EUR",
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * PriceTag
+ *
+ * Displays a USDC amount and its approximate fiat value beneath it.
+ *
+ * ```tsx
+ * <PriceTag amountUsdc={25} currency="usd" />
+ * // → "25.00 USDC"
+ * //   "≈ $25.01 USD"
+ * ```
+ *
+ * The fiat conversion is fetched from CoinGecko and cached for 5 minutes.
+ * If the fetch fails the component falls back to a sensible default rate
+ * and signals this to the user with a "(est.)" annotation.
+ */
+export function PriceTag({
+  amountUsdc,
+  currency = "usd",
+  className = "",
+}: PriceTagProps) {
+  const [fiatAmount, setFiatAmount] = useState<number | null>(null);
+  const [isFallback, setIsFallback] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    // Cancel any in-flight request when props change or component unmounts
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+
+    fetchUsdcRate(currency, controller.signal)
+      .then((result) => {
+        setFiatAmount(convertUsdcToFiat(amountUsdc, result.rate));
+        setIsFallback(result.isFallback);
+      })
+      .catch((err: unknown) => {
+        // AbortError fires when the component unmounts – ignore silently
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        // Any other unexpected error: keep the UI in a clean fallback state
+        console.error("[PriceTag] Unexpected error fetching USDC rate:", err);
+        setFiatAmount(convertUsdcToFiat(amountUsdc, currency === "eur" ? 0.92 : 1.0));
+        setIsFallback(true);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [amountUsdc, currency]);
+
+  // ── Derived display values ──────────────────────────────────────────────────
+
+  // USDC uses 7 decimal places on-chain, but we display 2 for readability
+  const usdcDisplay = amountUsdc.toFixed(2);
+
+  const symbol = CURRENCY_SYMBOL[currency];
+  const label = CURRENCY_LABEL[currency];
+
+  const fiatDisplay =
+    fiatAmount !== null ? fiatAmount.toFixed(2) : null;
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      className={`inline-flex flex-col gap-0.5 ${className}`}
+      // Accessible label so screen readers announce the full price upfront
+      aria-label={`${usdcDisplay} USDC${fiatDisplay !== null ? `, approximately ${symbol}${fiatDisplay} ${label}` : ""}`}
+    >
+      {/* Primary: USDC amount */}
+      <span className="font-semibold text-[20px] leading-tight text-black">
+        {usdcDisplay}{" "}
+        <span className="text-[14px] font-medium text-black/60">USDC</span>
+      </span>
+
+      {/* Secondary: fiat conversion */}
+      <span
+        className="text-[13px] leading-snug text-black/50 font-normal"
+        aria-hidden="true"
+      >
+        {isLoading ? (
+          // Skeleton shimmer while the rate is loading
+          <span
+            className="inline-block h-3.5 w-24 rounded bg-black/10 animate-pulse"
+            role="status"
+            aria-label="Loading conversion rate"
+          />
+        ) : fiatDisplay !== null ? (
+          <>
+            ≈&nbsp;{symbol}
+            {fiatDisplay}&nbsp;{label}
+            {isFallback && (
+              <span
+                className="ml-1 text-black/35"
+                title="Live rate unavailable – using estimated value"
+              >
+                (est.)
+              </span>
+            )}
+          </>
+        ) : (
+          // Should not normally be reached, but keeps JSX exhaustive
+          <span className="text-black/35">Conversion unavailable</span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/utils/usdc-rate.ts
+++ b/apps/web/utils/usdc-rate.ts
@@ -1,0 +1,130 @@
+/**
+ * USDC Exchange Rate Fetcher
+ *
+ * Fetches the current USDC price in USD and EUR from the CoinGecko public API.
+ * Falls back to a fixed 1:1 USD peg if the fetch fails, since USDC is a
+ * USD-backed stablecoin and its market price deviates by only a few basis points.
+ *
+ * Usage:
+ *   const rate = await fetchUsdcRate("usd");
+ *   const converted = 25 * rate; // e.g. 25.01
+ */
+
+export type FiatCurrency = "usd" | "eur";
+
+export interface UsdcRateResult {
+  /** The exchange rate: 1 USDC in the requested fiat currency */
+  rate: number;
+  /** Whether this value is a fallback due to a failed fetch */
+  isFallback: boolean;
+  /** Currency code returned */
+  currency: FiatCurrency;
+}
+
+/**
+ * USDC is pegged to USD, so 1 USDC ≈ 1 USD at all times.
+ * For EUR we use a reasonable fallback that keeps the UI functional.
+ */
+const FALLBACK_RATES: Record<FiatCurrency, number> = {
+  usd: 1.0,
+  eur: 0.92,
+};
+
+const COINGECKO_API_URL =
+  "https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd%2Ceur";
+
+/** Cache the last successful fetch to avoid hammering the API on re-renders. */
+let _cache: { data: Record<FiatCurrency, number>; fetchedAt: number } | null =
+  null;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Fetch the current USDC exchange rate for the given fiat currency.
+ *
+ * @param currency - Target fiat currency: "usd" (default) or "eur".
+ * @param signal   - Optional AbortSignal to cancel the request.
+ * @returns        - An object containing the rate, currency, and whether it is a fallback.
+ */
+export async function fetchUsdcRate(
+  currency: FiatCurrency = "usd",
+  signal?: AbortSignal,
+): Promise<UsdcRateResult> {
+  // Return cached value if it is still fresh
+  if (_cache && Date.now() - _cache.fetchedAt < CACHE_TTL_MS) {
+    return {
+      rate: _cache.data[currency],
+      isFallback: false,
+      currency,
+    };
+  }
+
+  try {
+    const response = await fetch(COINGECKO_API_URL, {
+      signal,
+      // Instruct browsers/CDNs to revalidate after 5 minutes
+      next: { revalidate: 300 },
+    } as RequestInit);
+
+    if (!response.ok) {
+      throw new Error(
+        `CoinGecko responded with status ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const json = (await response.json()) as {
+      "usd-coin"?: { usd?: number; eur?: number };
+    };
+
+    const usdRate = json["usd-coin"]?.usd;
+    const eurRate = json["usd-coin"]?.eur;
+
+    if (typeof usdRate !== "number" || typeof eurRate !== "number") {
+      throw new Error("Unexpected CoinGecko response shape");
+    }
+
+    _cache = {
+      data: { usd: usdRate, eur: eurRate },
+      fetchedAt: Date.now(),
+    };
+
+    return {
+      rate: _cache.data[currency],
+      isFallback: false,
+      currency,
+    };
+  } catch (err) {
+    // Do not re-throw when the request was intentionally cancelled
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw err;
+    }
+
+    console.warn(
+      "[usdc-rate] Failed to fetch USDC rate from CoinGecko, using fallback:",
+      err,
+    );
+
+    return {
+      rate: FALLBACK_RATES[currency],
+      isFallback: true,
+      currency,
+    };
+  }
+}
+
+/**
+ * Convert a USDC amount to fiat using the given rate.
+ * Uses fixed-point arithmetic to avoid floating-point rounding artefacts.
+ *
+ * @param amountUsdc - Amount in USDC.
+ * @param rate       - Exchange rate (1 USDC → fiat).
+ * @param decimals   - Number of decimal places (default: 2).
+ * @returns          - Converted fiat value as a number rounded to `decimals` places.
+ */
+export function convertUsdcToFiat(
+  amountUsdc: number,
+  rate: number,
+  decimals = 2,
+): number {
+  const factor = Math.pow(10, decimals);
+  return Math.round(amountUsdc * rate * factor) / factor;
+}


### PR DESCRIPTION
Description
This pull request introduces the new PriceTag display component along with a reliable USDC fiat rate-fetching utility, fulfilling the requirements for the Utilities module.

Changes Made
USDC Rate Fetching Utility: Implemented a robust function to fetch live USDC-to-fiat exchange rates (USD/EUR) with built-in fallback handling for network errors or API failures.

PriceTag Component (PriceTag.tsx):

Displays the primary amount in USDC formatted consistently to two decimal places (e.g., 25.00 USDC).

Renders a secondary, smaller conversion text showing the value in fiat beneath it.

Includes a graceful fallback display note if rate fetching fails.

Precision & Formatting: Ensured precise decimal handling to completely eliminate rounding errors.

Acceptance Criteria Checklist
[x] Implemented function to fetch current USDC rate relative to fiat currencies.

[x] Created PriceTag.tsx component receiving an amount in USDC.

[x] Displays primary price in USDC and secondary fiat conversion beneath.

[x] Conversion handling avoids rounding errors (prices formatted to two decimal points).

[x] Displays a fallback conversion note if rates fetching fails.

[x] Code is fully typed, formatted, and builds successfully.

[x] Branch created and pushed to GitHub.

closes #1018

