### PR TITLE
feat: high-concurrency virtual waiting room & bot-resistant queueing gateway

### DIFF
--- a/apps/mobile/__tests__/sha256.test.ts
+++ b/apps/mobile/__tests__/sha256.test.ts
@@ -1,0 +1,49 @@
+import { sha256Hex } from '@/utils/sha256';
+import { solvePow } from '@/services/waitingRoom';
+
+/**
+ * SHA-256 is verified against the standard NIST test vectors so a regression
+ * in the pure-TS implementation is caught immediately (Issue #1187).
+ */
+describe('sha256Hex', () => {
+  it('matches the empty-string test vector', () => {
+    expect(sha256Hex('')).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+
+  it('matches the "abc" test vector', () => {
+    expect(sha256Hex('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  it('matches the "The quick brown fox..." test vector', () => {
+    expect(sha256Hex('The quick brown fox jumps over the lazy dog')).toBe(
+      'd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592'
+    );
+  });
+
+  it('handles messages that exercise the padding boundary (55, 56, 64 bytes)', () => {
+    // 55 bytes → single block
+    expect(sha256Hex('a'.repeat(55))).toBe('9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318');
+    // 56 bytes → padding spills into a second block
+    expect(sha256Hex('a'.repeat(56))).toBe('b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a');
+    // 64 bytes → exactly one full block
+    expect(sha256Hex('a'.repeat(64))).toBe('ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb');
+  });
+
+  it('handles non-ASCII UTF-8 input', () => {
+    // "¡Hola, mundo!" — multi-byte characters exercise UTF-8 encoding.
+    expect(sha256Hex('¡Hola, mundo!')).toBe('89cbd75bc4d8136ac5a1b54619f73933a8cd55db7b686b470b3a5db083ccd527');
+  });
+});
+
+describe('solvePow', () => {
+  it('finds a nonce whose hash starts with the required number of zeros', () => {
+    const challenge = 'deadbeefdeadbeefdeadbeefdeadbeef';
+    const nonce = solvePow(challenge, 2, 100_000);
+    const digest = sha256Hex(`${challenge}${nonce}`);
+    expect(digest.startsWith('00')).toBe(true);
+  });
+
+  it('throws when the search space is exhausted', () => {
+    expect(() => solvePow('challenge', 30, 10)).toThrow(/proof-of-work/);
+  });
+});

--- a/apps/mobile/__tests__/waitingRoomService.test.ts
+++ b/apps/mobile/__tests__/waitingRoomService.test.ts
@@ -1,0 +1,186 @@
+import {
+  fetchPowChallenge,
+  getWaitingRoomStatus,
+  joinWaitingRoom,
+  openWaitingRoomStream,
+  solvePow,
+  WaitingRoomError,
+} from '@/services/waitingRoom';
+import { sha256Hex } from '@/utils/sha256';
+
+const EVENT_ID = '550e8400-e29b-41d4-a716-446655440000';
+const CLIENT_ID = 'GCLIENTWALLET';
+
+describe('waiting room API client', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function mockFetchJson(status: number, body: unknown) {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as any);
+  }
+
+  it('fetchPowChallenge unwraps the server { success, data, message } envelope', async () => {
+    mockFetchJson(200, {
+      success: true,
+      data: { challenge: 'deadbeef', difficulty: 4, expires_in: 300 },
+      message: 'Proof-of-work challenge issued',
+    });
+
+    const challenge = await fetchPowChallenge(EVENT_ID);
+    expect(challenge).toEqual({ challenge: 'deadbeef', difficulty: 4, expires_in: 300 });
+  });
+
+  it('joinWaitingRoom posts the PoW solution', async () => {
+    mockFetchJson(200, {
+      success: true,
+      data: {
+        status: 'waiting',
+        position: 142,
+        queue_size: 1000,
+        estimated_wait_seconds: 142,
+        grant_token: null,
+      },
+      message: 'Joined the queue',
+    });
+
+    const status = await joinWaitingRoom({
+      event_id: EVENT_ID,
+      client_id: CLIENT_ID,
+      challenge: 'deadbeef',
+      nonce: '12345',
+    });
+    expect(status.status).toBe('waiting');
+    expect(status.position).toBe(142);
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(JSON.parse((init as any).body)).toEqual({
+      event_id: EVENT_ID,
+      client_id: CLIENT_ID,
+      challenge: 'deadbeef',
+      nonce: '12345',
+    });
+  });
+
+  it('surfaces server error messages with their status', async () => {
+    mockFetchJson(422, { code: 422, message: 'Proof-of-work solution is incorrect' });
+
+    await expect(
+      joinWaitingRoom({ event_id: EVENT_ID, client_id: CLIENT_ID, challenge: 'c', nonce: 'n' })
+    ).rejects.toMatchObject({
+      name: 'WaitingRoomError',
+      status: 422,
+      message: 'Proof-of-work solution is incorrect',
+    });
+  });
+
+  it('getWaitingRoomStatus throws WaitingRoomError (404) when not in queue', async () => {
+    mockFetchJson(404, { code: 404, message: 'You are not in the queue for this event' });
+
+    await expect(getWaitingRoomStatus(EVENT_ID, CLIENT_ID)).rejects.toBeInstanceOf(WaitingRoomError);
+  });
+
+  it('solvePow produces a nonce the server-side rule accepts', () => {
+    const challenge = 'cafebabe'.repeat(4);
+    const nonce = solvePow(challenge, 2, 100_000);
+    expect(sha256Hex(`${challenge}${nonce}`).startsWith('00')).toBe(true);
+  });
+});
+
+describe('openWaitingRoomStream (SSE via XHR)', () => {
+  class FakeXHR {
+    responseText = '';
+    onprogress: (() => void) | null = null;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    aborted = false;
+    sent = false;
+    sentUrl = '';
+
+    open(_method: string, url: string) {
+      this.sentUrl = url;
+    }
+    setRequestHeader() {}
+    send() {
+      this.sent = true;
+    }
+    abort() {
+      this.aborted = true;
+    }
+
+    pushChunk(chunk: string) {
+      this.responseText += chunk;
+      this.onprogress?.();
+    }
+  }
+
+  const originalXHR = global.XMLHttpRequest;
+
+  afterEach(() => {
+    (global as any).XMLHttpRequest = originalXHR;
+  });
+
+  function mockXhr(fake: FakeXHR) {
+    (global as any).XMLHttpRequest = jest.fn(() => fake);
+  }
+
+  it('parses position frames and closes with the admitted grant', () => {
+    const fake = new FakeXHR();
+    mockXhr(fake);
+
+    const onPosition = jest.fn();
+    const onAdmitted = jest.fn();
+    const onClosed = jest.fn();
+    const onError = jest.fn();
+
+    openWaitingRoomStream(EVENT_ID, CLIENT_ID, {
+      onPosition,
+      onAdmitted,
+      onError,
+      onClosed,
+    });
+
+    expect(fake.sent).toBe(true);
+    expect(fake.sentUrl).toContain('/api/v1/waiting-room/stream');
+
+    fake.pushChunk(
+      'data: {"type":"position","position":142,"queue_size":1000,"estimated_wait_seconds":45}\n\n'
+    );
+    expect(onPosition).toHaveBeenCalledWith(142, 1000, 45);
+
+    fake.pushChunk('data: {"type":"admitted","grant_token":"signed-grant-jwt"}\n\n');
+    expect(onAdmitted).toHaveBeenCalledWith('signed-grant-jwt');
+    expect(fake.aborted).toBe(true);
+    expect(onClosed).toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('ignores keepalive comments and split frames', () => {
+    const fake = new FakeXHR();
+    mockXhr(fake);
+
+    const onPosition = jest.fn();
+    openWaitingRoomStream(EVENT_ID, CLIENT_ID, {
+      onPosition,
+      onAdmitted: jest.fn(),
+      onError: jest.fn(),
+      onClosed: jest.fn(),
+    });
+
+    // Keepalive comment has no `data:` line.
+    fake.pushChunk(': keepalive\n\n');
+    expect(onPosition).not.toHaveBeenCalled();
+
+    // A frame arriving across two progress ticks is still parsed.
+    fake.pushChunk('data: {"type":"position","position":1,"queue_size":2,"esti');
+    expect(onPosition).not.toHaveBeenCalled();
+    fake.pushChunk('mated_wait_seconds":3}\n\n');
+    expect(onPosition).toHaveBeenCalledWith(1, 2, 3);
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -90,6 +90,16 @@ function AppNavigation() {
           }}
         />
         <Stack.Screen
+          name="checkout/waiting-room"
+          options={{
+            presentation: 'modal',
+            title: 'Virtual Waiting Room',
+            headerStyle,
+            headerTintColor,
+            headerShadowVisible: false,
+          }}
+        />
+        <Stack.Screen
           name="event/[id]"
           options={{
             presentation: 'modal',

--- a/apps/mobile/app/checkout/__tests__/waiting-room.test.tsx
+++ b/apps/mobile/app/checkout/__tests__/waiting-room.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import WaitingRoomScreen from '../waiting-room';
+import { useWaitingRoom } from '@/hooks/useWaitingRoom';
+import { useAuth } from '@/hooks/useAuth';
+
+/**
+ * Issue #1187 acceptance criteria covered here:
+ *   - A dedicated countdown / waiting room screen exists.
+ *   - It shows the live queue position and estimated wait.
+ *   - On receiving the signed access grant it auto-redirects to checkout.
+ *
+ * Network orchestration (PoW + SSE) is mocked via `useWaitingRoom`; the hook
+ * and service layers have their own coverage.
+ */
+
+let mockParams: Record<string, string> = {
+  eventId: '550e8400-e29b-41d4-a716-446655440000',
+  eventTitle: 'Stellar Meridian 2026',
+};
+const mockReplace = jest.fn();
+const mockRetry = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => mockParams,
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+}));
+
+jest.mock('@/hooks/useAuth');
+jest.mock('@/hooks/useWaitingRoom');
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUseWaitingRoom = useWaitingRoom as jest.MockedFunction<typeof useWaitingRoom>;
+
+function waitingState(overrides: Partial<ReturnType<typeof useWaitingRoom>> = {}) {
+  return {
+    phase: 'waiting' as const,
+    position: 142,
+    queueSize: 1000,
+    estimatedWaitSeconds: 45,
+    grantToken: null,
+    errorMessage: null,
+    retry: mockRetry,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockParams = {
+    eventId: '550e8400-e29b-41d4-a716-446655440000',
+    eventTitle: 'Stellar Meridian 2026',
+  };
+  mockUseAuth.mockReturnValue({
+    token: 'mock-jwt-token-agora',
+    user: { name: 'Agora User', email: 'user@example.com', walletAddress: 'GCLIENTWALLET' },
+    isAuthenticated: true,
+    login: jest.fn(),
+    logout: jest.fn(),
+    updateWalletAddress: jest.fn(),
+  } as any);
+  mockUseWaitingRoom.mockReturnValue(waitingState());
+});
+
+describe('WaitingRoomScreen', () => {
+  it('shows the live queue position and estimated wait while waiting', () => {
+    const { getByTestId, getByText } = render(<WaitingRoomScreen />);
+
+    // JSX `#${position}` renders as a children array in React Native.
+    expect(getByTestId('queue-position').props.children).toEqual(['#', 142]);
+    expect(getByText('Estimated wait: 45s')).toBeTruthy();
+    expect(getByText('1,000 people ahead of you')).toBeTruthy();
+  });
+
+  it('shows the human-verification state while solving the PoW challenge', () => {
+    mockUseWaitingRoom.mockReturnValue(waitingState({ phase: 'solving', position: null }));
+
+    const { getByText } = render(<WaitingRoomScreen />);
+    expect(getByText('Verifying you are human...')).toBeTruthy();
+  });
+
+  it('shows an error with a retry button when joining fails', () => {
+    mockUseWaitingRoom.mockReturnValue(
+      waitingState({ phase: 'error', errorMessage: 'Proof-of-work solution is incorrect' })
+    );
+
+    const { getByText, getByTestId } = render(<WaitingRoomScreen />);
+    expect(getByText('Could not join the queue')).toBeTruthy();
+    expect(getByText('Proof-of-work solution is incorrect')).toBeTruthy();
+
+    fireEvent.press(getByTestId('waiting-room-retry'));
+    expect(mockRetry).toHaveBeenCalled();
+  });
+
+  it('auto-redirects to checkout when the signed grant token arrives', () => {
+    mockUseWaitingRoom.mockReturnValue(
+      waitingState({
+        phase: 'admitted',
+        position: null,
+        estimatedWaitSeconds: 0,
+        grantToken: 'eyJhbGciOiJIUzI1NiJ9.signed-grant',
+      })
+    );
+
+    render(<WaitingRoomScreen />);
+
+    expect(mockReplace).toHaveBeenCalledWith({
+      pathname: '/checkout',
+      params: {
+        eventId: '550e8400-e29b-41d4-a716-446655440000',
+        eventTitle: 'Stellar Meridian 2026',
+        grantToken: 'eyJhbGciOiJIUzI1NiJ9.signed-grant',
+      },
+    });
+  });
+});

--- a/apps/mobile/app/checkout/index.tsx
+++ b/apps/mobile/app/checkout/index.tsx
@@ -15,13 +15,21 @@ import { getTiersForEvent } from '@/lib/ticketTiers';
 const MAX_TICKETS_PER_ORDER = 10;
 
 export default function CheckoutScreen() {
-  const params = useLocalSearchParams<{ eventId?: string; eventTitle?: string }>();
+  const params = useLocalSearchParams<{
+    eventId?: string;
+    eventTitle?: string;
+    /** Signed checkout access grant issued by the waiting room (Issue #1187). */
+    grantToken?: string;
+  }>();
   const router = useRouter();
   const { user, token } = useAuth();
   const checkout = useTicketCheckout();
 
   const eventId = params.eventId ?? '1';
   const eventTitle = params.eventTitle ?? 'Agora Event';
+  // Received when the user was admitted through the virtual waiting room.
+  // Server-side checkout endpoints can verify it with the waiting-room API.
+  const grantToken = params.grantToken;
 
   const baseTiers = useMemo(() => getTiersForEvent(eventId), [eventId]);
 
@@ -82,6 +90,7 @@ export default function CheckoutScreen() {
       unitPriceUsdc: selectedTier.priceUsdc,
       quantity,
       buyerPublicKey: user.walletAddress,
+      grantToken,
     });
   };
 
@@ -165,6 +174,20 @@ export default function CheckoutScreen() {
         style={styles.confirmButton}
       />
 
+      <Button
+        testID="checkout-queue-link"
+        title="High demand? Join the virtual queue"
+        variant="outline"
+        onPress={() =>
+          router.push({
+            pathname: '/checkout/waiting-room',
+            params: { eventId, eventTitle },
+          })
+        }
+        disabled={checkout.isSubmitting}
+        style={styles.queueLink}
+      />
+
       <Text style={styles.disclaimer}>
         You will be asked to approve a USDC spending allowance, then submit the ticket purchase.
         Both transactions run on Stellar Testnet via {'\n'}soroban-testnet.stellar.org.
@@ -220,6 +243,9 @@ const styles = StyleSheet.create({
   },
   confirmButton: {
     marginTop: 4,
+  },
+  queueLink: {
+    marginTop: 12,
   },
   liveBadge: {
     fontSize: 11,

--- a/apps/mobile/app/checkout/waiting-room.tsx
+++ b/apps/mobile/app/checkout/waiting-room.tsx
@@ -1,0 +1,240 @@
+import React, { useEffect } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import Colors from '@/constants/Colors';
+import Button from '@/components/ui/Button';
+import { useAuth } from '@/hooks/useAuth';
+import { useWaitingRoom } from '@/hooks/useWaitingRoom';
+
+/**
+ * Virtual waiting room screen (Issue #1187).
+ *
+ * Gates checkout during high-traffic ticket releases:
+ *   1. Solves the server's SHA-256 proof-of-work challenge (anti-bot).
+ *   2. Joins the Redis-backed FIFO queue and streams its live position via
+ *      SSE ("You are #142 in line", "Estimated wait: 45s").
+ *   3. On receiving the cryptographically signed checkout access grant, it
+ *      automatically redirects to `/checkout` with the grant token attached.
+ */
+export default function WaitingRoomScreen() {
+  const params = useLocalSearchParams<{ eventId?: string; eventTitle?: string }>();
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const eventId = params.eventId ?? '';
+  const eventTitle = params.eventTitle ?? 'Agora Event';
+  const clientId = user?.walletAddress || 'guest';
+
+  const { phase, position, queueSize, estimatedWaitSeconds, grantToken, errorMessage, retry } =
+    useWaitingRoom(eventId, clientId);
+
+  // Auto-redirect to checkout the moment the signed grant arrives.
+  useEffect(() => {
+    if (phase === 'admitted' && grantToken && eventId) {
+      router.replace({
+        pathname: '/checkout',
+        params: { eventId, eventTitle, grantToken },
+      });
+    }
+  }, [phase, grantToken, eventId, eventTitle, router]);
+
+  const isBusy = phase === 'fetching-challenge' || phase === 'solving' || phase === 'joining';
+  const progress = queueSize > 0 && position != null ? Math.max(0, Math.min(1, 1 - position / queueSize)) : 0;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.eyebrow}>VIRTUAL WAITING ROOM</Text>
+        <Text style={styles.title}>{eventTitle}</Text>
+
+        {isBusy ? (
+          <View style={styles.centered}>
+            <ActivityIndicator color={Colors.primaryYellow} size="large" />
+            <Text style={styles.statusText}>
+              {phase === 'fetching-challenge' && 'Contacting the queue...'}
+              {phase === 'solving' && 'Verifying you are human...'}
+              {phase === 'joining' && 'Joining the queue...'}
+            </Text>
+            <Text style={styles.statusHint}>
+              This one-time check stops automated bots from cutting the line.
+            </Text>
+          </View>
+        ) : null}
+
+        {phase === 'waiting' && position != null ? (
+          <View style={styles.queueCard}>
+            <Text style={styles.positionLabel}>You are</Text>
+            <Text style={styles.positionValue} testID="queue-position">
+              #{position}
+            </Text>
+            <Text style={styles.positionLabel}>in line</Text>
+
+            <View style={styles.progressTrack}>
+              <View style={[styles.progressFill, { width: `${Math.round(progress * 100)}%` }]} />
+            </View>
+
+            <Text style={styles.estimatedWait} testID="estimated-wait">
+              Estimated wait:{' '}
+              {estimatedWaitSeconds != null
+                ? formatWait(estimatedWaitSeconds)
+                : 'calculating...'}
+            </Text>
+            {queueSize > 0 ? (
+              <Text style={styles.queueSize}>{queueSize.toLocaleString()} people ahead of you</Text>
+            ) : null}
+
+            <View style={styles.keepAliveRow}>
+              <View style={styles.liveDot} />
+              <Text style={styles.keepAliveText}>
+                Your place is reserved — keep this screen open. You will be sent to checkout
+                automatically.
+              </Text>
+            </View>
+          </View>
+        ) : null}
+
+        {phase === 'admitted' ? (
+          <View style={styles.centered}>
+            <Text style={styles.admittedTitle}>You are in! 🎉</Text>
+            <Text style={styles.statusText}>Taking you to checkout...</Text>
+          </View>
+        ) : null}
+
+        {phase === 'error' ? (
+          <View style={styles.centered}>
+            <Text style={styles.errorTitle}>Could not join the queue</Text>
+            <Text style={styles.errorMessage}>{errorMessage}</Text>
+            <Button testID="waiting-room-retry" title="Try again" onPress={retry} variant="primary" />
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function formatWait(seconds: number): string {
+  const rounded = Math.max(1, Math.round(seconds));
+  const minutes = Math.floor(rounded / 60);
+  const secs = rounded % 60;
+  if (minutes === 0) return `${secs}s`;
+  return `${minutes}m ${secs}s`;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.darkBackground,
+  },
+  content: {
+    flex: 1,
+    padding: 24,
+    justifyContent: 'center',
+  },
+  centered: {
+    alignItems: 'center',
+    marginTop: 32,
+    gap: 12,
+  },
+  eyebrow: {
+    color: Colors.primaryYellow,
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    textAlign: 'center',
+  },
+  title: {
+    color: Colors.primaryText,
+    fontSize: 22,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  statusText: {
+    color: Colors.primaryText,
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+    marginTop: 16,
+  },
+  statusHint: {
+    color: Colors.secondaryText,
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  queueCard: {
+    backgroundColor: '#1A1A1C',
+    borderRadius: 16,
+    padding: 24,
+    marginTop: 32,
+    alignItems: 'center',
+  },
+  positionLabel: {
+    color: Colors.secondaryText,
+    fontSize: 13,
+  },
+  positionValue: {
+    color: Colors.primaryText,
+    fontSize: 48,
+    fontWeight: '800',
+    marginVertical: 4,
+  },
+  progressTrack: {
+    width: '100%',
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#2C2C2E',
+    marginVertical: 16,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 3,
+    backgroundColor: Colors.primaryYellow,
+  },
+  estimatedWait: {
+    color: Colors.primaryText,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  queueSize: {
+    color: Colors.secondaryText,
+    fontSize: 12,
+    marginTop: 4,
+  },
+  keepAliveRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    marginTop: 20,
+  },
+  liveDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.primaryYellow,
+    marginTop: 4,
+  },
+  keepAliveText: {
+    color: Colors.secondaryText,
+    fontSize: 12,
+    lineHeight: 17,
+    flex: 1,
+  },
+  admittedTitle: {
+    color: Colors.primaryText,
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  errorTitle: {
+    color: Colors.primaryText,
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  errorMessage: {
+    color: Colors.secondaryText,
+    fontSize: 13,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+});

--- a/apps/mobile/hooks/useTicketCheckout.ts
+++ b/apps/mobile/hooks/useTicketCheckout.ts
@@ -149,6 +149,8 @@ export interface StartCheckoutParams {
   quantity: number;
   buyerPublicKey: string;
   recipientAddress?: string | null;
+  /** Signed waiting-room checkout access grant (Issue #1187). */
+  grantToken?: string | null;
 }
 
 export interface UseTicketCheckoutResult {
@@ -273,6 +275,7 @@ export function useTicketCheckout(): UseTicketCheckoutResult {
           paymentTxHash: purchaseResult.paymentTxHash,
           buyerPublicKey: purchaseResult.buyerPublicKey,
           completedAt: new Date().toISOString(),
+          grantToken: params.grantToken ?? undefined,
         },
       });
     } catch (error) {

--- a/apps/mobile/hooks/useWaitingRoom.ts
+++ b/apps/mobile/hooks/useWaitingRoom.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  fetchPowChallenge,
+  joinWaitingRoom,
+  openWaitingRoomStream,
+  solvePow,
+  WaitingRoomError,
+} from '@/services/waitingRoom';
+
+/**
+ * Drives the virtual waiting room flow (Issue #1187):
+ *
+ *   fetch challenge → solve PoW → join queue → stream position → admitted
+ *
+ * The screen only needs `phase`, the position fields for the countdown UI,
+ * `grantToken` (triggers the auto-redirect to checkout) and `retry`.
+ * All network orchestration lives in `services/waitingRoom.ts`.
+ */
+
+export type WaitingRoomPhase =
+  | 'idle'
+  | 'fetching-challenge'
+  | 'solving'
+  | 'joining'
+  | 'waiting'
+  | 'admitted'
+  | 'error';
+
+export interface WaitingRoomState {
+  phase: WaitingRoomPhase;
+  /** 1-based position in line. */
+  position: number | null;
+  queueSize: number;
+  estimatedWaitSeconds: number | null;
+  /** Signed checkout access grant — present only when admitted. */
+  grantToken: string | null;
+  errorMessage: string | null;
+}
+
+const initialState: WaitingRoomState = {
+  phase: 'idle',
+  position: null,
+  queueSize: 0,
+  estimatedWaitSeconds: null,
+  grantToken: null,
+  errorMessage: null,
+};
+
+export interface UseWaitingRoomResult extends WaitingRoomState {
+  retry: () => void;
+}
+
+export function useWaitingRoom(eventId: string, clientId: string): UseWaitingRoomResult {
+  const [state, setState] = useState<WaitingRoomState>(initialState);
+  const [attempt, setAttempt] = useState(0);
+  const closeStreamRef = useRef<(() => void) | null>(null);
+  // `onClosed` fires immediately after `onAdmitted` (the service aborts and
+  // finishes the stream); without this we'd overwrite the admitted state.
+  const phaseRef = useRef<WaitingRoomPhase>('idle');
+
+  useEffect(() => {
+    if (!eventId || !clientId) {
+      setState((s) => ({ ...s, phase: 'idle', errorMessage: null }));
+      return;
+    }
+
+    let disposed = false;
+
+    const closeStream = () => {
+      closeStreamRef.current?.();
+      closeStreamRef.current = null;
+    };
+
+    // Make sure any stream from a previous attempt is closed before retrying.
+    closeStream();
+
+    const set = (patch: Partial<WaitingRoomState>) => {
+      if (patch.phase) phaseRef.current = patch.phase;
+      if (!disposed) setState((s) => ({ ...s, ...patch }));
+    };
+
+    set({ phase: 'fetching-challenge', errorMessage: null, grantToken: null });
+
+    (async () => {
+      try {
+        const challenge = await fetchPowChallenge(eventId);
+        if (disposed) return;
+
+        set({ phase: 'solving' });
+        const nonce = solvePow(challenge.challenge, challenge.difficulty);
+        if (disposed) return;
+
+        set({ phase: 'joining' });
+        const status = await joinWaitingRoom({
+          event_id: eventId,
+          client_id: clientId,
+          challenge: challenge.challenge,
+          nonce,
+        });
+        if (disposed) return;
+
+        if (status.status === 'admitted' && status.grant_token) {
+          set({
+            phase: 'admitted',
+            position: null,
+            queueSize: status.queue_size,
+            estimatedWaitSeconds: 0,
+            grantToken: status.grant_token,
+          });
+          return;
+        }
+
+        set({
+          phase: 'waiting',
+          position: status.position,
+          queueSize: status.queue_size,
+          estimatedWaitSeconds: status.estimated_wait_seconds,
+        });
+
+        // Stream live position; the server closes with the grant on admission.
+        closeStreamRef.current = openWaitingRoomStream(eventId, clientId, {
+          onPosition: (position, queueSize, estimatedWaitSeconds) => {
+            set({ phase: 'waiting', position, queueSize, estimatedWaitSeconds });
+          },
+          onAdmitted: (grantToken) => {
+            set({
+              phase: 'admitted',
+              position: null,
+              estimatedWaitSeconds: 0,
+              grantToken,
+            });
+          },
+          onError: (message) => {
+            set({ phase: 'error', errorMessage: message });
+          },
+          onClosed: () => {
+            closeStreamRef.current = null;
+            // Only treat an unexpected close while waiting as a failure —
+            // after `admitted` or an explicit `error` the stream closing is
+            // expected and already handled.
+            if (!disposed && phaseRef.current === 'waiting') {
+              set({ phase: 'error', errorMessage: 'Lost connection to the queue. Please retry.' });
+            }
+          },
+        });
+      } catch (error) {
+        if (disposed) return;
+        const message =
+          error instanceof WaitingRoomError
+            ? error.message
+            : error instanceof Error
+              ? error.message
+              : 'Something went wrong joining the queue.';
+        set({ phase: 'error', errorMessage: message });
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      closeStream();
+    };
+  }, [eventId, clientId, attempt]);
+
+  const retry = useCallback(() => {
+    closeStreamRef.current?.();
+    closeStreamRef.current = null;
+    setAttempt((n) => n + 1);
+  }, []);
+
+  return useMemo(() => ({ ...state, retry }), [state, retry]);
+}

--- a/apps/mobile/services/waitingRoom.ts
+++ b/apps/mobile/services/waitingRoom.ts
@@ -1,0 +1,262 @@
+/**
+ * waitingRoom.ts
+ *
+ * Client for the virtual waiting room API (Issue #1187):
+ *
+ *   1. `fetchPowChallenge`     – POST /api/v1/waiting-room/challenge
+ *   2. `solvePow`              – brute-force a SHA-256 nonce (Hashcash-style)
+ *   3. `joinWaitingRoom`       – POST /api/v1/waiting-room/join
+ *   4. `getWaitingRoomStatus`  – GET  /api/v1/waiting-room/status
+ *   5. `openWaitingRoomStream` – GET  /api/v1/waiting-room/stream (SSE)
+ *
+ * React Native's `fetch` cannot stream response bodies, so the SSE stream is
+ * consumed through `XMLHttpRequest` `onprogress` (which does deliver partial
+ * response text) and parsed incrementally.
+ */
+
+import { sha256Hex } from '@/utils/sha256';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8080';
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export interface PowChallenge {
+  challenge: string;
+  difficulty: number;
+  expires_in: number;
+}
+
+export interface JoinWaitingRoomRequest {
+  event_id: string;
+  client_id: string;
+  challenge: string;
+  nonce: string;
+}
+
+export interface QueueStatusPayload {
+  status: 'waiting' | 'admitted';
+  /** 1-based position in line; null once admitted. */
+  position: number | null;
+  queue_size: number;
+  estimated_wait_seconds: number | null;
+  /** Cryptographically signed checkout access grant; present when admitted. */
+  grant_token: string | null;
+}
+
+export class WaitingRoomError extends Error {
+  readonly status: number | null;
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.name = 'WaitingRoomError';
+    this.status = status;
+  }
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof WaitingRoomError) return error.message;
+  if ((error as any)?.name === 'AbortError') return 'Request timed out. Please try again.';
+  return error instanceof Error ? error.message : 'Something went wrong. Please try again.';
+}
+
+async function parseJson(response: Response): Promise<any> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function extractMessage(body: any, status: number, fallback: string): string {
+  return body?.message || body?.error?.message || fallback;
+}
+
+async function postJson<T>(path: string, payload: unknown): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    const body = await parseJson(response);
+    if (!response.ok) {
+      throw new WaitingRoomError(extractMessage(body, response.status, `Request failed (${response.status}).`), response.status);
+    }
+    // Our server wraps successful payloads in `{ success, data, message }`.
+    return (body?.data ?? body) as T;
+  } catch (error) {
+    if (error instanceof WaitingRoomError) throw error;
+    throw new WaitingRoomError(describeError(error));
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const body = await parseJson(response);
+    if (!response.ok) {
+      throw new WaitingRoomError(extractMessage(body, response.status, `Request failed (${response.status}).`), response.status);
+    }
+    return (body?.data ?? body) as T;
+  } catch (error) {
+    if (error instanceof WaitingRoomError) throw error;
+    throw new WaitingRoomError(describeError(error));
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/** Issue a fresh proof-of-work challenge for an event. */
+export async function fetchPowChallenge(eventId: string): Promise<PowChallenge> {
+  return postJson<PowChallenge>('/api/v1/waiting-room/challenge', { event_id: eventId });
+}
+
+/**
+ * Find a nonce where SHA-256(challenge || nonce) starts with `difficulty`
+ * hex zeros. Expected attempts: 2^(4*difficulty).
+ */
+export function solvePow(challenge: string, difficulty: number, maxAttempts = 2_000_000): string {
+  const prefix = '0'.repeat(difficulty);
+  for (let nonce = 0; nonce < maxAttempts; nonce++) {
+    if (sha256Hex(`${challenge}${nonce}`).startsWith(prefix)) {
+      return String(nonce);
+    }
+  }
+  throw new WaitingRoomError(
+    `Could not solve the proof-of-work challenge at difficulty ${difficulty}. Please try again.`
+  );
+}
+
+/** Verify the client is in the queue / holds a grant. */
+export async function joinWaitingRoom(payload: JoinWaitingRoomRequest): Promise<QueueStatusPayload> {
+  return postJson<QueueStatusPayload>('/api/v1/waiting-room/join', payload);
+}
+
+/** Current queue status for a client. Throws 404 when not in the queue. */
+export async function getWaitingRoomStatus(eventId: string, clientId: string): Promise<QueueStatusPayload> {
+  const query = `event_id=${encodeURIComponent(eventId)}&client_id=${encodeURIComponent(clientId)}`;
+  return getJson<QueueStatusPayload>(`/api/v1/waiting-room/status?${query}`);
+}
+
+export interface WaitingRoomStreamHandlers {
+  onPosition: (position: number, queueSize: number, estimatedWaitSeconds: number) => void;
+  onAdmitted: (grantToken: string) => void;
+  onError: (message: string) => void;
+  /** Fired when the stream ends (admitted, server error, or abort). */
+  onClosed: () => void;
+}
+
+/**
+ * Open the SSE position stream for a client. Returns a `close()` function.
+ *
+ * The server pushes a `position` event every ~2s and finishes with an
+ * `admitted` event carrying the signed checkout access grant token.
+ */
+export function openWaitingRoomStream(
+  eventId: string,
+  clientId: string,
+  handlers: WaitingRoomStreamHandlers
+): () => void {
+  const url = `${API_BASE_URL}/api/v1/waiting-room/stream?event_id=${encodeURIComponent(eventId)}&client_id=${encodeURIComponent(clientId)}`;
+
+  const xhr = new XMLHttpRequest();
+  let cursor = 0;
+  let buffer = '';
+  let finished = false;
+
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    handlers.onClosed();
+  };
+
+  const handleMessage = (message: any) => {
+    switch (message?.type) {
+      case 'position':
+        handlers.onPosition(
+          message.position ?? 0,
+          message.queue_size ?? 0,
+          message.estimated_wait_seconds ?? 0
+        );
+        break;
+      case 'admitted':
+        if (message.grant_token) {
+          handlers.onAdmitted(message.grant_token);
+        }
+        xhr.abort();
+        finish();
+        break;
+      case 'not-in-queue':
+        handlers.onError('You are not in the queue for this event.');
+        xhr.abort();
+        finish();
+        break;
+      case 'error':
+        handlers.onError(message.message ?? 'The queue stream ended with an error.');
+        xhr.abort();
+        finish();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const consumeChunk = () => {
+    const text = xhr.responseText ?? '';
+    if (text.length > cursor) {
+      buffer += text.slice(cursor);
+      cursor = text.length;
+    }
+    // SSE events are separated by blank lines.
+    let separator = buffer.indexOf('\n\n');
+    while (separator !== -1) {
+      const rawEvent = buffer.slice(0, separator);
+      buffer = buffer.slice(separator + 2);
+      const dataLines = rawEvent
+        .split('\n')
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).trim());
+      if (dataLines.length > 0) {
+        try {
+          handleMessage(JSON.parse(dataLines.join('\n')));
+        } catch {
+          // Ignore malformed frames; keepalive comments carry no `data:`.
+        }
+      }
+      separator = buffer.indexOf('\n\n');
+    }
+  };
+
+  xhr.open('GET', url, true);
+  xhr.setRequestHeader('Accept', 'text/event-stream');
+  xhr.onprogress = consumeChunk;
+  xhr.onload = () => {
+    consumeChunk();
+    finish();
+  };
+  xhr.onerror = () => {
+    handlers.onError('Lost connection to the queue stream. Please retry.');
+    finish();
+  };
+  xhr.send();
+
+  // Cleanup: aborting is silent (no `onerror` fires for `abort()`), so no
+  // handler callbacks run on unmount.
+  return () => {
+    try {
+      xhr.abort();
+    } catch {
+      // noop
+    }
+  };
+}

--- a/apps/mobile/types/checkout.ts
+++ b/apps/mobile/types/checkout.ts
@@ -83,4 +83,6 @@ export interface CheckoutReceipt {
   paymentTxHash: string;
   buyerPublicKey: string;
   completedAt: string; // ISO timestamp
+  /** Signed waiting-room access grant the buyer redeemed (Issue #1187). */
+  grantToken?: string;
 }

--- a/apps/mobile/utils/sha256.ts
+++ b/apps/mobile/utils/sha256.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure TypeScript SHA-256 (FIPS 180-4).
+ *
+ * The waiting-room proof-of-work challenge (Issue #1187) needs SHA-256 on the
+ * device. React Native / Hermes has no WebCrypto `SubtleCrypto` and the app
+ * does not depend on `expo-crypto`, so this module provides a self-contained,
+ * dependency-free implementation that runs identically on iOS, Android, web,
+ * and under Jest.
+ *
+ * Only string inputs are supported; the message is UTF-8 encoded internally,
+ * which matches the server (`sha2` crate, fed the same UTF-8 bytes).
+ */
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+const H0 = new Uint32Array([
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+  0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+]);
+
+function rotr(x: number, n: number): number {
+  return (x >>> n) | (x << (32 - n));
+}
+
+function utf8Encode(str: string): Uint8Array {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(str);
+  }
+  // Manual fallback for exotic environments without TextEncoder.
+  const out: number[] = [];
+  for (const ch of str) {
+    const code = ch.codePointAt(0) as number;
+    if (code < 0x80) {
+      out.push(code);
+    } else if (code < 0x800) {
+      out.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code < 0x10000) {
+      out.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    } else {
+      out.push(
+        0xf0 | (code >> 18),
+        0x80 | ((code >> 12) & 0x3f),
+        0x80 | ((code >> 6) & 0x3f),
+        0x80 | (code & 0x3f)
+      );
+    }
+  }
+  return new Uint8Array(out);
+}
+
+/**
+ * Hex-encoded SHA-256 digest of a UTF-8 string.
+ */
+export function sha256Hex(message: string): string {
+  const bytes = utf8Encode(message);
+  const bitLen = bytes.length * 8;
+
+  // Padding: 0x80 byte, zero padding, then the 64-bit big-endian bit length.
+  const paddedLen = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLen);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const dv = new DataView(padded.buffer);
+  dv.setUint32(paddedLen - 8, Math.floor(bitLen / 0x100000000));
+  dv.setUint32(paddedLen - 4, bitLen >>> 0);
+
+  const w = new Uint32Array(64);
+  const h = new Uint32Array(H0);
+
+  for (let i = 0; i < paddedLen; i += 64) {
+    for (let t = 0; t < 16; t++) {
+      w[t] = dv.getUint32(i + t * 4);
+    }
+    for (let t = 16; t < 64; t++) {
+      const s0 = rotr(w[t - 15], 7) ^ rotr(w[t - 15], 18) ^ (w[t - 15] >>> 3);
+      const s1 = rotr(w[t - 2], 17) ^ rotr(w[t - 2], 19) ^ (w[t - 2] >>> 10);
+      w[t] = (w[t - 16] + s0 + w[t - 7] + s1) >>> 0;
+    }
+
+    let a = h[0];
+    let b = h[1];
+    let c = h[2];
+    let d = h[3];
+    let e = h[4];
+    let f = h[5];
+    let g = h[6];
+    let hh = h[7];
+
+    for (let t = 0; t < 64; t++) {
+      const s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (hh + s1 + ch + K[t] + w[t]) >>> 0;
+      const s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + maj) >>> 0;
+      hh = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    h[0] = (h[0] + a) >>> 0;
+    h[1] = (h[1] + b) >>> 0;
+    h[2] = (h[2] + c) >>> 0;
+    h[3] = (h[3] + d) >>> 0;
+    h[4] = (h[4] + e) >>> 0;
+    h[5] = (h[5] + f) >>> 0;
+    h[6] = (h[6] + g) >>> 0;
+    h[7] = (h[7] + hh) >>> 0;
+  }
+
+  let out = '';
+  for (let i = 0; i < 8; i++) {
+    out += h[i].toString(16).padStart(8, '0');
+  }
+  return out;
+}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agora-server"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -24,6 +25,7 @@ dependencies = [
  "dashmap",
  "dotenvy",
  "ed25519-dalek",
+ "futures-util",
  "hex",
  "http-body-util",
  "jsonwebtoken",
@@ -37,6 +39,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sqlx",
  "stellar-strkey",
  "sysinfo",
@@ -129,6 +132,28 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "async-trait"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -50,6 +50,13 @@ rand = "0.8"
 base64 = "0.21"
 hex = "0.4"
 
+# SHA-256 for the waiting-room proof-of-work challenge (Issue #1187)
+sha2 = "0.10"
+
+# Streaming (SSE) support for the waiting-room queue position stream (Issue #1187)
+async-stream = "0.3"
+futures-util = "0.3"
+
 
 # Rate limiting (using built-in RateLimitLayer only; tower_governor requires axum 0.8)
 

--- a/server/src/cache/mod.rs
+++ b/server/src/cache/mod.rs
@@ -102,6 +102,12 @@ impl RedisCache {
     pub async fn ping(&mut self) -> Result<(), RedisError> {
         redis::cmd("PING").query_async(&mut self.client).await
     }
+
+    /// Clone the underlying multiplexed connection manager so services can
+    /// issue raw Redis commands (e.g. the waiting-room queue engine, #1187).
+    pub fn connection(&self) -> redis::aio::ConnectionManager {
+        self.client.clone()
+    }
 }
 
 #[async_trait]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod profile;
 pub mod qr_payload;
 pub mod rates;
 pub mod soroban_listener;
+pub mod waiting_room;
 pub mod ws;
 
 use axum::{extract::Path, response::IntoResponse, response::Response};

--- a/server/src/handlers/waiting_room.rs
+++ b/server/src/handlers/waiting_room.rs
@@ -92,8 +92,10 @@ impl WaitingRoomConfig {
                 "WAITING_ROOM_ADMISSION_RATE_PER_MINUTE",
                 DEFAULT_ADMISSION_RATE_PER_MINUTE,
             ),
-            grant_ttl_minutes: env_u64("WAITING_ROOM_GRANT_TTL_MINUTES", DEFAULT_GRANT_TTL_MINUTES as u64)
-                as i64,
+            grant_ttl_minutes: env_u64(
+                "WAITING_ROOM_GRANT_TTL_MINUTES",
+                DEFAULT_GRANT_TTL_MINUTES as u64,
+            ) as i64,
             challenge_ttl_seconds: env_u64(
                 "WAITING_ROOM_CHALLENGE_TTL_SECONDS",
                 DEFAULT_CHALLENGE_TTL_SECONDS,
@@ -150,11 +152,8 @@ pub async fn request_challenge(
     Json(payload): Json<ChallengeRequest>,
 ) -> Response {
     if payload.event_id.trim().is_empty() {
-        return ApiError::new(
-            axum::http::StatusCode::BAD_REQUEST,
-            "event_id is required",
-        )
-        .into_response();
+        return ApiError::new(axum::http::StatusCode::BAD_REQUEST, "event_id is required")
+            .into_response();
     }
 
     let challenge = pow::generate_challenge();
@@ -240,7 +239,11 @@ pub async fn join_queue(
         .into_response();
     }
 
-    if !pow::verify_pow(&payload.challenge, &payload.nonce, state.config.pow_difficulty) {
+    if !pow::verify_pow(
+        &payload.challenge,
+        &payload.nonce,
+        state.config.pow_difficulty,
+    ) {
         return ApiError::new(
             axum::http::StatusCode::UNPROCESSABLE_ENTITY,
             "Proof-of-work solution is incorrect",

--- a/server/src/handlers/waiting_room.rs
+++ b/server/src/handlers/waiting_room.rs
@@ -1,0 +1,472 @@
+//! # Waiting Room Handlers (Issue #1187)
+//!
+//! Bot-resistant virtual queue API that gates checkout during high-traffic
+//! ticket releases.
+//!
+//! ## Endpoints
+//!
+//! | Method | Path | Purpose |
+//! |---|---|---|
+//! | `POST` | `/api/v1/waiting-room/challenge` | Issue a single-use SHA-256 proof-of-work challenge |
+//! | `POST` | `/api/v1/waiting-room/join` | Verify PoW, enqueue the client, return position / grant |
+//! | `GET` | `/api/v1/waiting-room/status` | Current position or grant for a client |
+//! | `GET` | `/api/v1/waiting-room/stream` | SSE stream pushing live position + admission grant |
+//!
+//! ## Admission flow
+//!
+//! 1. Client asks for a challenge (`challenge` endpoint).
+//! 2. Client brute-forces a `nonce` where `SHA-256(challenge || nonce)` starts
+//!    with `difficulty` hex zeros (see `services::pow`).
+//! 3. Client calls `join` with the solution. The handler verifies the PoW,
+//!    derives an admission rate from the venue's remaining inventory and adds
+//!    the client to the Redis ZSET queue (see `services::queue`).
+//! 4. A background Tokio worker admits clients at the token-bucket rate and
+//!    issues a cryptographically signed `checkout_access` grant JWT.
+//! 5. The client watches the SSE stream; when the `admitted` event arrives
+//!    with the grant token, they may proceed to checkout.
+
+use axum::{
+    extract::{Query, State},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Response,
+    },
+    Json,
+};
+use futures_util::stream::Stream;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::{convert::Infallible, sync::Arc, time::Duration};
+use uuid::Uuid;
+
+use crate::services::pow::{self, DEFAULT_CHALLENGE_TTL_SECONDS, DEFAULT_DIFFICULTY};
+use crate::services::queue::{
+    admission_rate_for_inventory, pow_challenge_key, QueueEngine, QueueStatusKind,
+    DEFAULT_ADMISSION_RATE_PER_MINUTE, DEFAULT_GRANT_TTL_MINUTES,
+};
+use crate::utils::error::{ApiError, AppError};
+use crate::utils::response::success;
+
+// ---------------------------------------------------------------------------
+// State & configuration
+// ---------------------------------------------------------------------------
+
+/// Shared state for the waiting-room routes.
+#[derive(Clone)]
+pub struct WaitingRoomState {
+    pub engine: Arc<QueueEngine>,
+    pub pool: PgPool,
+    pub config: WaitingRoomConfig,
+}
+
+/// Tuning knobs for the waiting room, read from the environment once.
+#[derive(Clone)]
+pub struct WaitingRoomConfig {
+    /// Leading hex zeros required by the PoW challenge (default 4 = 16 bits).
+    pub pow_difficulty: u32,
+    /// Maximum checkout admission rate (clients per minute) — scaled down by
+    /// remaining venue inventory at join time.
+    pub admission_rate_per_minute: u64,
+    /// Lifetime of an issued checkout access grant (minutes).
+    pub grant_ttl_minutes: i64,
+    /// Lifetime of an issued PoW challenge (seconds).
+    pub challenge_ttl_seconds: u64,
+    /// Background admission worker tick interval (ms).
+    pub tick_interval_ms: u64,
+}
+
+impl WaitingRoomConfig {
+    pub fn from_env() -> Self {
+        let env_u64 = |name: &str, default: u64| -> u64 {
+            std::env::var(name)
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default)
+        };
+        Self {
+            pow_difficulty: std::env::var("WAITING_ROOM_POW_DIFFICULTY")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_DIFFICULTY),
+            admission_rate_per_minute: env_u64(
+                "WAITING_ROOM_ADMISSION_RATE_PER_MINUTE",
+                DEFAULT_ADMISSION_RATE_PER_MINUTE,
+            ),
+            grant_ttl_minutes: env_u64("WAITING_ROOM_GRANT_TTL_MINUTES", DEFAULT_GRANT_TTL_MINUTES as u64)
+                as i64,
+            challenge_ttl_seconds: env_u64(
+                "WAITING_ROOM_CHALLENGE_TTL_SECONDS",
+                DEFAULT_CHALLENGE_TTL_SECONDS,
+            ),
+            tick_interval_ms: env_u64("WAITING_ROOM_TICK_INTERVAL_MS", 1000),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct ChallengeRequest {
+    pub event_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChallengeResponse {
+    pub challenge: String,
+    pub difficulty: u32,
+    /// Seconds until the challenge expires.
+    pub expires_in: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JoinRequest {
+    pub event_id: String,
+    /// Wallet address / device id that will be queued.
+    pub client_id: String,
+    pub challenge: String,
+    /// PoW solution such that SHA-256(challenge || nonce) has `difficulty` leading zeros.
+    pub nonce: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StatusQuery {
+    pub event_id: String,
+    pub client_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/waiting-room/challenge`
+///
+/// Issues a fresh, single-use SHA-256 proof-of-work challenge bound to the
+/// event. The challenge is stored in Redis with a short TTL; `join` consumes
+/// it so a solved nonce cannot be replayed.
+pub async fn request_challenge(
+    State(state): State<WaitingRoomState>,
+    Json(payload): Json<ChallengeRequest>,
+) -> Response {
+    if payload.event_id.trim().is_empty() {
+        return ApiError::new(
+            axum::http::StatusCode::BAD_REQUEST,
+            "event_id is required",
+        )
+        .into_response();
+    }
+
+    let challenge = pow::generate_challenge();
+    let mut conn = state.engine.redis_connection();
+
+    let stored: Result<(), redis::RedisError> = redis::cmd("SET")
+        .arg(pow_challenge_key(&challenge))
+        .arg(&payload.event_id)
+        .arg("EX")
+        .arg(state.config.challenge_ttl_seconds)
+        .query_async(&mut conn)
+        .await;
+
+    if let Err(e) = stored {
+        tracing::warn!(error = %e, "Waiting room: failed to persist PoW challenge");
+        return AppError::ExternalServiceError(format!("Redis error: {e}")).into_response();
+    }
+
+    success(
+        ChallengeResponse {
+            challenge,
+            difficulty: state.config.pow_difficulty,
+            expires_in: state.config.challenge_ttl_seconds,
+        },
+        "Proof-of-work challenge issued",
+    )
+    .into_response()
+}
+
+/// `POST /api/v1/waiting-room/join`
+///
+/// Verifies the PoW solution, derives the admission rate from the venue's
+/// remaining inventory and enqueues the client. Returns either a `waiting`
+/// status with position / estimated wait, or an `admitted` status with the
+/// signed checkout access grant when the client was already admitted.
+pub async fn join_queue(
+    State(state): State<WaitingRoomState>,
+    Json(payload): Json<JoinRequest>,
+) -> Response {
+    if payload.event_id.trim().is_empty()
+        || payload.client_id.trim().is_empty()
+        || payload.challenge.trim().is_empty()
+        || payload.nonce.trim().is_empty()
+    {
+        return ApiError::new(
+            axum::http::StatusCode::BAD_REQUEST,
+            "event_id, client_id, challenge, and nonce are all required",
+        )
+        .into_response();
+    }
+
+    if !is_valid_client_id(&payload.client_id) {
+        return ApiError::new(
+            axum::http::StatusCode::BAD_REQUEST,
+            "client_id must be 1-128 characters and contain only letters, digits, '-', '_', '.', ':'",
+        )
+        .into_response();
+    }
+
+    // Consume the challenge (single-use) — it must exist and match the event.
+    let mut conn = state.engine.redis_connection();
+    let stored_event: Result<Option<String>, redis::RedisError> = redis::cmd("GET")
+        .arg(pow_challenge_key(&payload.challenge))
+        .query_async(&mut conn)
+        .await;
+
+    let challenge_ok = match stored_event {
+        Ok(Some(event_id)) if event_id == payload.event_id => {
+            let _: Result<i64, redis::RedisError> = redis::cmd("DEL")
+                .arg(pow_challenge_key(&payload.challenge))
+                .query_async(&mut conn)
+                .await;
+            true
+        }
+        _ => false,
+    };
+
+    if !challenge_ok {
+        return ApiError::new(
+            axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "Invalid, expired, or already-used proof-of-work challenge",
+        )
+        .into_response();
+    }
+
+    if !pow::verify_pow(&payload.challenge, &payload.nonce, state.config.pow_difficulty) {
+        return ApiError::new(
+            axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "Proof-of-work solution is incorrect",
+        )
+        .into_response();
+    }
+
+    // Admission rate is derived from remaining inventory (Issue #1187).
+    let rate = match admission_rate_from_db(
+        &state.pool,
+        &payload.event_id,
+        state.config.admission_rate_per_minute,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return e.into_response(),
+    };
+
+    if rate == 0 {
+        return AppError::Conflict(
+            "This event is sold out; the waiting room is closed".to_string(),
+        )
+        .into_response();
+    }
+
+    match state
+        .engine
+        .join(&payload.event_id, &payload.client_id, rate)
+        .await
+    {
+        Ok(status) => success(status, "Joined the queue").into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+/// `GET /api/v1/waiting-room/status?event_id=&client_id=`
+///
+/// Returns the client's current position / estimated wait, or the signed
+/// grant once admitted. 404 when the client is not in the queue.
+pub async fn queue_status(
+    State(state): State<WaitingRoomState>,
+    Query(query): Query<StatusQuery>,
+) -> Response {
+    if query.event_id.trim().is_empty() || query.client_id.trim().is_empty() {
+        return ApiError::new(
+            axum::http::StatusCode::BAD_REQUEST,
+            "event_id and client_id query parameters are required",
+        )
+        .into_response();
+    }
+
+    match state.engine.status(&query.event_id, &query.client_id).await {
+        Ok(Some(status)) => success(status, "Queue status").into_response(),
+        Ok(None) => ApiError::new(
+            axum::http::StatusCode::NOT_FOUND,
+            "You are not in the queue for this event",
+        )
+        .into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+/// `GET /api/v1/waiting-room/stream?event_id=&client_id=`
+///
+/// Server-Sent Events stream that pushes a `position` event every 2 seconds
+/// ("You are #142 in line") and finally an `admitted` event carrying the
+/// cryptographically signed checkout access grant, after which the stream
+/// closes so the client can redirect to checkout.
+pub async fn queue_stream(
+    State(state): State<WaitingRoomState>,
+    Query(query): Query<StatusQuery>,
+) -> Response {
+    if query.event_id.trim().is_empty() || query.client_id.trim().is_empty() {
+        return ApiError::new(
+            axum::http::StatusCode::BAD_REQUEST,
+            "event_id and client_id query parameters are required",
+        )
+        .into_response();
+    }
+
+    let stream = position_stream(state, query.event_id, query.client_id);
+    Sse::new(stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text(": keepalive"),
+        )
+        .into_response()
+}
+
+/// Build the SSE position stream for a client.
+fn position_stream(
+    state: WaitingRoomState,
+    event_id: String,
+    client_id: String,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    async_stream::stream! {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+            match state.engine.status(&event_id, &client_id).await {
+                Ok(Some(status)) => {
+                    if status.status == QueueStatusKind::Admitted {
+                        if let Some(token) = status.grant_token {
+                            let payload = serde_json::json!({
+                                "type": "admitted",
+                                "event_id": event_id,
+                                "grant_token": token,
+                            });
+                            tracing::info!(event_id = %event_id, client_id = %client_id, "Waiting room: client admitted, closing stream");
+                            yield Ok(Event::default().data(payload.to_string()));
+                            break;
+                        }
+                    } else {
+                        let payload = serde_json::json!({
+                            "type": "position",
+                            "position": status.position,
+                            "queue_size": status.queue_size,
+                            "estimated_wait_seconds": status.estimated_wait_seconds,
+                        });
+                        yield Ok(Event::default().data(payload.to_string()));
+                    }
+                }
+                Ok(None) => {
+                    let payload = serde_json::json!({
+                        "type": "not-in-queue",
+                        "event_id": event_id,
+                    });
+                    yield Ok(Event::default().data(payload.to_string()));
+                    break;
+                }
+                Err(e) => {
+                    let payload = serde_json::json!({
+                        "type": "error",
+                        "message": e.public_message(),
+                    });
+                    yield Ok(Event::default().data(payload.to_string()));
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Admission rate for an event based on its remaining inventory.
+async fn admission_rate_from_db(
+    pool: &PgPool,
+    event_id: &str,
+    max_rate_per_minute: u64,
+) -> Result<u64, AppError> {
+    let event_uuid = Uuid::parse_str(event_id)
+        .map_err(|_| AppError::ValidationError("event_id must be a valid UUID".to_string()))?;
+
+    let row = sqlx::query_as::<_, (i64, i64)>(
+        "SELECT total_tickets, minted_tickets FROM events WHERE id = $1",
+    )
+    .bind(event_uuid)
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some((total, minted)) => Ok(admission_rate_for_inventory(
+            total,
+            minted,
+            max_rate_per_minute,
+        )),
+        None => Err(AppError::NotFound(format!("Event '{event_id}' not found"))),
+    }
+}
+
+/// Restrict client ids to safe, Redis-key-friendly values.
+fn is_valid_client_id(client_id: &str) -> bool {
+    let len = client_id.len();
+    (1..=128).contains(&len)
+        && client_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':'))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_id_validation() {
+        assert!(is_valid_client_id("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"));
+        assert!(is_valid_client_id("550e8400-e29b-41d4-a716-446655440000"));
+        assert!(is_valid_client_id("a"));
+        assert!(is_valid_client_id("device_42:ios"));
+        assert!(!is_valid_client_id(""));
+        assert!(!is_valid_client_id("has space"));
+        assert!(!is_valid_client_id("bad/char"));
+        assert!(!is_valid_client_id(&"x".repeat(129)));
+    }
+
+    #[test]
+    fn test_waiting_room_config_defaults() {
+        // Ensure no env vars leak into the defaults test.
+        for name in [
+            "WAITING_ROOM_POW_DIFFICULTY",
+            "WAITING_ROOM_ADMISSION_RATE_PER_MINUTE",
+            "WAITING_ROOM_GRANT_TTL_MINUTES",
+            "WAITING_ROOM_CHALLENGE_TTL_SECONDS",
+            "WAITING_ROOM_TICK_INTERVAL_MS",
+        ] {
+            std::env::remove_var(name);
+        }
+        let config = WaitingRoomConfig::from_env();
+        assert_eq!(config.pow_difficulty, DEFAULT_DIFFICULTY);
+        assert_eq!(
+            config.admission_rate_per_minute,
+            DEFAULT_ADMISSION_RATE_PER_MINUTE
+        );
+        assert_eq!(config.grant_ttl_minutes, DEFAULT_GRANT_TTL_MINUTES);
+        assert_eq!(config.challenge_ttl_seconds, DEFAULT_CHALLENGE_TTL_SECONDS);
+        assert_eq!(config.tick_interval_ms, 1000);
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -6,4 +6,5 @@ pub mod middleware;
 pub mod models;
 pub mod notifications;
 pub mod routes;
+pub mod services;
 pub mod utils;

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -73,10 +73,10 @@ use crate::handlers::{
     },
     ws::{ws_purchases_handler, PurchaseBroadcaster},
 };
-use crate::services::queue::QueueEngine;
 use crate::metrics::{metrics_handler, track_metrics};
 use crate::middleware::admin_auth::{require_admin_token, AdminAuthState};
 use crate::middleware::audit::audit_layer;
+use crate::services::queue::QueueEngine;
 
 /// Sensitive routes that hit the database or expose internal state.
 /// Limited to 30 requests per IP per minute.

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -67,8 +67,13 @@ use crate::handlers::{
     },
     rates::{get_rates, RatesState},
     soroban_listener::{spawn_listener, ListenerConfig},
+    waiting_room::{
+        join_queue, queue_status, queue_stream, request_challenge, WaitingRoomConfig,
+        WaitingRoomState,
+    },
     ws::{ws_purchases_handler, PurchaseBroadcaster},
 };
+use crate::services::queue::QueueEngine;
 use crate::metrics::{metrics_handler, track_metrics};
 use crate::middleware::admin_auth::{require_admin_token, AdminAuthState};
 use crate::middleware::audit::audit_layer;
@@ -103,6 +108,16 @@ pub struct ApiDoc;
 
 pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> Router {
     let broadcaster = PurchaseBroadcaster::new();
+
+    // Virtual waiting room (Issue #1187): queue engine + background admission
+    // worker. Admission rate / PoW difficulty / grant TTL are env-tunable.
+    let waiting_room_config = WaitingRoomConfig::from_env();
+    let waiting_room_engine = std::sync::Arc::new(QueueEngine::new(redis.clone()));
+    QueueEngine::spawn_admission_worker(
+        waiting_room_engine.clone(),
+        Duration::from_millis(waiting_room_config.tick_interval_ms),
+        waiting_room_config.grant_ttl_minutes,
+    );
 
     let event_state = EventState {
         pool: pool.clone(),
@@ -168,6 +183,19 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
     let ws_routes = Router::new()
         .route("/purchases", get(ws_purchases_handler))
         .with_state(broadcaster);
+
+    // Virtual waiting room routes (Issue #1187)
+    let waiting_room_state = WaitingRoomState {
+        engine: waiting_room_engine,
+        pool: pool.clone(),
+        config: waiting_room_config,
+    };
+    let waiting_room_routes = Router::new()
+        .route("/challenge", post(request_challenge))
+        .route("/join", post(join_queue))
+        .route("/status", get(queue_status))
+        .route("/stream", get(queue_stream))
+        .with_state(waiting_room_state);
 
     // QR payload routes for cryptographically signed QR codes
     let qr_routes = Router::new()
@@ -270,6 +298,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .nest("/auth", auth_routes)
         .nest("/profile", profile_routes)
         .nest("/ws", ws_routes)
+        .nest("/waiting-room", waiting_room_routes)
         .nest("/qr", qr_routes)
         .merge(rates_route)
         .layer(middleware::from_fn(require_json_content_type))

--- a/server/src/services/mod.rs
+++ b/server/src/services/mod.rs
@@ -1,0 +1,10 @@
+//! # Services Module
+//!
+//! Reusable background services that are not tied to a single HTTP handler:
+//! - [`pow`] – SHA-256 proof-of-work challenge (Hashcash-style) used to gate
+//!   entrance into the virtual waiting room (Issue #1187).
+//! - [`queue`] – the Redis-backed virtual waiting room queue engine with
+//!   token-bucket admission and signed checkout-grant issuance (Issue #1187).
+
+pub mod pow;
+pub mod queue;

--- a/server/src/services/pow.rs
+++ b/server/src/services/pow.rs
@@ -108,7 +108,10 @@ mod tests {
     fn test_verify_pow_deterministic() {
         let challenge = generate_challenge();
         let nonce = solve_pow(&challenge, 4).unwrap();
-        assert_eq!(verify_pow(&challenge, &nonce, 4), verify_pow(&challenge, &nonce, 4));
+        assert_eq!(
+            verify_pow(&challenge, &nonce, 4),
+            verify_pow(&challenge, &nonce, 4)
+        );
         // A different challenge must not accept the same nonce.
         let other = generate_challenge();
         assert_ne!(challenge, other);

--- a/server/src/services/pow.rs
+++ b/server/src/services/pow.rs
@@ -1,0 +1,126 @@
+//! # SHA-256 Proof-of-Work (Issue #1187)
+//!
+//! Hashcash-style proof-of-work used to gate entrance into the virtual
+//! waiting room. Clients are issued a random challenge and must find a `nonce`
+//! such that `SHA-256(challenge || nonce)` starts with `difficulty` hex `0`
+//! characters (i.e. `difficulty * 4` leading zero bits). This makes automated
+//! queue spam expensive while remaining trivially fast for real users on any
+//! device (a difficulty of 4 requires ~65k hash attempts on average).
+//!
+//! The challenge itself is a random 128-bit value so answers cannot be
+//! pre-computed, and handlers additionally make challenges single-use and
+//! time-limited so a solved nonce cannot be replayed.
+
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+/// Default number of leading hex zeros required (16 bits of work).
+pub const DEFAULT_DIFFICULTY: u32 = 4;
+
+/// Default lifetime of an issued challenge in seconds.
+pub const DEFAULT_CHALLENGE_TTL_SECONDS: u64 = 300;
+
+/// Generate a fresh random challenge string (32 hex chars / 16 random bytes).
+pub fn generate_challenge() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Verify that `nonce` satisfies the challenge at the given difficulty.
+///
+/// Returns `true` when `SHA-256(challenge || nonce)` begins with `difficulty`
+/// hex zeros. A difficulty of 0 always passes (no work required).
+pub fn verify_pow(challenge: &str, nonce: &str, difficulty: u32) -> bool {
+    if difficulty == 0 {
+        return true;
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(challenge.as_bytes());
+    hasher.update(nonce.as_bytes());
+    let digest = hasher.finalize();
+    hex::encode(digest)
+        .chars()
+        .take(difficulty as usize)
+        .all(|c| c == '0')
+}
+
+/// Brute-force a nonce that satisfies the challenge (used by clients and tests).
+///
+/// Iterates nonces from `0` upwards; statistically expects `2^(4*difficulty)`
+/// attempts. Returns `None` only if the search space is exhausted, which is
+/// effectively impossible at the difficulties used in practice.
+pub fn solve_pow(challenge: &str, difficulty: u32) -> Option<String> {
+    for nonce in 0..u64::MAX {
+        let candidate = nonce.to_string();
+        if verify_pow(challenge, &candidate, difficulty) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_challenge_is_random_hex() {
+        let a = generate_challenge();
+        let b = generate_challenge();
+        assert_eq!(a.len(), 32);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_verify_pow_accepts_solved_nonce() {
+        let challenge = generate_challenge();
+        let nonce = solve_pow(&challenge, 4).expect("should find a nonce at difficulty 4");
+        assert!(verify_pow(&challenge, &nonce, 4));
+    }
+
+    #[test]
+    fn test_verify_pow_rejects_bad_nonce() {
+        let challenge = generate_challenge();
+        // Nonce "0" will virtually never satisfy difficulty 4 — assert the
+        // obvious failure path and also that a difficulty bump invalidates a
+        // previously-valid nonce.
+        assert!(!verify_pow(&challenge, "0", 4));
+        let nonce = solve_pow(&challenge, 3).expect("should find a nonce at difficulty 3");
+        assert!(verify_pow(&challenge, &nonce, 3));
+        // The same nonce fails at a higher difficulty (unless the hash is
+        // spectacularly lucky — astronomically unlikely at 3 -> 4).
+        assert!(!verify_pow(&challenge, &nonce, 6));
+    }
+
+    #[test]
+    fn test_verify_pow_zero_difficulty_always_passes() {
+        assert!(verify_pow("challenge", "any-nonce", 0));
+        assert!(verify_pow("", "", 0));
+    }
+
+    #[test]
+    fn test_verify_pow_deterministic() {
+        let challenge = generate_challenge();
+        let nonce = solve_pow(&challenge, 4).unwrap();
+        assert_eq!(verify_pow(&challenge, &nonce, 4), verify_pow(&challenge, &nonce, 4));
+        // A different challenge must not accept the same nonce.
+        let other = generate_challenge();
+        assert_ne!(challenge, other);
+        assert!(!verify_pow(&other, &nonce, 4));
+    }
+
+    #[test]
+    fn test_solve_pow_expected_difficulty() {
+        // Difficulty 2 (8 bits) — quick sanity check that solved nonces carry
+        // exactly the required number of leading zeros.
+        let challenge = generate_challenge();
+        let nonce = solve_pow(&challenge, 2).unwrap();
+        assert!(verify_pow(&challenge, &nonce, 2));
+    }
+}

--- a/server/src/services/queue.rs
+++ b/server/src/services/queue.rs
@@ -1,0 +1,613 @@
+//! # Redis-backed Virtual Waiting Room Queue Engine (Issue #1187)
+//!
+//! A fair, bot-resistant virtual queue that protects checkout from
+//! connection-pool exhaustion during high-traffic ticket releases.
+//!
+//! ## Design
+//!
+//! - **Fair FIFO queue** — one Redis sorted set per event
+//!   (`agora:waiting:{event_id}:zset`). Members are scored with an atomic
+//!   per-event sequence counter, so admission order is exactly arrival order
+//!   regardless of how many workers or server replicas are running.
+//! - **Token-bucket admission** — each event has a Redis token bucket whose
+//!   refill rate is derived from the venue inventory at join time
+//!   (`rate_per_minute = min(remaining_inventory, configured_max)`). A Lua
+//!   script atomically refills the bucket and pops the queue head, so
+//!   admissions per minute can never exceed the configured rate even under
+//!   concurrency.
+//! - **Signed access grants** — admitted clients receive a short-lived JWT
+//!   (`purpose = "checkout_access"`) stored in Redis with a TTL. Handlers and
+//!   future checkout endpoints can verify it with [`verify_grant_token`].
+//! - **Background admission worker** — a Tokio interval task drains every
+//!   active event queue at the bucket rate. Clients observe their admission
+//!   through the SSE position stream (`handlers::waiting_room::queue_stream`).
+
+use crate::cache::RedisCache;
+use crate::handlers::auth::jwt_secret;
+use crate::utils::error::AppError;
+use chrono::{Duration, Utc};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use std::time::Duration as StdDuration;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Redis key helpers
+// ---------------------------------------------------------------------------
+
+/// Prefix for every waiting-room key.
+pub const WAITING_ROOM_KEY_PREFIX: &str = "agora:waiting";
+
+/// Set of event ids that currently have a non-empty queue (worker sweep list).
+pub const ACTIVE_EVENTS_KEY: &str = "agora:waiting:active";
+
+/// Prefix for single-use proof-of-work challenges.
+pub const POW_CHALLENGE_PREFIX: &str = "agora:pow";
+
+/// Default admission rate (clients per minute) when no env override is set.
+pub const DEFAULT_ADMISSION_RATE_PER_MINUTE: u64 = 60;
+
+/// Default lifetime of a checkout access grant in minutes.
+pub const DEFAULT_GRANT_TTL_MINUTES: i64 = 10;
+
+/// The queue zset member score is a per-event sequence number, giving strict FIFO order.
+fn queue_zset_key(event_id: &str) -> String {
+    format!("{WAITING_ROOM_KEY_PREFIX}:{event_id}:zset")
+}
+
+fn queue_seq_key(event_id: &str) -> String {
+    format!("{WAITING_ROOM_KEY_PREFIX}:{event_id}:seq")
+}
+
+fn queue_config_key(event_id: &str) -> String {
+    format!("{WAITING_ROOM_KEY_PREFIX}:{event_id}:config")
+}
+
+fn queue_bucket_key(event_id: &str) -> String {
+    format!("{WAITING_ROOM_KEY_PREFIX}:{event_id}:bucket")
+}
+
+fn grant_key(event_id: &str, client_id: &str) -> String {
+    format!("{WAITING_ROOM_KEY_PREFIX}:{event_id}:grant:{client_id}")
+}
+
+/// Key under which a single-use PoW challenge is stored (value = event_id).
+pub fn pow_challenge_key(challenge: &str) -> String {
+    format!("{POW_CHALLENGE_PREFIX}:{challenge}")
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Queue membership state reported to clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum QueueStatusKind {
+    /// Client is in the line, waiting for admission.
+    Waiting,
+    /// Client has been admitted and holds a checkout access grant.
+    Admitted,
+}
+
+/// Position / admission payload returned by `join` and `status`.
+#[derive(Debug, Clone, Serialize)]
+pub struct QueueStatus {
+    pub status: QueueStatusKind,
+    /// 1-based position in line, or `None` when admitted / not in queue.
+    pub position: Option<u64>,
+    /// Total number of clients currently in line.
+    pub queue_size: u64,
+    /// Estimated seconds until admission (`position / rate * 60`).
+    pub estimated_wait_seconds: Option<u64>,
+    /// Signed checkout access grant — present only when `status == admitted`.
+    pub grant_token: Option<String>,
+}
+
+/// Claims embedded in the signed checkout access grant (JWT).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GrantClaims {
+    /// Client identifier (e.g. wallet address / device id).
+    pub sub: String,
+    /// Event the grant admits the client to.
+    pub event_id: String,
+    /// Always `"checkout_access"` — allows callers to reject cross-purpose tokens.
+    pub purpose: String,
+    /// Issued-at timestamp (Unix seconds).
+    pub iat: i64,
+    /// Expiry timestamp (Unix seconds).
+    pub exp: i64,
+    /// Unique grant id (prevents token reuse confusion).
+    pub jti: String,
+}
+
+/// The purpose string embedded in every checkout access grant.
+pub const GRANT_PURPOSE: &str = "checkout_access";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-testable without Redis)
+// ---------------------------------------------------------------------------
+
+/// Admission rate (clients per minute) for an event based on its inventory.
+///
+/// * `total_tickets <= 0` – the event has no inventory cap → use `max_rate`.
+/// * `total_tickets - minted_tickets <= 0` – sold out → no admissions.
+/// * otherwise `min(remaining, max_rate)` so we never admit faster than the
+///   venue can actually sell.
+pub fn admission_rate_for_inventory(
+    total_tickets: i64,
+    minted_tickets: i64,
+    max_rate_per_minute: u64,
+) -> u64 {
+    if total_tickets <= 0 {
+        return max_rate_per_minute;
+    }
+    let remaining = total_tickets - minted_tickets;
+    match remaining {
+        r if r <= 0 => 0,
+        r => (r as u64).min(max_rate_per_minute),
+    }
+}
+
+/// Estimated wait (seconds) for a 1-based position at a given admission rate.
+pub fn estimated_wait_seconds(position: u64, rate_per_minute: u64) -> u64 {
+    if rate_per_minute == 0 {
+        return 0;
+    }
+    ((position as f64) / (rate_per_minute as f64) * 60.0).ceil() as u64
+}
+
+// ---------------------------------------------------------------------------
+// Grant token issuance / verification
+// ---------------------------------------------------------------------------
+
+/// Issue a cryptographically signed checkout access grant for `client_id`.
+pub fn issue_grant_token(
+    client_id: &str,
+    event_id: &str,
+    ttl_minutes: i64,
+) -> Result<String, AppError> {
+    let now = Utc::now();
+    let claims = GrantClaims {
+        sub: client_id.to_string(),
+        event_id: event_id.to_string(),
+        purpose: GRANT_PURPOSE.to_string(),
+        iat: now.timestamp(),
+        exp: (now + Duration::minutes(ttl_minutes)).timestamp(),
+        jti: Uuid::new_v4().to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(jwt_secret().as_bytes()),
+    )
+    .map_err(|e| AppError::InternalServerError(format!("Failed to issue checkout grant: {e}")))
+}
+
+/// Verify a checkout access grant token and return its claims.
+pub fn verify_grant_token(token: &str) -> Result<GrantClaims, AppError> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+    decode::<GrantClaims>(
+        token,
+        &DecodingKey::from_secret(jwt_secret().as_bytes()),
+        &validation,
+    )
+    .map(|data| data.claims)
+    .map_err(|e| AppError::AuthError(format!("Invalid or expired checkout grant: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Queue engine
+// ---------------------------------------------------------------------------
+
+/// Lua script that atomically refills an event's admission token bucket and
+/// pops the head of its queue. Returns the admitted client ids.
+///
+/// KEYS[1] = bucket hash key (fields: `tokens`, `last_refill`)
+/// KEYS[2] = queue zset key
+/// ARGV[1] = now (ms)
+/// ARGV[2] = refill rate (tokens per second)
+/// ARGV[3] = bucket capacity (max stored tokens)
+/// ARGV[4] = max clients to admit in this call
+const ADMIT_LUA: &str = r#"
+local tokens = redis.call('HGET', KEYS[1], 'tokens')
+local last = redis.call('HGET', KEYS[1], 'last_refill')
+if not tokens then tokens = 0 else tokens = tonumber(tokens) end
+if not last then last = tonumber(ARGV[1]) else last = tonumber(last) end
+local elapsed = (tonumber(ARGV[1]) - last) / 1000.0
+tokens = tokens + elapsed * tonumber(ARGV[2])
+if tokens > tonumber(ARGV[3]) then tokens = tonumber(ARGV[3]) end
+if tokens < 1 then
+  redis.call('HSET', KEYS[1], 'tokens', tokens, 'last_refill', ARGV[1])
+  return {}
+end
+local take = math.min(math.floor(tokens), tonumber(ARGV[4]))
+local members = redis.call('ZRANGE', KEYS[2], 0, take - 1)
+local admitted = {}
+if #members > 0 then
+  redis.call('ZREM', KEYS[2], unpack(members))
+  admitted = members
+end
+redis.call('HSET', KEYS[1], 'tokens', tokens - #members, 'last_refill', ARGV[1])
+return admitted
+"#;
+
+/// The virtual waiting room engine.
+///
+/// Cheap to clone (`RedisCache` wraps a multiplexed connection manager), so it
+/// can be shared across handlers and background tasks.
+#[derive(Clone)]
+pub struct QueueEngine {
+    redis: RedisCache,
+}
+
+impl QueueEngine {
+    pub fn new(redis: RedisCache) -> Self {
+        Self { redis }
+    }
+
+    /// Clone the underlying Redis connection for ad-hoc commands (e.g. PoW
+    /// challenge persistence in the handlers).
+    pub fn redis_connection(&self) -> redis::aio::ConnectionManager {
+        self.redis.connection()
+    }
+
+    // -- public API ---------------------------------------------------------
+
+    /// Add `client_id` to the FIFO queue for `event_id` (idempotent) and
+    /// report their position. Returns an `Admitted` status immediately when
+    /// the client already holds a grant.
+    pub async fn join(
+        &self,
+        event_id: &str,
+        client_id: &str,
+        rate_per_minute: u64,
+    ) -> Result<QueueStatus, AppError> {
+        if rate_per_minute == 0 {
+            return Err(AppError::Conflict(
+                "This event is sold out; the waiting room is closed".to_string(),
+            ));
+        }
+
+        let mut conn = self.redis.connection();
+
+        // Already admitted → hand back the grant instead of re-queueing.
+        if let Some(token) = self.grant_for(event_id, client_id).await? {
+            return Ok(QueueStatus {
+                status: QueueStatusKind::Admitted,
+                position: None,
+                queue_size: self.queue_size(event_id).await?,
+                estimated_wait_seconds: Some(0),
+                grant_token: Some(token),
+            });
+        }
+
+        // FIFO enqueue: score with an atomic per-event sequence number.
+        let seq: i64 = redis::cmd("INCR")
+            .arg(queue_seq_key(event_id))
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        let _added: i64 = redis::cmd("ZADD")
+            .arg(queue_zset_key(event_id))
+            .arg("NX")
+            .arg(seq)
+            .arg(client_id)
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        // Keep the worker sweeping this event and persist its admission rate
+        // (first join wins; later inventory changes don't yank the rate).
+        let _: i64 = redis::cmd("SADD")
+            .arg(ACTIVE_EVENTS_KEY)
+            .arg(event_id)
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        let _: bool = redis::cmd("HSETNX")
+            .arg(queue_config_key(event_id))
+            .arg("rate_per_minute")
+            .arg(rate_per_minute)
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        // `_added` is 0 on idempotent re-join (member already queued).
+
+        let rank: Option<i64> = redis::cmd("ZRANK")
+            .arg(queue_zset_key(event_id))
+            .arg(client_id)
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        let position = rank.map(|r| (r + 1) as u64).unwrap_or(1);
+        let queue_size = self.queue_size(event_id).await?;
+
+        Ok(QueueStatus {
+            status: QueueStatusKind::Waiting,
+            position: Some(position),
+            queue_size,
+            estimated_wait_seconds: Some(estimated_wait_seconds(
+                position,
+                rate_per_minute,
+            )),
+            grant_token: None,
+        })
+    }
+
+    /// Current queue status for `client_id`; `None` if they are not in the
+    /// queue and hold no grant.
+    pub async fn status(
+        &self,
+        event_id: &str,
+        client_id: &str,
+    ) -> Result<Option<QueueStatus>, AppError> {
+        let mut conn = self.redis.connection();
+
+        if let Some(token) = self.grant_for(event_id, client_id).await? {
+            return Ok(Some(QueueStatus {
+                status: QueueStatusKind::Admitted,
+                position: None,
+                queue_size: self.queue_size(event_id).await?,
+                estimated_wait_seconds: Some(0),
+                grant_token: Some(token),
+            }));
+        }
+
+        let rank: Option<i64> = redis::cmd("ZRANK")
+            .arg(queue_zset_key(event_id))
+            .arg(client_id)
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        let Some(rank) = rank else {
+            return Ok(None);
+        };
+
+        let position = (rank + 1) as u64;
+        let rate = self.rate_per_minute(event_id).await?;
+        let queue_size = self.queue_size(event_id).await?;
+
+        Ok(Some(QueueStatus {
+            status: QueueStatusKind::Waiting,
+            position: Some(position),
+            queue_size,
+            estimated_wait_seconds: Some(estimated_wait_seconds(position, rate)),
+            grant_token: None,
+        }))
+    }
+
+    /// Spawn the background admission worker. Runs `tick`-periodically,
+    /// draining every active event queue at its token-bucket rate and issuing
+    /// signed grants with the given TTL.
+    pub fn spawn_admission_worker(engine: std::sync::Arc<Self>, tick: StdDuration, grant_ttl_minutes: i64) {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tick);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                match engine.admit_all(grant_ttl_minutes).await {
+                    Ok(total) => {
+                        if total > 0 {
+                            tracing::info!(admitted = total, "Waiting room: admitted clients");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Waiting room admission worker error");
+                    }
+                }
+            }
+        });
+    }
+
+    // -- internals ----------------------------------------------------------
+
+    /// Admit clients from every active event queue.
+    async fn admit_all(&self, grant_ttl_minutes: i64) -> Result<usize, AppError> {
+        let mut conn = self.redis.connection();
+        let event_ids: Vec<String> = redis::cmd("SMEMBERS")
+            .arg(ACTIVE_EVENTS_KEY)
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        let mut total = 0usize;
+        for event_id in event_ids {
+            total += self.admit_for_event(&event_id, grant_ttl_minutes).await?;
+        }
+        Ok(total)
+    }
+
+    /// Admit up to the token-bucket allowance for one event, issuing grants.
+    async fn admit_for_event(
+        &self,
+        event_id: &str,
+        grant_ttl_minutes: i64,
+    ) -> Result<usize, AppError> {
+        let mut conn = self.redis.connection();
+
+        let rate = self.rate_per_minute(event_id).await?;
+        if rate == 0 {
+            return Ok(0);
+        }
+
+        let now_ms = Utc::now().timestamp_millis();
+        let refill_per_sec = rate as f64 / 60.0;
+        let capacity = rate as f64;
+        let max_admit = capacity.ceil() as i64;
+
+        let admitted: Vec<String> = redis::cmd("EVAL")
+            .arg(ADMIT_LUA)
+            .arg(2) // numkeys
+            .arg(queue_bucket_key(event_id))
+            .arg(queue_zset_key(event_id))
+            .arg(now_ms)
+            .arg(refill_per_sec)
+            .arg(capacity)
+            .arg(max_admit)
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        for client_id in &admitted {
+            let token = issue_grant_token(client_id, event_id, grant_ttl_minutes)?;
+            let _: () = redis::cmd("SET")
+                .arg(grant_key(event_id, client_id))
+                .arg(&token)
+                .arg("EX")
+                .arg((grant_ttl_minutes * 60).max(60))
+                .query_async(&mut conn)
+                .await
+                .map_err(redis_err)?;
+            tracing::info!(
+                event_id = %event_id,
+                client_id = %client_id,
+                "Waiting room: issued checkout access grant"
+            );
+        }
+
+        // Stop sweeping the event once its queue is empty.
+        let remaining: i64 = redis::cmd("ZCARD")
+            .arg(queue_zset_key(event_id))
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+        if remaining == 0 {
+            let _: i64 = redis::cmd("SREM")
+                .arg(ACTIVE_EVENTS_KEY)
+                .arg(event_id)
+                .query_async(&mut conn)
+                .await
+                .map_err(redis_err)?;
+        }
+
+        Ok(admitted.len())
+    }
+
+    /// The configured admission rate for an event (fallback: default).
+    async fn rate_per_minute(&self, event_id: &str) -> Result<u64, AppError> {
+        let mut conn = self.redis.connection();
+        let entries: Vec<(String, String)> = redis::cmd("HGETALL")
+            .arg(queue_config_key(event_id))
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+
+        Ok(entries
+            .into_iter()
+            .find(|(k, _)| k == "rate_per_minute")
+            .and_then(|(_, v)| v.parse().ok())
+            .unwrap_or(DEFAULT_ADMISSION_RATE_PER_MINUTE))
+    }
+
+    /// Fetch a stored grant token for a client, if any.
+    async fn grant_for(&self, event_id: &str, client_id: &str) -> Result<Option<String>, AppError> {
+        let mut conn = self.redis.connection();
+        let token: Option<String> = redis::cmd("GET")
+            .arg(grant_key(event_id, client_id))
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(token)
+    }
+
+    /// Number of clients currently in the queue for an event.
+    async fn queue_size(&self, event_id: &str) -> Result<u64, AppError> {
+        let mut conn = self.redis.connection();
+        let size: i64 = redis::cmd("ZCARD")
+            .arg(queue_zset_key(event_id))
+            .query_async(&mut conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(size.max(0) as u64)
+    }
+}
+
+fn redis_err(e: redis::RedisError) -> AppError {
+    AppError::ExternalServiceError(format!("Redis error: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ensure_test_jwt_secret() {
+        std::env::set_var("JWT_SECRET", "test-secret-for-waiting-room-unit-tests-32b");
+    }
+
+    #[test]
+    fn test_admission_rate_scales_with_inventory() {
+        // No inventory cap → max rate.
+        assert_eq!(admission_rate_for_inventory(0, 0, 60), 60);
+        // Plenty of inventory → max rate.
+        assert_eq!(admission_rate_for_inventory(500, 10, 60), 60);
+        // Limited inventory → rate clamped to what remains.
+        assert_eq!(admission_rate_for_inventory(100, 85, 60), 15);
+        assert_eq!(admission_rate_for_inventory(100, 99, 60), 1);
+        // Sold out → no admissions.
+        assert_eq!(admission_rate_for_inventory(100, 100, 60), 0);
+        assert_eq!(admission_rate_for_inventory(100, 120, 60), 0);
+        // Small venue but large configured max → still clamped.
+        assert_eq!(admission_rate_for_inventory(3, 0, 600), 3);
+    }
+
+    #[test]
+    fn test_estimated_wait_seconds() {
+        // #1 at 60/min → ~1s.
+        assert_eq!(estimated_wait_seconds(1, 60), 1);
+        // #142 at 60/min → ceil(142/60*60) = 142s.
+        assert_eq!(estimated_wait_seconds(142, 60), 142);
+        // #30 at 120/min → ceil(15) = 15s.
+        assert_eq!(estimated_wait_seconds(30, 120), 15);
+        // Zero rate → 0 (defensive).
+        assert_eq!(estimated_wait_seconds(10, 0), 0);
+    }
+
+    #[test]
+    fn test_grant_token_roundtrip() {
+        ensure_test_jwt_secret();
+        let token = issue_grant_token("GCLIENT123", "550e8400-e29b-41d4-a716-446655440000", 10)
+            .expect("grant should be issued");
+        let claims = verify_grant_token(&token).expect("grant should verify");
+        assert_eq!(claims.sub, "GCLIENT123");
+        assert_eq!(claims.purpose, GRANT_PURPOSE);
+        assert_eq!(
+            claims.event_id,
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert!(claims.exp > claims.iat);
+        assert!(!claims.jti.is_empty());
+    }
+
+    #[test]
+    fn test_grant_token_rejects_garbage() {
+        ensure_test_jwt_secret();
+        assert!(verify_grant_token("not.a.grant").is_err());
+    }
+
+    #[test]
+    fn test_key_builders_are_namespaced() {
+        assert_eq!(
+            queue_zset_key("e1"),
+            format!("{WAITING_ROOM_KEY_PREFIX}:e1:zset")
+        );
+        assert_eq!(
+            grant_key("e1", "c1"),
+            format!("{WAITING_ROOM_KEY_PREFIX}:e1:grant:c1")
+        );
+        assert_eq!(
+            pow_challenge_key("abc"),
+            format!("{POW_CHALLENGE_PREFIX}:abc")
+        );
+    }
+}

--- a/server/src/services/queue.rs
+++ b/server/src/services/queue.rs
@@ -332,10 +332,7 @@ impl QueueEngine {
             status: QueueStatusKind::Waiting,
             position: Some(position),
             queue_size,
-            estimated_wait_seconds: Some(estimated_wait_seconds(
-                position,
-                rate_per_minute,
-            )),
+            estimated_wait_seconds: Some(estimated_wait_seconds(position, rate_per_minute)),
             grant_token: None,
         })
     }
@@ -386,7 +383,11 @@ impl QueueEngine {
     /// Spawn the background admission worker. Runs `tick`-periodically,
     /// draining every active event queue at its token-bucket rate and issuing
     /// signed grants with the given TTL.
-    pub fn spawn_admission_worker(engine: std::sync::Arc<Self>, tick: StdDuration, grant_ttl_minutes: i64) {
+    pub fn spawn_admission_worker(
+        engine: std::sync::Arc<Self>,
+        tick: StdDuration,
+        grant_ttl_minutes: i64,
+    ) {
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(tick);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -581,10 +582,7 @@ mod tests {
         let claims = verify_grant_token(&token).expect("grant should verify");
         assert_eq!(claims.sub, "GCLIENT123");
         assert_eq!(claims.purpose, GRANT_PURPOSE);
-        assert_eq!(
-            claims.event_id,
-            "550e8400-e29b-41d4-a716-446655440000"
-        );
+        assert_eq!(claims.event_id, "550e8400-e29b-41d4-a716-446655440000");
         assert!(claims.exp > claims.iat);
         assert!(!claims.jti.is_empty());
     }


### PR DESCRIPTION
## Summary

Implements the High-Concurrency Virtual Waiting Room & Bot-Resistant Queueing Gateway (#1187) across the server (Rust/Axum/Redis) and mobile (Expo) apps.

### Server

**Token-Bucket Queueing Engine** (`server/src/services/queue.rs`)
- Fair FIFO virtual line per event backed by a Redis ZSET, scored with an atomic per-event sequence counter (strict arrival order across workers/replicas).
- Strict admission rate limit based on venue inventory: `rate_per_minute = min(remaining_inventory, configured max)`. A Lua script atomically refills the per-event token bucket and pops the queue head, so admissions can never exceed the per-minute rate under concurrency.
- Tokio async interval worker (`spawn_admission_worker`) drains every active event queue and issues cryptographically signed `checkout_access` grant JWTs (stored in Redis with a TTL; verifiable via `verify_grant_token`).
- Env-tunable: `WAITING_ROOM_ADMISSION_RATE_PER_MINUTE`, `WAITING_ROOM_POW_DIFFICULTY`, `WAITING_ROOM_GRANT_TTL_MINUTES`, `WAITING_ROOM_CHALLENGE_TTL_SECONDS`, `WAITING_ROOM_TICK_INTERVAL_MS`.

**PoW Anti-Bot Challenge** (`server/src/services/pow.rs`)
- Hashcash-style SHA-256 challenge: clients must find a nonce where `SHA-256(challenge || nonce)` starts with `difficulty` hex zeros (default 4 = 16 bits). Challenges are random, single-use (consumed on join) and expire after 5 minutes.

**SSE Queue Position Streaming** (`server/src/handlers/waiting_room.rs`)
- `POST /api/v1/waiting-room/challenge` – issue a single-use PoW challenge
- `POST /api/v1/waiting-room/join` – verify PoW, enqueue, return position / estimated wait / grant
- `GET  /api/v1/waiting-room/status` – current position or grant
- `GET  /api/v1/waiting-room/stream` – SSE stream pushing `position` events every 2s ("You are #142 in line", "Estimated wait: 45s") and finally an `admitted` event with the signed grant, then closes.

### Mobile (`apps/mobile`)
- `utils/sha256.ts` – dependency-free pure-TS SHA-256 (verified against NIST vectors) so PoW solving works on Hermes/web/Jest without `expo-crypto`.
- `services/waitingRoom.ts` – challenge fetch, PoW solver, join/status API, and an SSE client built on `XMLHttpRequest` (RN `fetch` cannot stream bodies).
- `hooks/useWaitingRoom.ts` – state machine: fetch challenge → solve → join → stream position → admitted.
- `app/checkout/waiting-room.tsx` – dedicated countdown/waiting screen showing live position + estimated wait, with **auto-redirect to checkout upon receiving the signed access grant token**.
- Checkout screen gains a "High demand? Join the virtual queue" entry point and threads the grant token through the receipt.

## Verification

- `cargo check --all-targets`, `cargo clippy --lib`, `cargo test --lib` (356 tests) — all green on Rust 1.97 (matching CI)
- `tsc --noEmit`, `eslint`, `jest` (167 tests, 21 suites) — all green
- New unit tests: PoW challenge/verify, admission-rate-from-inventory, estimated wait, grant JWT roundtrip, client-id validation, SHA-256 test vectors, SSE stream parsing (split frames + keepalive), waiting-room screen phases + auto-redirect.

Closes #1187