### PR TITLE
feat: E2EE atomic ticket resale and capped secondary market

### DIFF
--- a/apps/mobile/app/ticket/resale.tsx
+++ b/apps/mobile/app/ticket/resale.tsx
@@ -1,0 +1,682 @@
+/**
+ * resale.tsx — secondary market screen for a single ticket (issue #1184).
+ *
+ * Route: `/ticket/resale?paymentId=<on-chain payment id>&eventId=<event id>`
+ *
+ * The screen covers the seller's whole journey in one place, because the steps
+ * are not independent — listing, watching offers, and handing over the ticket
+ * key are one obligation, and dropping out halfway leaves a buyer with a
+ * ticket they cannot use.
+ *
+ *   1. **Cap feedback.** The ceiling is read from the contract before the form
+ *      is usable, so the seller sees the maximum up front and gets live
+ *      validation while typing rather than a rejected transaction later.
+ *   2. **Listing management.** List and cancel, mirroring each confirmed
+ *      on-chain action to the backend so the listing is discoverable.
+ *   3. **Offers.** Buyers publish an X25519 key with their offer. Accepting one
+ *      seals this ticket's check-in secret to that key and uploads the
+ *      envelope; the server relays ciphertext it cannot read.
+ *
+ * Settlement itself happens on the buyer's device — `purchase_resale_ticket`
+ * moves money and ownership atomically — which is why the seller's "accept"
+ * action is a key handover rather than a transfer.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+import Colors from '@/constants/Colors';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { useAuth } from '@/hooks/useAuth';
+import { useSaleNotifications } from '@/hooks/useSaleNotifications';
+import {
+  fetchMaxResalePrice,
+  fetchOnChainListing,
+  submitCancelResaleListing,
+  submitListForResale,
+  type OnChainResaleListing,
+} from '@/services/resaleContract';
+import {
+  fetchOffers,
+  publishListing,
+  uploadKeyEnvelope,
+  withdrawListing,
+  type ResaleOffer,
+} from '@/services/marketplaceApi';
+import { clearTicketSecret, getTicketSecret, sealTicketSecret } from '@/services/resaleCrypto';
+import { describePurchaseFailure, stroopsToUsdc, usdcToStroops } from '@/services/ticketPaymentContract';
+
+/** How often the offer book refreshes while the screen is open. */
+const OFFER_POLL_INTERVAL_MS = 20_000;
+
+type ScreenState = 'loading' | 'ready' | 'error';
+
+export default function TicketResaleScreen() {
+  const { paymentId, eventId } = useLocalSearchParams<{
+    paymentId?: string;
+    eventId?: string;
+  }>();
+  const { user } = useAuth();
+
+  const [screenState, setScreenState] = useState<ScreenState>('loading');
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [maxPriceStroops, setMaxPriceStroops] = useState<bigint | null>(null);
+  const [listing, setListing] = useState<OnChainResaleListing | null>(null);
+  const [offers, setOffers] = useState<ResaleOffer[]>([]);
+
+  const [priceInput, setPriceInput] = useState('');
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [isRefreshing, setRefreshing] = useState(false);
+  /** Wallet of the offer currently being sealed, so only its row shows a spinner. */
+  const [sealingFor, setSealingFor] = useState<string | null>(null);
+
+  // Ask for push permission on arrival: the seller is about to take on an
+  // obligation that only they can discharge.
+  const notifications = useSaleNotifications(Boolean(paymentId));
+
+  const isListed = listing?.status === 'Active';
+
+  // ── Loading ───────────────────────────────────────────────────────────────
+
+  const loadChainState = useCallback(async () => {
+    if (!paymentId) {
+      setLoadError('No ticket was specified for resale.');
+      setScreenState('error');
+      return;
+    }
+
+    try {
+      const [cap, existing] = await Promise.all([
+        fetchMaxResalePrice(paymentId),
+        fetchOnChainListing(paymentId),
+      ]);
+
+      setMaxPriceStroops(cap);
+      setListing(existing);
+      // Prefill with the live listing price, or the cap for a fresh listing —
+      // the cap is the useful anchor, since the seller is choosing under it.
+      setPriceInput(
+        stroopsToUsdc(existing?.status === 'Active' ? existing.price : cap).toFixed(2)
+      );
+      setScreenState('ready');
+      setLoadError(null);
+    } catch (error) {
+      setLoadError(describePurchaseFailure(error));
+      setScreenState('error');
+    }
+  }, [paymentId]);
+
+  const loadOffers = useCallback(async () => {
+    if (!paymentId) return;
+    try {
+      setOffers(await fetchOffers(paymentId));
+    } catch {
+      // The offer book is supplementary; a failure here must not take down the
+      // listing controls, which are the part the seller actually needs.
+    }
+  }, [paymentId]);
+
+  useEffect(() => {
+    loadChainState();
+  }, [loadChainState]);
+
+  useEffect(() => {
+    if (!isListed) return;
+
+    loadOffers();
+    const timer = setInterval(loadOffers, OFFER_POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [isListed, loadOffers]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await Promise.all([loadChainState(), loadOffers()]);
+    setRefreshing(false);
+  }, [loadChainState, loadOffers]);
+
+  // ── Live price validation ─────────────────────────────────────────────────
+
+  /**
+   * Validates the typed price against the cap and derives what the seller
+   * would actually take home. Recomputed on every keystroke so the feedback
+   * tracks the input rather than the last submission.
+   */
+  const priceFeedback = useMemo(() => {
+    if (maxPriceStroops == null) return null;
+
+    const maxUsdc = stroopsToUsdc(maxPriceStroops);
+    const parsed = Number(priceInput);
+
+    if (priceInput.trim() === '') {
+      return { error: null as string | null, maxUsdc, royaltyUsdc: 0, proceedsUsdc: 0 };
+    }
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return {
+        error: 'Enter a price greater than 0.',
+        maxUsdc,
+        royaltyUsdc: 0,
+        proceedsUsdc: 0,
+      };
+    }
+    if (usdcToStroops(parsed) > maxPriceStroops) {
+      return {
+        error: `Above the ${maxUsdc.toFixed(2)} USDC cap for this ticket. The organizer limits resale markup to protect buyers.`,
+        maxUsdc,
+        royaltyUsdc: 0,
+        proceedsUsdc: 0,
+      };
+    }
+
+    // Mirrors `resale::split_proceeds` — royalty floors, dust to the seller.
+    const royaltyBps = listing?.royaltyBps ?? 500;
+    const royaltyUsdc = Math.floor((parsed * royaltyBps) / 100) / 100;
+
+    return {
+      error: null,
+      maxUsdc,
+      royaltyUsdc,
+      proceedsUsdc: parsed - royaltyUsdc,
+    };
+  }, [priceInput, maxPriceStroops, listing?.royaltyBps]);
+
+  const canSubmitPrice = Boolean(
+    priceFeedback && !priceFeedback.error && priceInput.trim() !== ''
+  );
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+
+  const handleList = useCallback(async () => {
+    if (!paymentId || !canSubmitPrice) return;
+
+    setSubmitting(true);
+    try {
+      const { hash, listing: created } = await submitListForResale(
+        paymentId,
+        Number(priceInput)
+      );
+      setListing(created);
+
+      // Mirror to the backend so buyers can discover it. The listing is real
+      // on-chain either way, so a mirror failure is a discoverability problem,
+      // not a failed sale — say so rather than implying the listing failed.
+      try {
+        await publishListing({
+          paymentId,
+          eventId: eventId ?? created.eventId,
+          priceStroops: created.price,
+          maxPriceStroops: created.maxPrice,
+          royaltyBps: created.royaltyBps,
+          listingTxHash: hash,
+        });
+        Alert.alert('Listed', 'Your ticket is now on the resale market.');
+      } catch (error) {
+        Alert.alert(
+          'Listed on-chain',
+          `Your ticket is listed, but it could not be published to the marketplace feed yet: ${
+            error instanceof Error ? error.message : 'unknown error'
+          }. Pull to refresh to retry.`
+        );
+      }
+
+      loadOffers();
+    } catch (error) {
+      Alert.alert('Listing failed', describePurchaseFailure(error));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [paymentId, eventId, priceInput, canSubmitPrice, loadOffers]);
+
+  const handleCancel = useCallback(async () => {
+    if (!paymentId) return;
+
+    setSubmitting(true);
+    try {
+      await submitCancelResaleListing(paymentId);
+      try {
+        await withdrawListing(paymentId);
+      } catch {
+        // Same reasoning as listing: the chain is authoritative. A stale feed
+        // entry resolves on the next mirror.
+      }
+      await loadChainState();
+      setOffers([]);
+      Alert.alert('Unlisted', 'Your ticket has been taken off the resale market.');
+    } catch (error) {
+      Alert.alert('Could not unlist', describePurchaseFailure(error));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [paymentId, loadChainState]);
+
+  /**
+   * Seals this ticket's check-in secret to the chosen buyer and uploads it.
+   *
+   * Only meaningful once that buyer has settled on-chain — until then the
+   * seller still owns the ticket. The confirmation spells that out, since
+   * sending the key to someone who has not paid gives away the ticket.
+   */
+  const handleSendKey = useCallback(
+    async (offer: ResaleOffer) => {
+      if (!paymentId) return;
+
+      const secret = await getTicketSecret(paymentId);
+      if (!secret) {
+        Alert.alert(
+          'Ticket key unavailable',
+          'This device does not hold the check-in key for this ticket, so the handover cannot be completed here. Use the device you originally bought the ticket on.'
+        );
+        return;
+      }
+
+      Alert.alert(
+        'Send ticket key?',
+        `This hands the check-in key to ${shortenWallet(offer.buyer_wallet)}. Only do this once their purchase has settled on-chain — afterwards they can enter the event with this ticket.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Send key',
+            style: 'destructive',
+            onPress: async () => {
+              setSealingFor(offer.buyer_wallet);
+              try {
+                const envelope = sealTicketSecret(secret, offer.buyer_public_key);
+                await uploadKeyEnvelope(paymentId, offer.buyer_wallet, envelope);
+
+                // The ticket is theirs now; keeping our copy only widens the
+                // window in which it could leak from this device.
+                await clearTicketSecret(paymentId);
+
+                await loadChainState();
+                await loadOffers();
+                Alert.alert('Key sent', 'The buyer can now check in with this ticket.');
+              } catch (error) {
+                Alert.alert(
+                  'Could not send key',
+                  error instanceof Error ? error.message : 'Unknown error.'
+                );
+              } finally {
+                setSealingFor(null);
+              }
+            },
+          },
+        ]
+      );
+    },
+    [paymentId, loadChainState, loadOffers]
+  );
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  if (screenState === 'loading') {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={Colors.primaryYellow} />
+        <Text style={styles.mutedText}>Checking the resale price cap…</Text>
+      </View>
+    );
+  }
+
+  if (screenState === 'error') {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{loadError}</Text>
+        <Button title="Try again" onPress={loadChainState} style={styles.fullWidthButton} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefreshing}
+          onRefresh={onRefresh}
+          tintColor={Colors.primaryYellow}
+        />
+      }
+    >
+      <Text style={styles.header}>Resell Ticket</Text>
+      <Text style={styles.subheader}>{paymentId}</Text>
+
+      {/* Cap panel — the anti-scalping rule, stated before the seller types. */}
+      <View style={styles.capCard}>
+        <Text style={styles.capLabel}>Maximum resale price</Text>
+        <Text style={styles.capValue}>
+          {priceFeedback ? `${priceFeedback.maxUsdc.toFixed(2)} USDC` : '—'}
+        </Text>
+        <Text style={styles.capNote}>
+          Enforced on-chain. The organizer caps how far above face value a ticket can be
+          resold, and takes a {((listing?.royaltyBps ?? 500) / 100).toFixed(1)}% royalty on
+          each sale.
+        </Text>
+      </View>
+
+      {isListed ? (
+        <View style={styles.statusCard}>
+          <Text style={styles.statusBadge}>Listed</Text>
+          <Text style={styles.statusPrice}>
+            {stroopsToUsdc(listing!.price).toFixed(2)} USDC
+          </Text>
+          <Text style={styles.mutedText}>
+            Waiting for a buyer. You will be notified when it sells
+            {notifications.token ? '' : ' — enable notifications so you do not miss it'}.
+          </Text>
+          <Button
+            title="Remove listing"
+            variant="outline"
+            onPress={handleCancel}
+            loading={isSubmitting}
+            style={styles.fullWidthButton}
+          />
+        </View>
+      ) : (
+        <View style={styles.formCard}>
+          <Input
+            label="Asking price (USDC)"
+            placeholder="0.00"
+            keyboardType="decimal-pad"
+            value={priceInput}
+            onChangeText={setPriceInput}
+            error={priceFeedback?.error ?? undefined}
+          />
+
+          {priceFeedback && !priceFeedback.error && priceInput.trim() !== '' && (
+            <View style={styles.breakdown}>
+              <BreakdownRow
+                label="Organizer royalty"
+                value={`−${priceFeedback.royaltyUsdc.toFixed(2)} USDC`}
+              />
+              <BreakdownRow
+                label="You receive"
+                value={`${priceFeedback.proceedsUsdc.toFixed(2)} USDC`}
+                emphasis
+              />
+            </View>
+          )}
+
+          <Button
+            title="List for resale"
+            onPress={handleList}
+            disabled={!canSubmitPrice}
+            loading={isSubmitting}
+            style={styles.fullWidthButton}
+          />
+        </View>
+      )}
+
+      {/* Offers */}
+      {isListed && (
+        <View style={styles.offersSection}>
+          <Text style={styles.sectionTitle}>Offers ({offers.length})</Text>
+
+          {offers.length === 0 ? (
+            <Text style={styles.mutedText}>
+              No offers yet. Buyers who are interested will appear here.
+            </Text>
+          ) : (
+            offers.map((offer) => (
+              <View key={offer.id} style={styles.offerRow}>
+                <View style={styles.offerInfo}>
+                  <Text style={styles.offerWallet}>{shortenWallet(offer.buyer_wallet)}</Text>
+                  <Text style={styles.offerPrice}>
+                    {stroopsToUsdc(BigInt(offer.offer_price_stroops)).toFixed(2)} USDC
+                  </Text>
+                  <Text style={styles.offerStatus}>{offer.status}</Text>
+                </View>
+                {offer.status === 'accepted' ? (
+                  <Text style={styles.offerDone}>Key sent</Text>
+                ) : (
+                  <Button
+                    title="Send key"
+                    onPress={() => handleSendKey(offer)}
+                    loading={sealingFor === offer.buyer_wallet}
+                    disabled={sealingFor != null}
+                    style={styles.offerButton}
+                  />
+                )}
+              </View>
+            ))
+          )}
+
+          <Text style={styles.helpText}>
+            The buyer pays and receives ownership in a single on-chain transaction. Sending
+            the key is the last step — it is encrypted to that buyer alone and nobody in
+            between, including Agora, can read it.
+          </Text>
+        </View>
+      )}
+
+      {user?.walletAddress ? (
+        <Text style={styles.footerNote}>Selling as {shortenWallet(user.walletAddress)}</Text>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function BreakdownRow({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: string;
+  emphasis?: boolean;
+}) {
+  return (
+    <View style={styles.breakdownRow}>
+      <Text style={[styles.breakdownLabel, emphasis && styles.breakdownEmphasis]}>
+        {label}
+      </Text>
+      <Text style={[styles.breakdownValue, emphasis && styles.breakdownEmphasis]}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+/** Renders a Stellar address as `GABC…WXYZ` for compact display. */
+function shortenWallet(wallet: string): string {
+  if (wallet.length <= 12) return wallet;
+  return `${wallet.slice(0, 4)}…${wallet.slice(-4)}`;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.darkBackground,
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 48,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: Colors.darkBackground,
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: Colors.primaryText,
+  },
+  subheader: {
+    fontSize: 12,
+    color: Colors.secondaryText,
+    fontFamily: 'SpaceMono',
+    marginTop: 4,
+    marginBottom: 20,
+  },
+  capCard: {
+    backgroundColor: '#1E1E20',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    borderLeftWidth: 4,
+    borderLeftColor: Colors.primaryYellow,
+    borderWidth: 1,
+    borderColor: '#2C2C2E',
+  },
+  capLabel: {
+    fontSize: 12,
+    color: Colors.secondaryText,
+    marginBottom: 4,
+  },
+  capValue: {
+    fontSize: 26,
+    fontWeight: 'bold',
+    color: Colors.primaryYellow,
+    marginBottom: 8,
+  },
+  capNote: {
+    fontSize: 12,
+    color: Colors.secondaryText,
+    lineHeight: 18,
+  },
+  formCard: {
+    backgroundColor: '#1E1E20',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: '#2C2C2E',
+  },
+  statusCard: {
+    backgroundColor: '#1E1E20',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: '#2C2C2E',
+    alignItems: 'flex-start',
+  },
+  statusBadge: {
+    backgroundColor: '#34C75922',
+    color: '#34C759',
+    fontSize: 10,
+    fontWeight: 'bold',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+    overflow: 'hidden',
+    marginBottom: 8,
+  },
+  statusPrice: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: Colors.primaryText,
+    marginBottom: 8,
+  },
+  breakdown: {
+    borderTopWidth: 1,
+    borderTopColor: '#2C2C2E',
+    paddingTop: 12,
+    marginBottom: 16,
+  },
+  breakdownRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  breakdownLabel: {
+    fontSize: 13,
+    color: Colors.secondaryText,
+  },
+  breakdownValue: {
+    fontSize: 13,
+    color: Colors.primaryText,
+  },
+  breakdownEmphasis: {
+    color: Colors.primaryYellow,
+    fontWeight: 'bold',
+  },
+  offersSection: {
+    marginTop: 8,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: Colors.primaryText,
+    marginBottom: 12,
+  },
+  offerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#1E1E20',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: '#2C2C2E',
+  },
+  offerInfo: {
+    flex: 1,
+    marginRight: 12,
+  },
+  offerWallet: {
+    fontSize: 13,
+    color: Colors.primaryText,
+    fontFamily: 'SpaceMono',
+  },
+  offerPrice: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Colors.primaryYellow,
+    marginTop: 2,
+  },
+  offerStatus: {
+    fontSize: 11,
+    color: Colors.secondaryText,
+    marginTop: 2,
+  },
+  offerButton: {
+    paddingHorizontal: 16,
+  },
+  offerDone: {
+    fontSize: 12,
+    color: '#34C759',
+    fontWeight: 'bold',
+  },
+  helpText: {
+    fontSize: 12,
+    color: Colors.secondaryText,
+    lineHeight: 18,
+    marginTop: 12,
+  },
+  mutedText: {
+    fontSize: 13,
+    color: Colors.secondaryText,
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  errorText: {
+    fontSize: 14,
+    color: Colors.accentRed,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  fullWidthButton: {
+    width: '100%',
+  },
+  footerNote: {
+    fontSize: 11,
+    color: Colors.secondaryText,
+    textAlign: 'center',
+    marginTop: 24,
+  },
+});

--- a/apps/mobile/hooks/useSaleNotifications.ts
+++ b/apps/mobile/hooks/useSaleNotifications.ts
@@ -1,0 +1,94 @@
+/**
+ * useSaleNotifications.ts
+ *
+ * Registers this device for the "your ticket sold" push (issue #1184).
+ *
+ * A resale can complete while the seller has the app backgrounded — the buyer
+ * drives settlement — and the seller has work left to do afterwards: they have
+ * to seal the ticket secret to the buyer. Without a push, that handover stalls
+ * until they happen to reopen the app, leaving the buyer holding a ticket they
+ * cannot check in with.
+ *
+ * Registration is entirely best-effort. Simulators have no push token, users
+ * decline the permission prompt, and Expo Go on Android has its own caveats —
+ * none of which should surface as an error in a resale screen. Failures are
+ * captured in `error` for optional display and otherwise ignored.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
+
+import { registerPushToken } from '@/services/marketplaceApi';
+
+export interface SaleNotificationsState {
+  /** The Expo push token, once registered with the backend. */
+  token: string | null;
+  /** Why registration did not complete, if it did not. Safe to ignore. */
+  error: string | null;
+}
+
+/**
+ * Resolves the EAS project id Expo needs to mint a push token. Bare
+ * `expo-notifications` in SDK 51 requires it explicitly outside of the classic
+ * managed workflow.
+ */
+function getProjectId(): string | undefined {
+  return (
+    Constants.expoConfig?.extra?.eas?.projectId ??
+    (Constants as any)?.easConfig?.projectId
+  );
+}
+
+export function useSaleNotifications(enabled: boolean = true): SaleNotificationsState {
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const register = useCallback(async () => {
+    // Push tokens are a device concept; the web build has no equivalent here.
+    if (Platform.OS === 'web') {
+      setError('Push notifications are not available on web.');
+      return;
+    }
+
+    const existing = await Notifications.getPermissionsAsync();
+    let status = existing.status;
+
+    // Only prompt if we have not been answered yet — re-prompting a user who
+    // said no is both futile and annoying.
+    if (status !== 'granted' && existing.canAskAgain) {
+      status = (await Notifications.requestPermissionsAsync()).status;
+    }
+
+    if (status !== 'granted') {
+      setError('Notifications are turned off, so we cannot alert you when your ticket sells.');
+      return;
+    }
+
+    const projectId = getProjectId();
+    const { data } = await Notifications.getExpoPushTokenAsync(
+      projectId ? { projectId } : undefined
+    );
+
+    await registerPushToken(data, Platform.OS === 'ios' ? 'ios' : 'android');
+    setToken(data);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    register().catch((e: unknown) => {
+      if (cancelled) return;
+      setError(e instanceof Error ? e.message : 'Could not register for sale alerts.');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, register]);
+
+  return { token, error };
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,6 +32,7 @@
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",
     "expo-linking": "~6.3.1",
+    "expo-notifications": "~0.28.19",
     "expo-router": "~3.5.23",
     "expo-secure-store": "13.0.1",
     "expo-splash-screen": "~0.27.5",
@@ -47,6 +48,7 @@
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
     "react-native-web": "~0.19.10",
+    "tweetnacl": "^1.0.3",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/apps/mobile/services/__tests__/resaleCrypto.test.ts
+++ b/apps/mobile/services/__tests__/resaleCrypto.test.ts
@@ -1,0 +1,126 @@
+import nacl from 'tweetnacl';
+
+import {
+  BOX_NONCE_BYTES,
+  X25519_KEY_BYTES,
+  fromBase64,
+  openTicketSecret,
+  sealTicketSecret,
+  toBase64,
+} from '../resaleCrypto';
+
+/**
+ * Issue #1184 — the resale flow hands a ticket's check-in secret from seller to
+ * buyer through a server that must not be able to read it. These tests cover
+ * the sealing/opening round trip and the failure modes that matter: a wrong
+ * recipient, and tampering in transit.
+ *
+ * `getOrCreateEncryptionKeyPair` and the ticket-secret helpers are not covered
+ * here — they are thin SecureStore wrappers, and SecureStore is a native
+ * module with no meaningful behavior to assert under jest.
+ */
+
+/** Stands in for a buyer's device: a keypair whose secret never leaves it. */
+function makeRecipient() {
+  const pair = nacl.box.keyPair();
+  return {
+    publicKey: toBase64(pair.publicKey),
+    secretKey: toBase64(pair.secretKey),
+  };
+}
+
+const TICKET_SECRET = new Uint8Array(32).fill(7);
+
+describe('sealTicketSecret / openTicketSecret', () => {
+  it('round-trips a ticket secret to the intended recipient', () => {
+    const buyer = makeRecipient();
+
+    const envelope = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+    const opened = openTicketSecret(envelope, buyer.secretKey);
+
+    expect(Array.from(opened)).toEqual(Array.from(TICKET_SECRET));
+  });
+
+  it('produces envelope fields of the sizes the server validates', () => {
+    const buyer = makeRecipient();
+    const envelope = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+
+    expect(fromBase64(envelope.ephemeralPublicKey)).toHaveLength(X25519_KEY_BYTES);
+    expect(fromBase64(envelope.nonce)).toHaveLength(BOX_NONCE_BYTES);
+    // Ciphertext is the plaintext plus a 16-byte Poly1305 tag.
+    expect(fromBase64(envelope.ciphertext)).toHaveLength(TICKET_SECRET.length + 16);
+  });
+
+  it('never emits the plaintext secret in the envelope', () => {
+    const buyer = makeRecipient();
+    const envelope = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+
+    const plaintextB64 = toBase64(TICKET_SECRET);
+    expect(envelope.ciphertext).not.toContain(plaintextB64);
+    expect(fromBase64(envelope.ciphertext)).not.toEqual(TICKET_SECRET);
+  });
+
+  it('uses a fresh ephemeral key and nonce for every envelope', () => {
+    const buyer = makeRecipient();
+
+    const first = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+    const second = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+
+    expect(first.ephemeralPublicKey).not.toEqual(second.ephemeralPublicKey);
+    expect(first.nonce).not.toEqual(second.nonce);
+    // Same plaintext, different ciphertext — no deterministic leak.
+    expect(first.ciphertext).not.toEqual(second.ciphertext);
+  });
+
+  it('cannot be opened by a different recipient', () => {
+    const buyer = makeRecipient();
+    const eavesdropper = makeRecipient();
+
+    const envelope = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+
+    expect(() => openTicketSecret(envelope, eavesdropper.secretKey)).toThrow(
+      /Could not decrypt/
+    );
+  });
+
+  it('rejects a tampered ciphertext rather than returning garbage', () => {
+    const buyer = makeRecipient();
+    const envelope = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+
+    const bytes = fromBase64(envelope.ciphertext);
+    bytes[0] ^= 0xff;
+    const tampered = { ...envelope, ciphertext: toBase64(bytes) };
+
+    // The Poly1305 tag is what makes this a hard failure instead of a silent
+    // corruption the buyer would carry to the gate.
+    expect(() => openTicketSecret(tampered, buyer.secretKey)).toThrow(/Could not decrypt/);
+  });
+
+  it('rejects a tampered nonce', () => {
+    const buyer = makeRecipient();
+    const envelope = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+
+    const nonce = fromBase64(envelope.nonce);
+    nonce[0] ^= 0xff;
+    const tampered = { ...envelope, nonce: toBase64(nonce) };
+
+    expect(() => openTicketSecret(tampered, buyer.secretKey)).toThrow(/Could not decrypt/);
+  });
+
+  it('rejects a buyer public key of the wrong length', () => {
+    const shortKey = toBase64(new Uint8Array(31));
+
+    expect(() => sealTicketSecret(TICKET_SECRET, shortKey)).toThrow(
+      /must decode to 32 bytes/
+    );
+  });
+
+  it('rejects a malformed envelope on open', () => {
+    const buyer = makeRecipient();
+    const envelope = sealTicketSecret(TICKET_SECRET, buyer.publicKey);
+
+    expect(() =>
+      openTicketSecret({ ...envelope, nonce: toBase64(new Uint8Array(8)) }, buyer.secretKey)
+    ).toThrow(/must decode to 24 bytes/);
+  });
+});

--- a/apps/mobile/services/marketplaceApi.ts
+++ b/apps/mobile/services/marketplaceApi.ts
@@ -1,0 +1,302 @@
+/**
+ * marketplaceApi.ts
+ *
+ * Client for the secondary-market endpoints under `/api/v1/marketplace`
+ * (`server/src/handlers/marketplace.rs`).
+ *
+ * Two distinct jobs live behind these endpoints:
+ *
+ *   1. **Discovery.** On-chain listings are keyed by `payment_id` and cannot be
+ *      iterated, so the server keeps a browsable mirror. Nothing here is
+ *      authoritative — the contract is. A listing that disagrees with chain
+ *      state simply fails to settle.
+ *   2. **Key handover.** The seller uploads the ticket's check-in secret
+ *      sealed to the buyer's X25519 key. The payloads crossing this boundary
+ *      are ciphertext produced by `resaleCrypto.ts`; the server cannot read
+ *      them, and neither can anything in this file.
+ *
+ * Prices are carried as integer stroop strings/numbers end to end. Formatting
+ * to decimal USDC happens only at the display edge.
+ */
+
+import { useAuthStore } from '@/hooks/useAuth';
+import type { KeyEnvelope } from './resaleCrypto';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8080';
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export class MarketplaceApiError extends Error {
+  readonly status: number | null;
+
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.name = 'MarketplaceApiError';
+    this.status = status;
+  }
+
+  /** True when the server has nothing for us yet, as opposed to a real failure. */
+  get isNotFound(): boolean {
+    return this.status === 404;
+  }
+}
+
+// ── Wire types ──────────────────────────────────────────────────────────────
+
+export type ResaleListingStatus = 'active' | 'cancelled' | 'sold';
+
+export interface ResaleListing {
+  payment_id: string;
+  event_id: string;
+  seller_wallet: string;
+  price_stroops: number;
+  max_price_stroops: number;
+  royalty_bps: number;
+  status: ResaleListingStatus;
+  buyer_wallet: string | null;
+  listing_tx_hash: string | null;
+  sale_tx_hash: string | null;
+  sold_at: string | null;
+  created_at: string;
+  updated_at: string;
+  /** Server-derived: organizer's cut of `price_stroops`. */
+  royalty_stroops: number;
+  /** Server-derived: `price_stroops - royalty_stroops`. */
+  seller_proceeds_stroops: number;
+  /** Server-derived: how much room is left under the cap. */
+  headroom_stroops: number;
+}
+
+export interface ResaleOffer {
+  id: string;
+  payment_id: string;
+  buyer_wallet: string;
+  /** Base64 X25519 key this buyer's envelope must be sealed to. */
+  buyer_public_key: string;
+  offer_price_stroops: number;
+  status: 'pending' | 'accepted' | 'withdrawn' | 'declined';
+  created_at: string;
+}
+
+export interface StoredKeyEnvelope {
+  payment_id: string;
+  buyer_wallet: string;
+  ephemeral_public_key: string;
+  nonce: string;
+  ciphertext: string;
+  claimed_at: string | null;
+  created_at: string;
+}
+
+// ── Transport ───────────────────────────────────────────────────────────────
+
+/**
+ * Issues an authenticated JSON request and unwraps the server's response
+ * envelope.
+ *
+ * Successful reads come back as `{ success, data, message }` while creates
+ * return the resource directly (201), so this normalises both to the resource.
+ */
+async function request<T>(
+  path: string,
+  init: { method: string; body?: unknown } = { method: 'GET' }
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const token = useAuthStore.getState().token;
+    const response = await fetch(`${API_BASE_URL}/api/v1/marketplace${path}`, {
+      method: init.method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      signal: controller.signal,
+    });
+
+    let body: any = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+
+    if (!response.ok) {
+      throw new MarketplaceApiError(
+        body?.message || `Marketplace request failed (${response.status}).`,
+        response.status
+      );
+    }
+
+    return (body?.data ?? body) as T;
+  } catch (error) {
+    if (error instanceof MarketplaceApiError) throw error;
+    if ((error as any)?.name === 'AbortError') {
+      throw new MarketplaceApiError('The marketplace request timed out.');
+    }
+    throw new MarketplaceApiError(
+      error instanceof Error ? error.message : 'Marketplace request failed.'
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ── Listings ────────────────────────────────────────────────────────────────
+
+export interface CreateListingInput {
+  paymentId: string;
+  eventId: string;
+  priceStroops: bigint;
+  /** Cap read back from the `ResaleListing` the contract returned. */
+  maxPriceStroops: bigint;
+  royaltyBps: number;
+  listingTxHash?: string | null;
+}
+
+/**
+ * Publishes a listing that already exists on-chain. Call this only after the
+ * `list_for_resale` transaction confirms — advertising a listing the contract
+ * has not accepted would show buyers something that cannot be bought.
+ */
+export function publishListing(input: CreateListingInput): Promise<ResaleListing> {
+  return request<ResaleListing>('/listings', {
+    method: 'POST',
+    body: {
+      payment_id: input.paymentId,
+      event_id: input.eventId,
+      price_stroops: Number(input.priceStroops),
+      max_price_stroops: Number(input.maxPriceStroops),
+      royalty_bps: input.royaltyBps,
+      listing_tx_hash: input.listingTxHash ?? null,
+    },
+  });
+}
+
+export interface ListListingsFilter {
+  eventId?: string;
+  sellerWallet?: string;
+  status?: ResaleListingStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export function fetchListings(filter: ListListingsFilter = {}): Promise<ResaleListing[]> {
+  const params = new URLSearchParams();
+  if (filter.eventId) params.set('event_id', filter.eventId);
+  if (filter.sellerWallet) params.set('seller_wallet', filter.sellerWallet);
+  if (filter.status) params.set('status', filter.status);
+  if (filter.limit != null) params.set('limit', String(filter.limit));
+  if (filter.offset != null) params.set('offset', String(filter.offset));
+
+  const query = params.toString();
+  return request<ResaleListing[]>(`/listings${query ? `?${query}` : ''}`);
+}
+
+export function fetchListing(paymentId: string): Promise<ResaleListing> {
+  return request<ResaleListing>(`/listings/${encodeURIComponent(paymentId)}`);
+}
+
+export function withdrawListing(paymentId: string): Promise<string> {
+  return request<string>(`/listings/${encodeURIComponent(paymentId)}`, {
+    method: 'DELETE',
+  });
+}
+
+// ── Offers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Registers interest in a listing and publishes the X25519 key the seller
+ * should seal the ticket secret to. Re-calling updates the standing offer,
+ * which is how a buyer rotates their encryption key.
+ */
+export function submitOffer(
+  paymentId: string,
+  buyerPublicKey: string,
+  offerPriceStroops: bigint
+): Promise<ResaleOffer> {
+  return request<ResaleOffer>(`/listings/${encodeURIComponent(paymentId)}/offers`, {
+    method: 'POST',
+    body: {
+      buyer_public_key: buyerPublicKey,
+      offer_price_stroops: Number(offerPriceStroops),
+    },
+  });
+}
+
+/** Seller-only: the offer book for one of your listings, best offer first. */
+export function fetchOffers(paymentId: string): Promise<ResaleOffer[]> {
+  return request<ResaleOffer[]>(`/listings/${encodeURIComponent(paymentId)}/offers`);
+}
+
+// ── Key envelope ────────────────────────────────────────────────────────────
+
+/**
+ * Uploads the sealed ticket secret for `buyerWallet` and flips the listing to
+ * sold. The envelope must come from `sealTicketSecret` — this function will
+ * happily post anything, but only a correctly sealed box is openable by the
+ * buyer.
+ */
+export function uploadKeyEnvelope(
+  paymentId: string,
+  buyerWallet: string,
+  envelope: KeyEnvelope,
+  saleTxHash?: string | null
+): Promise<StoredKeyEnvelope> {
+  return request<StoredKeyEnvelope>(
+    `/listings/${encodeURIComponent(paymentId)}/key-envelope`,
+    {
+      method: 'POST',
+      body: {
+        buyer_wallet: buyerWallet,
+        ephemeral_public_key: envelope.ephemeralPublicKey,
+        nonce: envelope.nonce,
+        ciphertext: envelope.ciphertext,
+        sale_tx_hash: saleTxHash ?? null,
+      },
+    }
+  );
+}
+
+/**
+ * Fetches the envelope sealed for the authenticated buyer.
+ *
+ * Returns `null` rather than throwing when nothing is waiting yet — a buyer
+ * polling right after settlement will legitimately see a 404 until the seller
+ * uploads.
+ */
+export async function fetchKeyEnvelope(
+  paymentId: string
+): Promise<StoredKeyEnvelope | null> {
+  try {
+    return await request<StoredKeyEnvelope>(
+      `/listings/${encodeURIComponent(paymentId)}/key-envelope`
+    );
+  } catch (error) {
+    if (error instanceof MarketplaceApiError && error.isNotFound) return null;
+    throw error;
+  }
+}
+
+/** Converts a stored envelope back into the shape `openTicketSecret` expects. */
+export function toKeyEnvelope(stored: StoredKeyEnvelope): KeyEnvelope {
+  return {
+    ephemeralPublicKey: stored.ephemeral_public_key,
+    nonce: stored.nonce,
+    ciphertext: stored.ciphertext,
+  };
+}
+
+// ── Push registration ───────────────────────────────────────────────────────
+
+/** Registers this device so the seller is alerted when their ticket sells. */
+export function registerPushToken(
+  token: string,
+  platform: 'ios' | 'android' | 'web'
+): Promise<string> {
+  return request<string>('/push-token', {
+    method: 'POST',
+    body: { token, platform },
+  });
+}

--- a/apps/mobile/services/resaleContract.ts
+++ b/apps/mobile/services/resaleContract.ts
@@ -1,0 +1,305 @@
+/**
+ * resaleContract.ts
+ *
+ * Soroban calls for the capped secondary market in `ticket_payment`
+ * (`contract/contracts/ticket_payment/src/resale.rs`):
+ *
+ *   pub fn list_for_resale(payment_id: String, price_usdc: i128) -> ResaleListing
+ *   pub fn cancel_resale_listing(payment_id: String)
+ *   pub fn purchase_resale_ticket(payment_id: String, buyer: Address) -> ResaleListing
+ *   pub fn get_max_resale_price(payment_id: String) -> i128
+ *   pub fn get_resale_listing(payment_id: String) -> Option<ResaleListing>
+ *
+ * Buying is two signed transactions, the same approve-then-call shape as
+ * primary checkout: `purchase_resale_ticket` pulls the price with
+ * `transfer_from`, so the buyer must approve the contract first or the call
+ * fails with `InsufficientAllowance` (error 12).
+ *
+ * Selling is one transaction. Listing moves no money — the price ceiling is
+ * checked and the listing recorded, nothing more.
+ */
+
+import { Address, Contract, Keypair, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
+import { StellarWalletManager } from './stellar';
+import {
+  buildAndSimulateContractCall,
+  getLatestLedgerSequence,
+  loadSorobanAccount,
+  pollTransactionUntilFinal,
+  signTransaction,
+  submitTransaction,
+} from './sorobanClient';
+import {
+  TICKET_PAYMENT_CONTRACT_ID,
+  getUsdcTokenContractId,
+  usdcToStroops,
+} from './ticketPaymentContract';
+
+/** Ledgers of validity granted to the resale allowance (~1 hour at 5s/ledger). */
+const APPROVAL_LEDGER_WINDOW = 720;
+
+/** Mirrors `resale::ResaleStatus`. */
+export type ResaleStatus = 'Active' | 'Cancelled' | 'Sold';
+
+/** Mirrors `resale::ResaleListing`, with i128 fields as bigint. */
+export interface OnChainResaleListing {
+  paymentId: string;
+  eventId: string;
+  seller: string;
+  price: bigint;
+  tokenAddress: string;
+  maxPrice: bigint;
+  royaltyBps: number;
+  status: ResaleStatus;
+  createdAt: bigint;
+  updatedAt: bigint;
+}
+
+/**
+ * Converts the contract's `ResaleListing` return value into the shape above.
+ *
+ * `scValToNative` renders a `#[contracttype]` struct as a snake_case object and
+ * a fieldless enum variant as a single-element array (`['Active']`), so both
+ * are normalised here rather than at every call site.
+ */
+function parseListing(raw: any): OnChainResaleListing {
+  const status = Array.isArray(raw?.status) ? raw.status[0] : raw?.status;
+
+  return {
+    paymentId: raw.payment_id,
+    eventId: raw.event_id,
+    seller: raw.seller,
+    price: BigInt(raw.price),
+    tokenAddress: raw.token_address,
+    maxPrice: BigInt(raw.max_price),
+    royaltyBps: Number(raw.royalty_bps),
+    status: status as ResaleStatus,
+    createdAt: BigInt(raw.created_at),
+    updatedAt: BigInt(raw.updated_at),
+  };
+}
+
+/**
+ * Simulates a contract call without submitting it, for read-only entry points.
+ * Uses the caller's own account purely as a simulation source — no signature
+ * is produced and nothing reaches the ledger.
+ */
+async function simulateRead(
+  sourcePublicKey: string,
+  method: string,
+  args: xdr.ScVal[]
+): Promise<any> {
+  const account = await loadSorobanAccount(sourcePublicKey);
+  const contract = new Contract(TICKET_PAYMENT_CONTRACT_ID);
+  const { simulation } = await buildAndSimulateContractCall({
+    sourceAccount: account,
+    operation: contract.call(method, ...args),
+  });
+
+  const retval = simulation.result?.retval;
+  return retval ? scValToNative(retval) : null;
+}
+
+async function loadKeypair(): Promise<Keypair> {
+  const secretKey = await StellarWalletManager.getSecretKey();
+  if (!secretKey) {
+    throw new Error(
+      'No Stellar wallet found on this device. Import or create a wallet before using the resale market.'
+    );
+  }
+  return Keypair.fromSecret(secretKey);
+}
+
+// ── Reads ───────────────────────────────────────────────────────────────────
+
+/**
+ * Highest price this ticket may legally be listed at, in stroops.
+ *
+ * Worth reading before showing the listing form: it lets the UI show the
+ * ceiling up front instead of letting the seller discover it by having a
+ * transaction rejected.
+ */
+export async function fetchMaxResalePrice(paymentId: string): Promise<bigint> {
+  const keypair = await loadKeypair();
+  const result = await simulateRead(keypair.publicKey(), 'get_max_resale_price', [
+    nativeToScVal(paymentId, { type: 'string' }),
+  ]);
+  return BigInt(result ?? 0);
+}
+
+/** Reads a listing from the ledger, or `null` if the ticket was never listed. */
+export async function fetchOnChainListing(
+  paymentId: string
+): Promise<OnChainResaleListing | null> {
+  const keypair = await loadKeypair();
+  const result = await simulateRead(keypair.publicKey(), 'get_resale_listing', [
+    nativeToScVal(paymentId, { type: 'string' }),
+  ]);
+  return result ? parseListing(result) : null;
+}
+
+// ── Listing ─────────────────────────────────────────────────────────────────
+
+export interface ListForResaleResult {
+  hash: string;
+  listing: OnChainResaleListing;
+}
+
+/**
+ * Lists a ticket at `priceUsdc`. Rejected on-chain with
+ * `ResalePriceExceedsCap` (error 26) if the price is above the ceiling, so
+ * callers should validate against `fetchMaxResalePrice` first for a better
+ * error than a failed transaction.
+ */
+export async function submitListForResale(
+  paymentId: string,
+  priceUsdc: number
+): Promise<ListForResaleResult> {
+  const keypair = await loadKeypair();
+  const account = await loadSorobanAccount(keypair.publicKey());
+
+  const contract = new Contract(TICKET_PAYMENT_CONTRACT_ID);
+  const operation = contract.call(
+    'list_for_resale',
+    nativeToScVal(paymentId, { type: 'string' }),
+    nativeToScVal(usdcToStroops(priceUsdc), { type: 'i128' })
+  );
+
+  const { transaction, simulation } = await buildAndSimulateContractCall({
+    sourceAccount: account,
+    operation,
+  });
+
+  const signed = signTransaction(transaction, keypair);
+  const { hash } = await submitTransaction(signed);
+  await pollTransactionUntilFinal(hash);
+
+  const retval = simulation.result?.retval;
+  if (!retval) {
+    throw new Error('The contract did not return the created listing.');
+  }
+
+  return { hash, listing: parseListing(scValToNative(retval)) };
+}
+
+/** Withdraws a listing. Only the seller who created it can cancel. */
+export async function submitCancelResaleListing(paymentId: string): Promise<string> {
+  const keypair = await loadKeypair();
+  const account = await loadSorobanAccount(keypair.publicKey());
+
+  const contract = new Contract(TICKET_PAYMENT_CONTRACT_ID);
+  const { transaction } = await buildAndSimulateContractCall({
+    sourceAccount: account,
+    operation: contract.call(
+      'cancel_resale_listing',
+      nativeToScVal(paymentId, { type: 'string' })
+    ),
+  });
+
+  const signed = signTransaction(transaction, keypair);
+  const { hash } = await submitTransaction(signed);
+  await pollTransactionUntilFinal(hash);
+  return hash;
+}
+
+// ── Buying ──────────────────────────────────────────────────────────────────
+
+export type ResalePurchaseStage =
+  | 'loading-wallet'
+  | 'approving'
+  | 'confirming-approval'
+  | 'buying'
+  | 'confirming-purchase';
+
+export interface PurchaseResaleParams {
+  paymentId: string;
+  /** Listed price in stroops, read from the listing rather than user input. */
+  priceStroops: bigint;
+  onProgress?: (stage: ResalePurchaseStage) => void;
+}
+
+export interface PurchaseResaleResult {
+  approvalTxHash: string;
+  purchaseTxHash: string;
+  buyerPublicKey: string;
+  listing: OnChainResaleListing;
+}
+
+/**
+ * Runs the full buy flow: approve the listing price, wait for it to confirm,
+ * then call `purchase_resale_ticket`.
+ *
+ * The contract settles payment, the organizer royalty and the ownership
+ * transfer in that second transaction, so there is no state in which the buyer
+ * has paid without receiving the ticket. What they still need afterwards is
+ * the check-in secret, which arrives out-of-band via the key envelope — see
+ * `marketplaceApi.fetchKeyEnvelope`.
+ */
+export async function purchaseResaleTicket(
+  params: PurchaseResaleParams
+): Promise<PurchaseResaleResult> {
+  const { paymentId, priceStroops, onProgress } = params;
+  const emit = (stage: ResalePurchaseStage) => onProgress?.(stage);
+
+  emit('loading-wallet');
+  const keypair = await loadKeypair();
+  const buyerPublicKey = keypair.publicKey();
+
+  emit('approving');
+  const [account, latestLedger] = await Promise.all([
+    loadSorobanAccount(buyerPublicKey),
+    getLatestLedgerSequence(),
+  ]);
+
+  const tokenContract = new Contract(getUsdcTokenContractId());
+  const approvalOperation = tokenContract.call(
+    'approve',
+    new Address(buyerPublicKey).toScVal(),
+    new Address(TICKET_PAYMENT_CONTRACT_ID).toScVal(),
+    nativeToScVal(priceStroops, { type: 'i128' }),
+    nativeToScVal(latestLedger + APPROVAL_LEDGER_WINDOW, { type: 'u32' })
+  );
+
+  const approval = await buildAndSimulateContractCall({
+    sourceAccount: account,
+    operation: approvalOperation,
+  });
+  const approvalSubmission = await submitTransaction(
+    signTransaction(approval.transaction, keypair)
+  );
+
+  emit('confirming-approval');
+  await pollTransactionUntilFinal(approvalSubmission.hash);
+
+  emit('buying');
+  // Reload the account: its sequence number advanced with the approval.
+  const purchaseAccount = await loadSorobanAccount(buyerPublicKey);
+  const contract = new Contract(TICKET_PAYMENT_CONTRACT_ID);
+  const purchase = await buildAndSimulateContractCall({
+    sourceAccount: purchaseAccount,
+    operation: contract.call(
+      'purchase_resale_ticket',
+      nativeToScVal(paymentId, { type: 'string' }),
+      new Address(buyerPublicKey).toScVal()
+    ),
+  });
+
+  const purchaseSubmission = await submitTransaction(
+    signTransaction(purchase.transaction, keypair)
+  );
+
+  emit('confirming-purchase');
+  await pollTransactionUntilFinal(purchaseSubmission.hash);
+
+  const retval = purchase.simulation.result?.retval;
+  if (!retval) {
+    throw new Error('The contract did not return the settled listing.');
+  }
+
+  return {
+    approvalTxHash: approvalSubmission.hash,
+    purchaseTxHash: purchaseSubmission.hash,
+    buyerPublicKey,
+    listing: parseListing(scValToNative(retval)),
+  };
+}

--- a/apps/mobile/services/resaleCrypto.ts
+++ b/apps/mobile/services/resaleCrypto.ts
@@ -1,0 +1,239 @@
+/**
+ * resaleCrypto.ts
+ *
+ * End-to-end encryption for handing a ticket's check-in secret from seller to
+ * buyer during a resale (issue #1184).
+ *
+ * ## Why this exists
+ *
+ * Buying a ticket on-chain moves ownership, but it does not get the buyer
+ * through the gate. Check-in requires the raw secret whose SHA-256 digest the
+ * `ticket_payment` contract stored as the payment's `ValidationHash` (see
+ * `generatePurchaseSecret` in `ticketPaymentContract.ts`). That secret lives
+ * only on the original buyer's device, so a resale has to move it too — and it
+ * must not be readable by the server that relays it.
+ *
+ * ## Scheme
+ *
+ * NaCl `box`: X25519 key agreement over Curve25519, then XSalsa20-Poly1305
+ * authenticated encryption. The seller generates a fresh ephemeral keypair per
+ * envelope, derives a shared secret against the buyer's published X25519
+ * public key, and seals the ticket secret under it. Only the holder of the
+ * buyer's X25519 secret key can open the result.
+ *
+ * A fresh ephemeral keypair per envelope means a seller's long-term key is
+ * never the thing protecting a past handover.
+ *
+ * ## Key separation
+ *
+ * The buyer's encryption keypair is generated independently of their Stellar
+ * signing keypair. Reusing an Ed25519 signing key for X25519 key agreement is
+ * possible via birational mapping, but sharing key material across two
+ * primitives is a well-known footgun, so the app keeps them separate and
+ * stores the encryption secret in the device keychain via SecureStore.
+ *
+ * ## Randomness
+ *
+ * Ephemeral keys and nonces come from tweetnacl's own `randomBytes`. That is
+ * the same generator the app already trusts for ticket secrets: `Keypair.random()`
+ * in `ticketPaymentContract.ts` is `@stellar/stellar-base` calling into this
+ * very tweetnacl instance. Do not install a custom PRNG via `nacl.setPRNG`
+ * here — because the SDK shares this instance, a shim that sources entropy
+ * from `Keypair.random()` recurses into itself and never terminates.
+ */
+
+import nacl from 'tweetnacl';
+import * as SecureStore from 'expo-secure-store';
+
+/** SecureStore key holding the device's base64 X25519 secret key. */
+const X25519_SECRET_STORE_KEY = 'agora.resale.x25519.secret';
+
+/** SecureStore key prefix for a ticket's check-in secret, by payment id. */
+const TICKET_SECRET_STORE_PREFIX = 'agora.ticket.secret.';
+
+/** Raw byte lengths fixed by the NaCl box construction. */
+export const X25519_KEY_BYTES = 32;
+export const BOX_NONCE_BYTES = 24;
+
+// ── Base64 helpers ──────────────────────────────────────────────────────────
+
+export function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+export function fromBase64(value: string): Uint8Array {
+  return new Uint8Array(Buffer.from(value, 'base64'));
+}
+
+/** Decodes a base64 field and asserts the exact raw length the scheme requires. */
+function decodeExact(field: string, value: string, expectedLength: number): Uint8Array {
+  const bytes = fromBase64(value);
+  if (bytes.length !== expectedLength) {
+    throw new Error(
+      `${field} must decode to ${expectedLength} bytes, got ${bytes.length}.`
+    );
+  }
+  return bytes;
+}
+
+// ── Buyer's long-lived encryption keypair ───────────────────────────────────
+
+export interface EncryptionKeyPair {
+  /** Base64 X25519 public key — safe to publish with an offer. */
+  publicKey: string;
+  /** Base64 X25519 secret key — never leaves the device. */
+  secretKey: string;
+}
+
+/**
+ * Returns this device's X25519 keypair, generating and persisting one on first
+ * use. The secret is written to SecureStore (Keychain / Keystore), never to
+ * ordinary storage.
+ */
+export async function getOrCreateEncryptionKeyPair(): Promise<EncryptionKeyPair> {
+  const stored = await SecureStore.getItemAsync(X25519_SECRET_STORE_KEY);
+  if (stored) {
+    const secretKey = decodeExact('stored encryption key', stored, X25519_KEY_BYTES);
+    const pair = nacl.box.keyPair.fromSecretKey(secretKey);
+    return { publicKey: toBase64(pair.publicKey), secretKey: stored };
+  }
+
+  const pair = nacl.box.keyPair();
+  const secretKey = toBase64(pair.secretKey);
+  await SecureStore.setItemAsync(X25519_SECRET_STORE_KEY, secretKey);
+
+  return { publicKey: toBase64(pair.publicKey), secretKey };
+}
+
+/**
+ * Discards the device's encryption keypair. Any envelope still sealed to the
+ * old key becomes permanently unreadable, so this is only for sign-out.
+ */
+export async function clearEncryptionKeyPair(): Promise<void> {
+  await SecureStore.deleteItemAsync(X25519_SECRET_STORE_KEY);
+}
+
+// ── Ticket secret storage ───────────────────────────────────────────────────
+
+/**
+ * Reads the locally-held check-in secret for a ticket. Returns `null` when
+ * this device never held it — a seller in that position cannot complete a
+ * resale, because there is nothing to hand over.
+ */
+export async function getTicketSecret(paymentId: string): Promise<Uint8Array | null> {
+  const stored = await SecureStore.getItemAsync(
+    `${TICKET_SECRET_STORE_PREFIX}${paymentId}`
+  );
+  return stored ? fromBase64(stored) : null;
+}
+
+/** Persists a ticket's check-in secret for later check-in or resale. */
+export async function storeTicketSecret(
+  paymentId: string,
+  secret: Uint8Array
+): Promise<void> {
+  await SecureStore.setItemAsync(
+    `${TICKET_SECRET_STORE_PREFIX}${paymentId}`,
+    toBase64(secret)
+  );
+}
+
+/**
+ * Drops a ticket's secret from this device. Called after a completed sale:
+ * the seller no longer owns the ticket, and keeping the secret around only
+ * widens the window in which it could leak.
+ *
+ * This is hygiene, not enforcement — a determined seller could have copied it
+ * beforehand. Double-spend is prevented at the gate, where check-in is
+ * single-use per ticket.
+ */
+export async function clearTicketSecret(paymentId: string): Promise<void> {
+  await SecureStore.deleteItemAsync(`${TICKET_SECRET_STORE_PREFIX}${paymentId}`);
+}
+
+// ── Sealing / opening ───────────────────────────────────────────────────────
+
+/** The wire form of a sealed ticket secret. Every field is base64. */
+export interface KeyEnvelope {
+  /** Ephemeral X25519 public key of the sender, needed to derive the shared secret. */
+  ephemeralPublicKey: string;
+  /** 24-byte XSalsa20 nonce. */
+  nonce: string;
+  /** NaCl box ciphertext (secret + 16-byte Poly1305 tag). */
+  ciphertext: string;
+}
+
+/**
+ * Seals `secret` so that only the holder of the X25519 secret key matching
+ * `buyerPublicKeyB64` can read it.
+ *
+ * Called on the seller's device after the on-chain purchase settles. The
+ * returned envelope is safe to hand to the server, which stores it verbatim
+ * and cannot open it.
+ */
+export function sealTicketSecret(
+  secret: Uint8Array,
+  buyerPublicKeyB64: string
+): KeyEnvelope {
+  const buyerPublicKey = decodeExact(
+    'buyer_public_key',
+    buyerPublicKeyB64,
+    X25519_KEY_BYTES
+  );
+
+  // Fresh per envelope: the sending key is discarded as soon as this returns.
+  const ephemeral = nacl.box.keyPair();
+  const nonce = nacl.randomBytes(BOX_NONCE_BYTES);
+  const ciphertext = nacl.box(secret, nonce, buyerPublicKey, ephemeral.secretKey);
+
+  if (!ciphertext) {
+    throw new Error('Failed to encrypt the ticket key for this buyer.');
+  }
+
+  return {
+    ephemeralPublicKey: toBase64(ephemeral.publicKey),
+    nonce: toBase64(nonce),
+    ciphertext: toBase64(ciphertext),
+  };
+}
+
+/**
+ * Opens an envelope sealed to this device's encryption key.
+ *
+ * Returns the raw ticket secret. A `null` from `nacl.box.open` means the
+ * Poly1305 tag did not verify — the envelope was tampered with, addressed to a
+ * different key, or the buyer's key has been rotated since the offer — so this
+ * throws rather than returning something the caller might treat as a secret.
+ */
+export function openTicketSecret(
+  envelope: KeyEnvelope,
+  recipientSecretKeyB64: string
+): Uint8Array {
+  const ephemeralPublicKey = decodeExact(
+    'ephemeral_public_key',
+    envelope.ephemeralPublicKey,
+    X25519_KEY_BYTES
+  );
+  const nonce = decodeExact('nonce', envelope.nonce, BOX_NONCE_BYTES);
+  const recipientSecretKey = decodeExact(
+    'recipient secret key',
+    recipientSecretKeyB64,
+    X25519_KEY_BYTES
+  );
+  const ciphertext = fromBase64(envelope.ciphertext);
+
+  const opened = nacl.box.open(
+    ciphertext,
+    nonce,
+    ephemeralPublicKey,
+    recipientSecretKey
+  );
+
+  if (!opened) {
+    throw new Error(
+      'Could not decrypt the ticket key. It may have been sealed to a different device, or tampered with in transit.'
+    );
+  }
+
+  return opened;
+}

--- a/apps/mobile/services/ticketPaymentContract.ts
+++ b/apps/mobile/services/ticketPaymentContract.ts
@@ -222,7 +222,7 @@ export const TICKET_PAYMENT_ERROR_MESSAGES: Record<number, string> = {
   23: 'The refund window for this ticket has passed.',
   24: 'This withdrawal would exceed the organizer’s daily withdrawal cap.',
   25: 'There are insufficient platform fees available for this action.',
-  26: 'The resale price exceeds the price cap set for this ticket.',
+  26: 'The resale price exceeds the anti-scalping cap set for this ticket.',
   27: 'Ticket sales are temporarily paused. Please try again later.',
   35: 'This event has been cancelled.',
   36: 'This event is currently under dispute and cannot process payments.',
@@ -253,6 +253,10 @@ export const TICKET_PAYMENT_ERROR_MESSAGES: Record<number, string> = {
   61: 'The secret provided does not match this ticket.',
   62: 'That discount code has expired.',
   63: 'That discount code has reached its maximum number of uses.',
+  64: 'This ticket is not listed for resale.',
+  65: 'This listing is no longer active — it may have been cancelled or already sold.',
+  66: 'This ticket is already listed for resale. Cancel the existing listing first.',
+  67: 'The royalty percentage provided is invalid.',
 };
 
 export const INSUFFICIENT_ALLOWANCE_ERROR_CODE = 12;

--- a/contract/contracts/ticket_payment/README.md
+++ b/contract/contracts/ticket_payment/README.md
@@ -37,10 +37,13 @@ The Ticket Payment contract manages all financial transactions for event ticketi
 - Winner determination and settlement
 
 ### Resale Marketplace
-- List tickets for resale
-- Price cap enforcement (organizer-set)
-- Escrow for resale transactions
-- Automatic ownership transfer
+- List tickets for resale (`resale.rs`)
+- Hard price cap enforcement — organizer-set `resale_cap_bps`, defaulting to
+  110% of face value when the organizer has not set one
+- Automatic organizer royalty (default 5%) deducted at settlement
+- Atomic swap: payment, royalty and ownership transfer in one invocation
+- The ticket's check-in secret is handed over off-chain, sealed to the buyer's
+  X25519 key — see `server/src/handlers/marketplace.rs`
 
 ### Rewards Distribution
 - Track staker contributions
@@ -61,9 +64,20 @@ The Ticket Payment contract manages all financial transactions for event ticketi
 - `batch_refund(refund_requests)` - Process multiple refunds
 
 ### Resale Operations
-- `list_for_resale(ticket_id, price)` - List ticket on resale market
-- `cancel_resale_listing(ticket_id)` - Cancel resale listing
-- `purchase_resale_ticket(resale_id, buyer)` - Buy from resale market
+Listings are keyed by the `payment_id` of the ticket being sold, so a ticket
+has at most one listing at a time.
+
+- `list_for_resale(payment_id, price_usdc)` - List ticket on resale market
+- `cancel_resale_listing(payment_id)` - Cancel a listing (seller only)
+- `purchase_resale_ticket(payment_id, buyer)` - Buy from resale market
+- `get_resale_listing(payment_id)` - Read a listing (including sold/cancelled)
+- `get_max_resale_price(payment_id)` - Highest legal listing price
+- `set_resale_royalty_bps(event_id, royalty_bps)` - Organizer royalty rate
+- `get_resale_royalty_bps(event_id)` - Read the royalty rate
+
+The buyer must `approve` the contract for the listing price before calling
+`purchase_resale_ticket`, the same two-transaction pattern `process_payment`
+uses.
 
 ### Auction Operations
 - `create_auction(event_id, tier_id, start_price, end_price, duration)` - Create auction
@@ -112,12 +126,17 @@ pub enum PaymentStatus {
 ### ResaleListing
 ```rust
 pub struct ResaleListing {
-    pub listing_id: u64,
-    pub ticket_id: u64,
+    pub payment_id: String,
+    pub event_id: String,
     pub seller: Address,
     pub price: i128,
-    pub status: ResaleStatus,
+    pub token_address: Address,
+    /// Ceiling this listing was validated against.
+    pub max_price: i128,
+    pub royalty_bps: u32,
+    pub status: ResaleStatus, // Active | Cancelled | Sold
     pub created_at: u64,
+    pub updated_at: u64,
 }
 ```
 
@@ -146,7 +165,8 @@ The contract emits events for tracking and integration:
 - `RefundProcessed` - Refund completed
 - `PaymentDistributed` - Payment split to parties
 - `ResaleListed` - Ticket listed for resale
-- `ResalePurchased` - Resale transaction completed
+- `ResaleCancelled` - Listing withdrawn by the seller
+- `ResalePurchased` - Resale settled (carries price, royalty, seller proceeds)
 - `AuctionCreated` - New auction started
 - `BidPlaced` - Auction bid submitted
 - `AuctionSettled` - Auction completed

--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -1977,6 +1977,85 @@ impl TicketPaymentContract {
         Ok(())
     }
 
+    // ── Secondary market ─────────────────────────────────────────────────
+    //
+    // Thin entry points over `crate::resale`, which holds the pricing rules,
+    // royalty split and atomic settlement logic. See that module for the
+    // anti-scalping model and how it relates to the off-chain E2EE handover
+    // of the ticket's check-in secret.
+
+    /// Lists a confirmed ticket on the secondary market at `price_usdc`
+    /// (token base units). Authorized by the current holder; rejected if the
+    /// price exceeds the event's resale ceiling.
+    pub fn list_for_resale(
+        env: Env,
+        payment_id: String,
+        price_usdc: i128,
+    ) -> Result<crate::resale::ResaleListing, TicketPaymentError> {
+        crate::resale::list_for_resale(&env, payment_id, price_usdc)
+    }
+
+    /// Withdraws an active listing. Only the seller may cancel.
+    pub fn cancel_resale_listing(
+        env: Env,
+        payment_id: String,
+    ) -> Result<(), TicketPaymentError> {
+        crate::resale::cancel_resale_listing(&env, payment_id)
+    }
+
+    /// Buys a listed ticket. Settles payment, organizer royalty and ownership
+    /// transfer in a single atomic invocation. Requires the buyer to have
+    /// approved this contract for the listing price first.
+    pub fn purchase_resale_ticket(
+        env: Env,
+        payment_id: String,
+        buyer: Address,
+    ) -> Result<crate::resale::ResaleListing, TicketPaymentError> {
+        crate::resale::purchase_resale_ticket(&env, payment_id, buyer)
+    }
+
+    /// Returns the listing for a ticket, if one has ever been created.
+    /// Cancelled and sold listings are retained for history.
+    pub fn get_resale_listing(
+        env: Env,
+        payment_id: String,
+    ) -> Option<crate::resale::ResaleListing> {
+        crate::resale::get_listing(&env, &payment_id)
+    }
+
+    /// Sets the organizer royalty applied to resales of this event's tickets.
+    /// Organizer-only; capped at `MAX_RESALE_ROYALTY_BPS`.
+    pub fn set_resale_royalty_bps(
+        env: Env,
+        event_id: String,
+        royalty_bps: u32,
+    ) -> Result<(), TicketPaymentError> {
+        crate::resale::set_royalty_bps(&env, &event_id, royalty_bps)
+    }
+
+    /// Returns the royalty rate in bps used for this event's resales.
+    pub fn get_resale_royalty_bps(env: Env, event_id: String) -> u32 {
+        crate::resale::get_royalty_bps(&env, &event_id)
+    }
+
+    /// Returns the highest price `payment_id` may currently be listed at.
+    /// Useful for client-side validation before building a listing tx.
+    pub fn get_max_resale_price(
+        env: Env,
+        payment_id: String,
+    ) -> Result<i128, TicketPaymentError> {
+        let payment =
+            get_payment(&env, payment_id).ok_or(TicketPaymentError::PaymentNotFound)?;
+
+        let registry_client = event_registry::Client::new(&env, &get_event_registry(&env));
+        let event_info = match registry_client.try_get_event(&payment.event_id) {
+            Ok(Ok(Some(info))) => info,
+            _ => return Err(TicketPaymentError::EventNotFound),
+        };
+
+        crate::resale::max_resale_price(payment.amount, event_info.resale_cap_bps)
+    }
+
     /// Triggers a bulk refund for a cancelled event. Processes in batches.
     pub fn trigger_bulk_refund(
         env: Env,
@@ -2666,7 +2745,7 @@ fn validate_address(env: &Env, address: &Address) -> Result<(), TicketPaymentErr
 }
 
 /// Validates that a transfer recipient is neither the zero address nor the contract itself.
-fn validate_recipient(env: &Env, address: &Address) -> Result<(), TicketPaymentError> {
+pub(crate) fn validate_recipient(env: &Env, address: &Address) -> Result<(), TicketPaymentError> {
     if address == &env.current_contract_address() || is_zero_address(env, address) {
         return Err(TicketPaymentError::InvalidAddress);
     }

--- a/contract/contracts/ticket_payment/src/contract.rs
+++ b/contract/contracts/ticket_payment/src/contract.rs
@@ -1996,10 +1996,7 @@ impl TicketPaymentContract {
     }
 
     /// Withdraws an active listing. Only the seller may cancel.
-    pub fn cancel_resale_listing(
-        env: Env,
-        payment_id: String,
-    ) -> Result<(), TicketPaymentError> {
+    pub fn cancel_resale_listing(env: Env, payment_id: String) -> Result<(), TicketPaymentError> {
         crate::resale::cancel_resale_listing(&env, payment_id)
     }
 
@@ -2040,12 +2037,8 @@ impl TicketPaymentContract {
 
     /// Returns the highest price `payment_id` may currently be listed at.
     /// Useful for client-side validation before building a listing tx.
-    pub fn get_max_resale_price(
-        env: Env,
-        payment_id: String,
-    ) -> Result<i128, TicketPaymentError> {
-        let payment =
-            get_payment(&env, payment_id).ok_or(TicketPaymentError::PaymentNotFound)?;
+    pub fn get_max_resale_price(env: Env, payment_id: String) -> Result<i128, TicketPaymentError> {
+        let payment = get_payment(&env, payment_id).ok_or(TicketPaymentError::PaymentNotFound)?;
 
         let registry_client = event_registry::Client::new(&env, &get_event_registry(&env));
         let event_info = match registry_client.try_get_event(&payment.event_id) {

--- a/contract/contracts/ticket_payment/src/error.rs
+++ b/contract/contracts/ticket_payment/src/error.rs
@@ -57,6 +57,10 @@ pub enum TicketPaymentError {
     InvalidSecret = 61,
     DiscountExpired = 62,
     DiscountMaxUsesReached = 63,
+    ResaleListingNotFound = 64,
+    ResaleListingNotActive = 65,
+    TicketAlreadyListed = 66,
+    InvalidRoyaltyBps = 67,
 }
 
 impl From<TicketPaymentError> for soroban_sdk::Error {
@@ -130,6 +134,10 @@ impl From<soroban_sdk::Error> for TicketPaymentError {
             61 => TicketPaymentError::InvalidSecret,
             62 => TicketPaymentError::DiscountExpired,
             63 => TicketPaymentError::DiscountMaxUsesReached,
+            64 => TicketPaymentError::ResaleListingNotFound,
+            65 => TicketPaymentError::ResaleListingNotActive,
+            66 => TicketPaymentError::TicketAlreadyListed,
+            67 => TicketPaymentError::InvalidRoyaltyBps,
             _ => TicketPaymentError::ArithmeticError,
         }
     }

--- a/contract/contracts/ticket_payment/src/events.rs
+++ b/contract/contracts/ticket_payment/src/events.rs
@@ -28,6 +28,9 @@ pub enum AgoraEvent {
     EventCancelled,
     CancellationRefundClaimed,
     PoapMinted,
+    ResaleListed,
+    ResaleCancelled,
+    ResalePurchased,
 }
 
 #[contracttype]
@@ -247,5 +250,47 @@ pub struct PoapMintedEvent {
     /// The attendee who earned the POAP.
     pub attendee: Address,
     /// Ledger timestamp at mint time.
+    pub timestamp: u64,
+}
+
+/// Emitted when a ticket holder lists their ticket on the secondary market.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResaleListedEvent {
+    pub payment_id: String,
+    pub event_id: String,
+    pub seller: Address,
+    /// Asking price in token base units.
+    pub price: i128,
+    /// The cap this listing was validated against, so indexers can show
+    /// how much headroom the organizer allows without re-reading the registry.
+    pub max_price: i128,
+    pub timestamp: u64,
+}
+
+/// Emitted when a seller withdraws their own listing before it sells.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResaleCancelledEvent {
+    pub payment_id: String,
+    pub event_id: String,
+    pub seller: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted on a completed atomic resale: payment settled and ownership moved.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResalePurchasedEvent {
+    pub payment_id: String,
+    pub event_id: String,
+    pub seller: Address,
+    pub buyer: Address,
+    /// Gross price paid by the buyer.
+    pub price: i128,
+    /// Portion routed to the organizer as a royalty.
+    pub royalty: i128,
+    /// Net proceeds received by the seller (`price - royalty`).
+    pub seller_proceeds: i128,
     pub timestamp: u64,
 }

--- a/contract/contracts/ticket_payment/src/keys.rs
+++ b/contract/contracts/ticket_payment/src/keys.rs
@@ -64,4 +64,8 @@ pub enum DataKey {
     PoapsByAttendee(Address, u32),
     /// Total number of POAPs minted for an attendee (Persistent)
     PoapsByAttendeeCount(Address),
+    /// Active secondary-market listing: payment_id -> ResaleListing (Persistent)
+    ResaleListing(String),
+    /// Per-event resale royalty paid to the organizer: event_id -> rate_bps (u32) (Persistent)
+    ResaleRoyaltyBps(String),
 }

--- a/contract/contracts/ticket_payment/src/lib.rs
+++ b/contract/contracts/ticket_payment/src/lib.rs
@@ -6,6 +6,7 @@ pub mod governance;
 pub mod interfaces;
 pub mod keys;
 pub mod payment_types;
+pub mod resale;
 pub mod storage;
 pub mod types;
 

--- a/contract/contracts/ticket_payment/src/resale.rs
+++ b/contract/contracts/ticket_payment/src/resale.rs
@@ -1,0 +1,454 @@
+//! # Capped Secondary Market (Resale)
+//!
+//! Anti-scalping resale for confirmed tickets. A holder lists their ticket at a
+//! price that the contract validates against a hard ceiling derived from what
+//! they originally paid, and a buyer settles it in a single atomic invocation
+//! that moves USDC and ticket ownership together — there is no window in which
+//! one has happened without the other.
+//!
+//! ## Price ceiling
+//!
+//! The ceiling comes from the organizer's `resale_cap_bps` on the event
+//! registry entry. Unlike [`crate::contract::TicketPaymentContract::transfer_ticket`],
+//! which treats an unset cap as an uncapped free market, the marketplace falls
+//! back to [`DEFAULT_MAX_RESALE_MARKUP_BPS`] so that listings are *always*
+//! bounded. Organizers who genuinely want a free market can set a large
+//! explicit cap; leaving it unset no longer opts out of scalping protection.
+//!
+//! Face value is taken from `payment.amount` — the price actually paid for this
+//! specific ticket — rather than the tier's current price. Tier prices drift
+//! (early-bird expiry, scheduled price steps), and pinning the cap to the live
+//! tier price would let a holder who bought at an early-bird discount resell at
+//! a markup over the *later*, higher price.
+//!
+//! ## Royalty
+//!
+//! Every completed resale routes `royalty_bps` of the sale price to the event's
+//! `payment_address` — the same destination primary sales settle to — before
+//! the seller is paid. The rate defaults to [`DEFAULT_RESALE_ROYALTY_BPS`] and
+//! organizers can change it via `set_resale_royalty_bps`.
+//!
+//! ## What is deliberately *not* on-chain
+//!
+//! The ticket's check-in secret is never written here. Ownership transfer alone
+//! does not let the buyer through the gate — they also need the secret whose
+//! SHA-256 digest is stored as the payment's `ValidationHash`. That secret is
+//! handed over off-chain, sealed to the buyer's X25519 public key, via the
+//! server's marketplace key-envelope endpoints (`server/src/handlers/marketplace.rs`).
+//! The contract is the settlement layer; the server is a blind relay.
+
+use soroban_sdk::{contracttype, token, Address, Env, String};
+
+use crate::contract::{event_registry, validate_recipient};
+use crate::error::TicketPaymentError;
+use crate::events::{
+    AgoraEvent, ResaleCancelledEvent, ResaleListedEvent, ResalePurchasedEvent,
+};
+use crate::storage::{
+    add_payment_to_buyer_index, add_to_total_volume_processed, get_event_registry, get_payment,
+    is_event_disputed, is_initialized, is_paused, remove_payment_from_buyer_index,
+};
+use crate::types::{DataKey, PaymentStatus, MAX_BPS};
+
+/// Markup ceiling applied when an organizer has not set `resale_cap_bps`.
+/// 1000 bps = 110% of face value, the example given in the protocol spec.
+pub const DEFAULT_MAX_RESALE_MARKUP_BPS: u32 = 1000;
+
+/// Organizer royalty applied when an event has no explicit rate. 500 bps = 5%.
+pub const DEFAULT_RESALE_ROYALTY_BPS: u32 = 500;
+
+/// Upper bound on a configurable royalty. Anything higher would leave the
+/// seller with less than half the sale price and is almost certainly a
+/// fat-finger, so it is rejected at configuration time rather than at sale time.
+pub const MAX_RESALE_ROYALTY_BPS: u32 = 5000;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ResaleStatus {
+    /// Listed and purchasable.
+    Active,
+    /// Withdrawn by the seller before it sold.
+    Cancelled,
+    /// Settled — ownership has moved to the buyer.
+    Sold,
+}
+
+/// A secondary-market listing. Keyed by the `payment_id` of the ticket being
+/// sold, so a ticket can only ever have one listing at a time.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResaleListing {
+    pub payment_id: String,
+    pub event_id: String,
+    pub seller: Address,
+    /// Asking price in `token_address` base units.
+    pub price: i128,
+    /// Token the buyer must pay in — pinned to the token of the original
+    /// purchase so a listing cannot be settled in a cheaper asset.
+    pub token_address: Address,
+    /// Ceiling this listing was validated against, recorded so clients can
+    /// render remaining headroom without re-deriving it from the registry.
+    pub max_price: i128,
+    /// Royalty rate captured at listing time.
+    pub royalty_bps: u32,
+    pub status: ResaleStatus,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+// ── Storage accessors ────────────────────────────────────────────────────────
+
+pub fn get_listing(env: &Env, payment_id: &String) -> Option<ResaleListing> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ResaleListing(payment_id.clone()))
+}
+
+fn set_listing(env: &Env, listing: &ResaleListing) {
+    env.storage().persistent().set(
+        &DataKey::ResaleListing(listing.payment_id.clone()),
+        listing,
+    );
+}
+
+pub fn get_royalty_bps(env: &Env, event_id: &String) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ResaleRoyaltyBps(event_id.clone()))
+        .unwrap_or(DEFAULT_RESALE_ROYALTY_BPS)
+}
+
+/// Sets the organizer royalty for an event. Caller must be the organizer.
+pub fn set_royalty_bps(
+    env: &Env,
+    event_id: &String,
+    royalty_bps: u32,
+) -> Result<(), TicketPaymentError> {
+    if !is_initialized(env) {
+        return Err(TicketPaymentError::NotInitialized);
+    }
+    if royalty_bps > MAX_RESALE_ROYALTY_BPS {
+        return Err(TicketPaymentError::InvalidRoyaltyBps);
+    }
+
+    let event_info = load_event(env, event_id)?;
+    event_info.organizer_address.require_auth();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::ResaleRoyaltyBps(event_id.clone()), &royalty_bps);
+    Ok(())
+}
+
+// ── Pricing ─────────────────────────────────────────────────────────────────
+
+fn load_event(
+    env: &Env,
+    event_id: &String,
+) -> Result<event_registry::EventInfo, TicketPaymentError> {
+    let registry_client = event_registry::Client::new(env, &get_event_registry(env));
+    match registry_client.try_get_event(event_id) {
+        Ok(Ok(Some(info))) => Ok(info),
+        _ => Err(TicketPaymentError::EventNotFound),
+    }
+}
+
+/// Highest price a ticket bought for `face_value` may be resold at.
+///
+/// Returns `face_value * (10000 + cap_bps) / 10000`, using the organizer's
+/// `resale_cap_bps` when set and [`DEFAULT_MAX_RESALE_MARKUP_BPS`] otherwise.
+pub fn max_resale_price(
+    face_value: i128,
+    resale_cap_bps: Option<u32>,
+) -> Result<i128, TicketPaymentError> {
+    let cap_bps = resale_cap_bps.unwrap_or(DEFAULT_MAX_RESALE_MARKUP_BPS);
+
+    let multiplier = (MAX_BPS as i128)
+        .checked_add(cap_bps as i128)
+        .ok_or(TicketPaymentError::ArithmeticError)?;
+
+    face_value
+        .checked_mul(multiplier)
+        .ok_or(TicketPaymentError::ArithmeticError)?
+        .checked_div(MAX_BPS as i128)
+        .ok_or(TicketPaymentError::ArithmeticError)
+}
+
+/// Splits a sale price into the organizer's royalty and the seller's net
+/// proceeds. Rounds the royalty down, so any rounding dust favours the seller.
+pub fn split_proceeds(price: i128, royalty_bps: u32) -> Result<(i128, i128), TicketPaymentError> {
+    let royalty = price
+        .checked_mul(royalty_bps as i128)
+        .ok_or(TicketPaymentError::ArithmeticError)?
+        .checked_div(MAX_BPS as i128)
+        .ok_or(TicketPaymentError::ArithmeticError)?;
+
+    let seller_proceeds = price
+        .checked_sub(royalty)
+        .ok_or(TicketPaymentError::ArithmeticError)?;
+
+    Ok((royalty, seller_proceeds))
+}
+
+// ── Shared guards ───────────────────────────────────────────────────────────
+
+/// Rejects events that must not host secondary trading: inactive, cancelled,
+/// disputed, or already over.
+fn require_tradeable_event(
+    env: &Env,
+    event_info: &event_registry::EventInfo,
+) -> Result<(), TicketPaymentError> {
+    if matches!(event_info.status, event_registry::EventStatus::Cancelled) {
+        return Err(TicketPaymentError::EventCancelled);
+    }
+    if !event_info.is_active {
+        return Err(TicketPaymentError::EventInactive);
+    }
+    if is_event_disputed(env, event_info.event_id.clone()) {
+        return Err(TicketPaymentError::EventDisputed);
+    }
+    if event_info.end_time > 0 && env.ledger().timestamp() >= event_info.end_time {
+        return Err(TicketPaymentError::EventEnded);
+    }
+    Ok(())
+}
+
+// ── list_for_resale ─────────────────────────────────────────────────────────
+
+/// Lists a confirmed, transferable ticket on the secondary market.
+///
+/// Authorized by the current holder. Fails if the asking price exceeds the
+/// event's ceiling, if the ticket has already been checked in, or if the
+/// ticket already has an active listing.
+pub fn list_for_resale(
+    env: &Env,
+    payment_id: String,
+    price: i128,
+) -> Result<ResaleListing, TicketPaymentError> {
+    if !is_initialized(env) {
+        return Err(TicketPaymentError::NotInitialized);
+    }
+    if is_paused(env) {
+        return Err(TicketPaymentError::ContractPaused);
+    }
+    if price <= 0 {
+        return Err(TicketPaymentError::InvalidPrice);
+    }
+
+    let payment = get_payment(env, payment_id.clone()).ok_or(TicketPaymentError::PaymentNotFound)?;
+
+    // Only a live, unused ticket can be sold on. `CheckedIn` is explicitly
+    // excluded: the ticket has already been consumed at the gate.
+    if payment.status != PaymentStatus::Confirmed {
+        return Err(TicketPaymentError::InvalidPaymentStatus);
+    }
+    if payment.is_soulbound {
+        return Err(TicketPaymentError::NonTransferable);
+    }
+
+    let seller = payment.buyer_address.clone();
+    seller.require_auth();
+
+    if let Some(existing) = get_listing(env, &payment_id) {
+        if existing.status == ResaleStatus::Active {
+            return Err(TicketPaymentError::TicketAlreadyListed);
+        }
+    }
+
+    let event_info = load_event(env, &payment.event_id)?;
+    require_tradeable_event(env, &event_info)?;
+
+    let max_price = max_resale_price(payment.amount, event_info.resale_cap_bps)?;
+    if price > max_price {
+        return Err(TicketPaymentError::ResalePriceExceedsCap);
+    }
+
+    let now = env.ledger().timestamp();
+    let listing = ResaleListing {
+        payment_id: payment_id.clone(),
+        event_id: payment.event_id.clone(),
+        seller: seller.clone(),
+        price,
+        token_address: payment.token_address.clone(),
+        max_price,
+        royalty_bps: get_royalty_bps(env, &payment.event_id),
+        status: ResaleStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    set_listing(env, &listing);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (AgoraEvent::ResaleListed,),
+        ResaleListedEvent {
+            payment_id,
+            event_id: payment.event_id,
+            seller,
+            price,
+            max_price,
+            timestamp: now,
+        },
+    );
+
+    Ok(listing)
+}
+
+// ── cancel_resale_listing ───────────────────────────────────────────────────
+
+/// Withdraws an active listing. Only the seller who created it may cancel.
+pub fn cancel_resale_listing(env: &Env, payment_id: String) -> Result<(), TicketPaymentError> {
+    if !is_initialized(env) {
+        return Err(TicketPaymentError::NotInitialized);
+    }
+
+    let mut listing =
+        get_listing(env, &payment_id).ok_or(TicketPaymentError::ResaleListingNotFound)?;
+
+    if listing.status != ResaleStatus::Active {
+        return Err(TicketPaymentError::ResaleListingNotActive);
+    }
+
+    listing.seller.require_auth();
+
+    let now = env.ledger().timestamp();
+    listing.status = ResaleStatus::Cancelled;
+    listing.updated_at = now;
+    set_listing(env, &listing);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (AgoraEvent::ResaleCancelled,),
+        ResaleCancelledEvent {
+            payment_id,
+            event_id: listing.event_id.clone(),
+            seller: listing.seller.clone(),
+            timestamp: now,
+        },
+    );
+
+    Ok(())
+}
+
+// ── purchase_resale_ticket ──────────────────────────────────────────────────
+
+/// Settles a listing atomically: pulls the full price from the buyer, pays the
+/// organizer royalty and the seller's net proceeds, and moves ticket ownership
+/// — all inside one invocation, so a failure at any step reverts the whole
+/// swap and neither the money nor the ticket moves.
+///
+/// The buyer must have granted this contract a USDC allowance covering `price`
+/// beforehand, matching the approve-then-call pattern `process_payment` uses.
+pub fn purchase_resale_ticket(
+    env: &Env,
+    payment_id: String,
+    buyer: Address,
+) -> Result<ResaleListing, TicketPaymentError> {
+    if !is_initialized(env) {
+        return Err(TicketPaymentError::NotInitialized);
+    }
+    if is_paused(env) {
+        return Err(TicketPaymentError::ContractPaused);
+    }
+
+    let mut listing =
+        get_listing(env, &payment_id).ok_or(TicketPaymentError::ResaleListingNotFound)?;
+    if listing.status != ResaleStatus::Active {
+        return Err(TicketPaymentError::ResaleListingNotActive);
+    }
+
+    buyer.require_auth();
+
+    let mut payment = get_payment(env, payment_id.clone()).ok_or(TicketPaymentError::PaymentNotFound)?;
+    if payment.status != PaymentStatus::Confirmed {
+        return Err(TicketPaymentError::InvalidPaymentStatus);
+    }
+    if payment.is_soulbound {
+        return Err(TicketPaymentError::NonTransferable);
+    }
+
+    // The listing is stale if the ticket moved on by some other route (a direct
+    // `transfer_ticket`, say) after it was listed. Refuse rather than pay a
+    // seller who no longer holds the ticket.
+    let seller = listing.seller.clone();
+    if payment.buyer_address != seller {
+        return Err(TicketPaymentError::ResaleListingNotActive);
+    }
+    if buyer == seller {
+        return Err(TicketPaymentError::InvalidAddress);
+    }
+    validate_recipient(env, &buyer)?;
+
+    let event_info = load_event(env, &listing.event_id)?;
+    require_tradeable_event(env, &event_info)?;
+
+    // Re-check the ceiling at settlement time: the organizer may have tightened
+    // `resale_cap_bps` after this listing went up, and the tighter cap wins.
+    let max_price = max_resale_price(payment.amount, event_info.resale_cap_bps)?;
+    if listing.price > max_price {
+        return Err(TicketPaymentError::ResalePriceExceedsCap);
+    }
+
+    let (royalty, seller_proceeds) = split_proceeds(listing.price, listing.royalty_bps)?;
+
+    // ── Atomic settlement ────────────────────────────────────────────────
+    let token_client = token::Client::new(env, &listing.token_address);
+    let contract_address = env.current_contract_address();
+
+    if token_client.allowance(&buyer, &contract_address) < listing.price {
+        return Err(TicketPaymentError::InsufficientAllowance);
+    }
+
+    let balance_before = token_client.balance(&contract_address);
+    token_client.transfer_from(&contract_address, &buyer, &contract_address, &listing.price);
+    let balance_after = token_client.balance(&contract_address);
+
+    if balance_after
+        .checked_sub(balance_before)
+        .ok_or(TicketPaymentError::ArithmeticError)?
+        != listing.price
+    {
+        return Err(TicketPaymentError::TransferVerificationFailed);
+    }
+
+    if royalty > 0 {
+        token_client.transfer(&contract_address, &event_info.payment_address, &royalty);
+    }
+    if seller_proceeds > 0 {
+        token_client.transfer(&contract_address, &seller, &seller_proceeds);
+    }
+
+    // ── Ownership transfer ───────────────────────────────────────────────
+    payment.buyer_address = buyer.clone();
+    payment.owner_address = buyer.clone();
+    env.storage()
+        .persistent()
+        .set(&DataKey::Payment(payment_id.clone()), &payment);
+
+    remove_payment_from_buyer_index(env, seller.clone(), payment_id.clone());
+    add_payment_to_buyer_index(env, buyer.clone(), payment_id.clone());
+
+    add_to_total_volume_processed(env, listing.price);
+
+    let now = env.ledger().timestamp();
+    listing.status = ResaleStatus::Sold;
+    listing.updated_at = now;
+    set_listing(env, &listing);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (AgoraEvent::ResalePurchased,),
+        ResalePurchasedEvent {
+            payment_id,
+            event_id: listing.event_id.clone(),
+            seller,
+            buyer,
+            price: listing.price,
+            royalty,
+            seller_proceeds,
+            timestamp: now,
+        },
+    );
+
+    Ok(listing)
+}

--- a/contract/contracts/ticket_payment/src/resale.rs
+++ b/contract/contracts/ticket_payment/src/resale.rs
@@ -41,9 +41,7 @@ use soroban_sdk::{contracttype, token, Address, Env, String};
 
 use crate::contract::{event_registry, validate_recipient};
 use crate::error::TicketPaymentError;
-use crate::events::{
-    AgoraEvent, ResaleCancelledEvent, ResaleListedEvent, ResalePurchasedEvent,
-};
+use crate::events::{AgoraEvent, ResaleCancelledEvent, ResaleListedEvent, ResalePurchasedEvent};
 use crate::storage::{
     add_payment_to_buyer_index, add_to_total_volume_processed, get_event_registry, get_payment,
     is_event_disputed, is_initialized, is_paused, remove_payment_from_buyer_index,
@@ -105,10 +103,9 @@ pub fn get_listing(env: &Env, payment_id: &String) -> Option<ResaleListing> {
 }
 
 fn set_listing(env: &Env, listing: &ResaleListing) {
-    env.storage().persistent().set(
-        &DataKey::ResaleListing(listing.payment_id.clone()),
-        listing,
-    );
+    env.storage()
+        .persistent()
+        .set(&DataKey::ResaleListing(listing.payment_id.clone()), listing);
 }
 
 pub fn get_royalty_bps(env: &Env, event_id: &String) -> u32 {
@@ -235,7 +232,8 @@ pub fn list_for_resale(
         return Err(TicketPaymentError::InvalidPrice);
     }
 
-    let payment = get_payment(env, payment_id.clone()).ok_or(TicketPaymentError::PaymentNotFound)?;
+    let payment =
+        get_payment(env, payment_id.clone()).ok_or(TicketPaymentError::PaymentNotFound)?;
 
     // Only a live, unused ticket can be sold on. `CheckedIn` is explicitly
     // excluded: the ticket has already been consumed at the gate.
@@ -359,7 +357,8 @@ pub fn purchase_resale_ticket(
 
     buyer.require_auth();
 
-    let mut payment = get_payment(env, payment_id.clone()).ok_or(TicketPaymentError::PaymentNotFound)?;
+    let mut payment =
+        get_payment(env, payment_id.clone()).ok_or(TicketPaymentError::PaymentNotFound)?;
     if payment.status != PaymentStatus::Confirmed {
         return Err(TicketPaymentError::InvalidPaymentStatus);
     }

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -10318,7 +10318,10 @@ fn test_list_for_resale_at_cap_succeeds() {
     assert_eq!(listing.seller, seller);
     assert_eq!(listing.price, 1100_0000000);
     assert_eq!(listing.max_price, 1100_0000000);
-    assert_eq!(listing.royalty_bps, crate::resale::DEFAULT_RESALE_ROYALTY_BPS);
+    assert_eq!(
+        listing.royalty_bps,
+        crate::resale::DEFAULT_RESALE_ROYALTY_BPS
+    );
     assert_eq!(listing.status, crate::resale::ResaleStatus::Active);
     assert_eq!(client.get_max_resale_price(&payment_id), 1100_0000000);
 }
@@ -10341,10 +10344,7 @@ fn test_list_for_resale_above_cap_rejected() {
 
     // One stroop over the ceiling.
     let result = client.try_list_for_resale(&payment_id, &1100_0000001);
-    assert_eq!(
-        result,
-        Err(Ok(TicketPaymentError::ResalePriceExceedsCap.into()))
-    );
+    assert_eq!(result, Err(Ok(TicketPaymentError::ResalePriceExceedsCap)));
 
     // Nothing should have been written for a rejected listing.
     assert!(client.get_resale_listing(&payment_id).is_none());
@@ -10365,10 +10365,7 @@ fn test_list_for_resale_falls_back_to_default_cap() {
     assert_eq!(client.get_max_resale_price(&payment_id), 110);
 
     let result = client.try_list_for_resale(&payment_id, &111);
-    assert_eq!(
-        result,
-        Err(Ok(TicketPaymentError::ResalePriceExceedsCap.into()))
-    );
+    assert_eq!(result, Err(Ok(TicketPaymentError::ResalePriceExceedsCap)));
 
     let listing = client.list_for_resale(&payment_id, &110);
     assert_eq!(listing.max_price, 110);
@@ -10392,10 +10389,7 @@ fn test_double_listing_rejected() {
 
     client.list_for_resale(&payment_id, &1000_0000000);
     let result = client.try_list_for_resale(&payment_id, &1050_0000000);
-    assert_eq!(
-        result,
-        Err(Ok(TicketPaymentError::TicketAlreadyListed.into()))
-    );
+    assert_eq!(result, Err(Ok(TicketPaymentError::TicketAlreadyListed)));
 }
 
 #[test]
@@ -10422,10 +10416,7 @@ fn test_cancel_then_relist() {
 
     // Cancelling twice is not allowed…
     let result = client.try_cancel_resale_listing(&payment_id);
-    assert_eq!(
-        result,
-        Err(Ok(TicketPaymentError::ResaleListingNotActive.into()))
-    );
+    assert_eq!(result, Err(Ok(TicketPaymentError::ResaleListingNotActive)));
 
     // …but the ticket is free to be listed again.
     let relisted = client.list_for_resale(&payment_id, &900_0000000);
@@ -10461,8 +10452,8 @@ fn test_purchase_resale_ticket_settles_atomically() {
     let listing = client.purchase_resale_ticket(&payment_id, &buyer);
 
     // 5% default royalty on 1100 USDC = 55 USDC to the organizer.
-    let expected_royalty = price * crate::resale::DEFAULT_RESALE_ROYALTY_BPS as i128
-        / MAX_BPS as i128;
+    let expected_royalty =
+        price * crate::resale::DEFAULT_RESALE_ROYALTY_BPS as i128 / MAX_BPS as i128;
     assert_eq!(listing.status, crate::resale::ResaleStatus::Sold);
     assert_eq!(usdc.balance(&buyer), 0);
     assert_eq!(usdc.balance(&seller), price - expected_royalty);
@@ -10500,15 +10491,18 @@ fn test_purchase_resale_requires_allowance() {
 
     // No approve() call — settlement must refuse rather than half-execute.
     let result = client.try_purchase_resale_ticket(&payment_id, &buyer);
-    assert_eq!(
-        result,
-        Err(Ok(TicketPaymentError::InsufficientAllowance.into()))
-    );
+    assert_eq!(result, Err(Ok(TicketPaymentError::InsufficientAllowance)));
 
     // The listing is untouched and the ticket still belongs to the seller.
     let listing = client.get_resale_listing(&payment_id).unwrap();
     assert_eq!(listing.status, crate::resale::ResaleStatus::Active);
-    assert_eq!(client.get_payment_status(&payment_id).unwrap().buyer_address, seller);
+    assert_eq!(
+        client
+            .get_payment_status(&payment_id)
+            .unwrap()
+            .buyer_address,
+        seller
+    );
 }
 
 #[test]
@@ -10530,7 +10524,7 @@ fn test_seller_cannot_buy_own_listing() {
     client.list_for_resale(&payment_id, &1000_0000000);
 
     let result = client.try_purchase_resale_ticket(&payment_id, &seller);
-    assert_eq!(result, Err(Ok(TicketPaymentError::InvalidAddress.into())));
+    assert_eq!(result, Err(Ok(TicketPaymentError::InvalidAddress)));
 }
 
 #[test]
@@ -10548,9 +10542,9 @@ fn test_resale_royalty_bps_is_configurable_and_bounded() {
     client.set_resale_royalty_bps(&event_id, &250);
     assert_eq!(client.get_resale_royalty_bps(&event_id), 250);
 
-    let result = client
-        .try_set_resale_royalty_bps(&event_id, &(crate::resale::MAX_RESALE_ROYALTY_BPS + 1));
-    assert_eq!(result, Err(Ok(TicketPaymentError::InvalidRoyaltyBps.into())));
+    let result =
+        client.try_set_resale_royalty_bps(&event_id, &(crate::resale::MAX_RESALE_ROYALTY_BPS + 1));
+    assert_eq!(result, Err(Ok(TicketPaymentError::InvalidRoyaltyBps)));
 
     // The rejected write must not have clobbered the accepted one.
     assert_eq!(client.get_resale_royalty_bps(&event_id), 250);
@@ -10615,5 +10609,5 @@ fn test_soulbound_ticket_cannot_be_listed() {
     env.as_contract(&client.address, || store_payment(&env, payment));
 
     let result = client.try_list_for_resale(&payment_id, &1000_0000000);
-    assert_eq!(result, Err(Ok(TicketPaymentError::NonTransferable.into())));
+    assert_eq!(result, Err(Ok(TicketPaymentError::NonTransferable)));
 }

--- a/contract/contracts/ticket_payment/src/test.rs
+++ b/contract/contracts/ticket_payment/src/test.rs
@@ -10253,3 +10253,367 @@ fn test_poap_minting_and_duplicate_prevention() {
     let res2 = client.try_mint_poap(&payment_id);
     assert!(res2.is_err());
 }
+
+// ── Secondary market (issue #1184) ───────────────────────────────────────────
+//
+// The registry mock behind `setup_test_with_resale_cap` reports
+// `resale_cap_bps: Some(1000)` on a tier with a 1000 USDC face value, so the
+// ceiling under test is 1100 USDC. `setup_test`'s registry leaves the cap
+// unset, which exercises the marketplace's own 110% default.
+
+/// Stores a confirmed, transferable ticket owned by `owner` and returns its id.
+fn seed_resale_ticket(
+    env: &Env,
+    client: &TicketPaymentContractClient<'static>,
+    owner: &Address,
+    event_id: &str,
+    payment_id: &str,
+    amount: i128,
+) -> String {
+    let payment_id = String::from_str(env, payment_id);
+    let payment = Payment {
+        payment_id: payment_id.clone(),
+        event_id: String::from_str(env, event_id),
+        buyer_address: owner.clone(),
+        owner_address: owner.clone(),
+        ticket_tier_id: String::from_str(env, "general"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(env)),
+        amount,
+        platform_fee: 0,
+        organizer_amount: amount,
+        status: PaymentStatus::Confirmed,
+        transaction_hash: String::from_str(env, "tx_resale"),
+        created_at: 100,
+        confirmed_at: Some(101),
+        refunded_amount: 0,
+        is_soulbound: false,
+        last_checked_in_at: 0,
+        referral_amount: 0,
+        referrer: None,
+    };
+
+    env.as_contract(&client.address, || store_payment(env, payment));
+    payment_id
+}
+
+#[test]
+fn test_list_for_resale_at_cap_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let seller = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_1",
+        1000_0000000,
+    );
+
+    // Exactly 110% of face value — the boundary must be inclusive.
+    let listing = client.list_for_resale(&payment_id, &1100_0000000);
+
+    assert_eq!(listing.seller, seller);
+    assert_eq!(listing.price, 1100_0000000);
+    assert_eq!(listing.max_price, 1100_0000000);
+    assert_eq!(listing.royalty_bps, crate::resale::DEFAULT_RESALE_ROYALTY_BPS);
+    assert_eq!(listing.status, crate::resale::ResaleStatus::Active);
+    assert_eq!(client.get_max_resale_price(&payment_id), 1100_0000000);
+}
+
+#[test]
+fn test_list_for_resale_above_cap_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let seller = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_2",
+        1000_0000000,
+    );
+
+    // One stroop over the ceiling.
+    let result = client.try_list_for_resale(&payment_id, &1100_0000001);
+    assert_eq!(
+        result,
+        Err(Ok(TicketPaymentError::ResalePriceExceedsCap.into()))
+    );
+
+    // Nothing should have been written for a rejected listing.
+    assert!(client.get_resale_listing(&payment_id).is_none());
+}
+
+#[test]
+fn test_list_for_resale_falls_back_to_default_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // This registry mock leaves `resale_cap_bps` as None.
+    let (client, _admin, _usdc_id, _, _) = setup_test(&env);
+
+    let seller = Address::generate(&env);
+    let payment_id = seed_resale_ticket(&env, &client, &seller, "event_1", "pay_resale_3", 100);
+
+    // 110% of 100 = 110, from DEFAULT_MAX_RESALE_MARKUP_BPS rather than the
+    // uncapped free market `transfer_ticket` allows.
+    assert_eq!(client.get_max_resale_price(&payment_id), 110);
+
+    let result = client.try_list_for_resale(&payment_id, &111);
+    assert_eq!(
+        result,
+        Err(Ok(TicketPaymentError::ResalePriceExceedsCap.into()))
+    );
+
+    let listing = client.list_for_resale(&payment_id, &110);
+    assert_eq!(listing.max_price, 110);
+}
+
+#[test]
+fn test_double_listing_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let seller = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_4",
+        1000_0000000,
+    );
+
+    client.list_for_resale(&payment_id, &1000_0000000);
+    let result = client.try_list_for_resale(&payment_id, &1050_0000000);
+    assert_eq!(
+        result,
+        Err(Ok(TicketPaymentError::TicketAlreadyListed.into()))
+    );
+}
+
+#[test]
+fn test_cancel_then_relist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let seller = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_5",
+        1000_0000000,
+    );
+
+    client.list_for_resale(&payment_id, &1000_0000000);
+    client.cancel_resale_listing(&payment_id);
+
+    let cancelled = client.get_resale_listing(&payment_id).unwrap();
+    assert_eq!(cancelled.status, crate::resale::ResaleStatus::Cancelled);
+
+    // Cancelling twice is not allowed…
+    let result = client.try_cancel_resale_listing(&payment_id);
+    assert_eq!(
+        result,
+        Err(Ok(TicketPaymentError::ResaleListingNotActive.into()))
+    );
+
+    // …but the ticket is free to be listed again.
+    let relisted = client.list_for_resale(&payment_id, &900_0000000);
+    assert_eq!(relisted.status, crate::resale::ResaleStatus::Active);
+    assert_eq!(relisted.price, 900_0000000);
+}
+
+#[test]
+fn test_purchase_resale_ticket_settles_atomically() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, usdc_id, _, _) = setup_test_with_resale_cap(&env);
+    let usdc_mint = token::StellarAssetClient::new(&env, &usdc_id);
+    let usdc = token::Client::new(&env, &usdc_id);
+
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_6",
+        1000_0000000,
+    );
+
+    let price: i128 = 1100_0000000;
+    client.list_for_resale(&payment_id, &price);
+
+    usdc_mint.mint(&buyer, &price);
+    usdc.approve(&buyer, &client.address, &price, &9999);
+
+    let listing = client.purchase_resale_ticket(&payment_id, &buyer);
+
+    // 5% default royalty on 1100 USDC = 55 USDC to the organizer.
+    let expected_royalty = price * crate::resale::DEFAULT_RESALE_ROYALTY_BPS as i128
+        / MAX_BPS as i128;
+    assert_eq!(listing.status, crate::resale::ResaleStatus::Sold);
+    assert_eq!(usdc.balance(&buyer), 0);
+    assert_eq!(usdc.balance(&seller), price - expected_royalty);
+    // Funds pass through the contract but must not be left sitting in it.
+    assert_eq!(usdc.balance(&client.address), 0);
+
+    // Ownership moved to the buyer on both fields the rest of the contract reads.
+    let payment = client.get_payment_status(&payment_id).unwrap();
+    assert_eq!(payment.buyer_address, buyer);
+    assert_eq!(payment.owner_address, buyer);
+
+    // …and the buyer index follows it.
+    assert!(client.get_buyer_payments(&buyer).contains(&payment_id));
+    assert!(!client.get_buyer_payments(&seller).contains(&payment_id));
+}
+
+#[test]
+fn test_purchase_resale_requires_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_7",
+        1000_0000000,
+    );
+
+    client.list_for_resale(&payment_id, &1000_0000000);
+
+    // No approve() call — settlement must refuse rather than half-execute.
+    let result = client.try_purchase_resale_ticket(&payment_id, &buyer);
+    assert_eq!(
+        result,
+        Err(Ok(TicketPaymentError::InsufficientAllowance.into()))
+    );
+
+    // The listing is untouched and the ticket still belongs to the seller.
+    let listing = client.get_resale_listing(&payment_id).unwrap();
+    assert_eq!(listing.status, crate::resale::ResaleStatus::Active);
+    assert_eq!(client.get_payment_status(&payment_id).unwrap().buyer_address, seller);
+}
+
+#[test]
+fn test_seller_cannot_buy_own_listing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let seller = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_8",
+        1000_0000000,
+    );
+
+    client.list_for_resale(&payment_id, &1000_0000000);
+
+    let result = client.try_purchase_resale_ticket(&payment_id, &seller);
+    assert_eq!(result, Err(Ok(TicketPaymentError::InvalidAddress.into())));
+}
+
+#[test]
+fn test_resale_royalty_bps_is_configurable_and_bounded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let event_id = String::from_str(&env, "event_capped");
+    assert_eq!(
+        client.get_resale_royalty_bps(&event_id),
+        crate::resale::DEFAULT_RESALE_ROYALTY_BPS
+    );
+
+    client.set_resale_royalty_bps(&event_id, &250);
+    assert_eq!(client.get_resale_royalty_bps(&event_id), 250);
+
+    let result = client
+        .try_set_resale_royalty_bps(&event_id, &(crate::resale::MAX_RESALE_ROYALTY_BPS + 1));
+    assert_eq!(result, Err(Ok(TicketPaymentError::InvalidRoyaltyBps.into())));
+
+    // The rejected write must not have clobbered the accepted one.
+    assert_eq!(client.get_resale_royalty_bps(&event_id), 250);
+}
+
+#[test]
+fn test_listing_captures_royalty_rate_at_listing_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let event_id = String::from_str(&env, "event_capped");
+    let seller = Address::generate(&env);
+    let payment_id = seed_resale_ticket(
+        &env,
+        &client,
+        &seller,
+        "event_capped",
+        "pay_resale_9",
+        1000_0000000,
+    );
+
+    client.set_resale_royalty_bps(&event_id, &300);
+    let listing = client.list_for_resale(&payment_id, &1000_0000000);
+    assert_eq!(listing.royalty_bps, 300);
+
+    // Raising the rate afterwards must not retroactively change what the
+    // seller agreed to when they listed.
+    client.set_resale_royalty_bps(&event_id, &2000);
+    let stored = client.get_resale_listing(&payment_id).unwrap();
+    assert_eq!(stored.royalty_bps, 300);
+}
+
+#[test]
+fn test_soulbound_ticket_cannot_be_listed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _usdc_id, _, _) = setup_test_with_resale_cap(&env);
+
+    let seller = Address::generate(&env);
+    let payment_id = String::from_str(&env, "pay_resale_10");
+    let payment = Payment {
+        payment_id: payment_id.clone(),
+        event_id: String::from_str(&env, "event_capped"),
+        buyer_address: seller.clone(),
+        owner_address: seller.clone(),
+        ticket_tier_id: String::from_str(&env, "general"),
+        token_address: env.as_contract(&client.address, || get_usdc_token(&env)),
+        amount: 1000_0000000,
+        platform_fee: 0,
+        organizer_amount: 1000_0000000,
+        status: PaymentStatus::Confirmed,
+        transaction_hash: String::from_str(&env, "tx_sb"),
+        created_at: 100,
+        confirmed_at: Some(101),
+        refunded_amount: 0,
+        is_soulbound: true,
+        last_checked_in_at: 0,
+        referral_amount: 0,
+        referrer: None,
+    };
+    env.as_contract(&client.address, || store_payment(&env, payment));
+
+    let result = client.try_list_for_resale(&payment_id, &1000_0000000);
+    assert_eq!(result, Err(Ok(TicketPaymentError::NonTransferable.into())));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       expo-linking:
         specifier: ~6.3.1
         version: 6.3.1(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
+      expo-notifications:
+        specifier: ~0.28.19
+        version: 0.28.19(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
       expo-router:
         specifier: ~3.5.23
         version: 3.5.24(947cb9737feda35c4d72249ffcfc8288)
@@ -129,6 +132,9 @@ importers:
       react-native-web:
         specifier: ~0.19.10
         version: 0.19.13(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
       zustand:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@18.2.79)(immer@11.1.15)(react@18.2.0)
@@ -1514,6 +1520,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3671,6 +3680,9 @@ packages:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -3804,6 +3816,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5041,6 +5056,11 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  expo-application@5.9.1:
+    resolution: {integrity: sha512-uAfLBNZNahnDZLRU41ZFmNSKtetHUT9Ua557/q189ua0AWV7pQjoVAx49E4953feuvqc9swtU3ScZ/hN1XO/FQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@10.0.10:
     resolution: {integrity: sha512-0qoTIihB79k+wGus9wy0JMKq7DdenziVx3iUkGvMAy2azscSgWH6bd2gJ9CGnhC6JRd3qTMFBL0ou/fx7WZl7A==}
     peerDependencies:
@@ -5080,6 +5100,11 @@ packages:
 
   expo-modules-core@1.12.26:
     resolution: {integrity: sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==}
+
+  expo-notifications@0.28.19:
+    resolution: {integrity: sha512-rKKTnVQQ9XNQyTNwKmI9OlchhVu0XOZfRpImMqPFCJg6IwECM1izdas2SLCbE/GApg2Tw3U5R2fd26OnCtUU/w==}
+    peerDependencies:
+      expo: '*'
 
   expo-router@3.5.24:
     resolution: {integrity: sha512-wFi+PIUrOntF5cgg0PgBMlkxEZlWedIv5dWnPFEzN6Tr3A3bpsqdDLgOEIwvwd+pxn5DLzykTmg9EkQ1pPGspw==}
@@ -5915,6 +5940,10 @@ packages:
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
@@ -7244,6 +7273,10 @@ packages:
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -11080,6 +11113,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@ide/backoff@1.0.0': {}
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -13683,6 +13718,14 @@ snapshots:
 
   assert-plus@1.0.0: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -13867,6 +13910,8 @@ snapshots:
       '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+
+  badgin@1.2.3: {}
 
   bail@2.0.2: {}
 
@@ -14935,7 +14980,7 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -14968,7 +15013,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -14982,7 +15027,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15234,6 +15279,10 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  expo-application@5.9.1(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+
   expo-asset@10.0.10(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)):
     dependencies:
       expo: 51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -15289,6 +15338,21 @@ snapshots:
   expo-modules-core@1.12.26:
     dependencies:
       invariant: 2.2.4
+
+  expo-notifications@0.28.19(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      '@expo/image-utils': 0.5.1
+      '@ide/backoff': 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      expo-application: 5.9.1(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
+      expo-constants: 16.0.2(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
+      fs-extra: 9.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   expo-router@3.5.24(947cb9737feda35c4d72249ffcfc8288):
     dependencies:
@@ -16188,6 +16252,11 @@ snapshots:
       is-glob: 2.0.1
 
   is-map@2.0.3: {}
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -18013,6 +18082,11 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 

--- a/server/migrations/20260816000001_resale_marketplace.sql
+++ b/server/migrations/20260816000001_resale_marketplace.sql
@@ -1,0 +1,121 @@
+-- Secondary ticket market with end-to-end encrypted key handover (Issue #1184)
+--
+-- Settlement (payment, royalty, ownership) happens on-chain in the
+-- `ticket_payment` contract. These tables are the off-chain half:
+--   * a queryable mirror of on-chain listings, so buyers can browse without
+--     scanning ledger state,
+--   * buyer offers carrying the X25519 public key the seller will seal to,
+--   * the sealed ticket secret itself.
+--
+-- The server is a BLIND RELAY for the last of those. Everything stored in
+-- `resale_key_envelopes` is ciphertext produced on the seller's device and
+-- opened on the buyer's; the server holds no key that can decrypt it and must
+-- never be given one. Ticket ids here are on-chain `payment_id` strings, not
+-- platform UUIDs — the contract is the source of truth for ownership.
+
+CREATE TABLE IF NOT EXISTS resale_listings (
+    -- On-chain `payment_id` of the ticket. Primary key because the contract
+    -- also allows only one listing per ticket at a time.
+    payment_id            TEXT PRIMARY KEY,
+    event_id              TEXT NOT NULL,
+    seller_wallet         TEXT NOT NULL,
+    -- Prices in token base units (stroops, 7dp for USDC) to avoid float drift.
+    price_stroops         BIGINT NOT NULL CHECK (price_stroops > 0),
+    -- Ceiling the contract validated this listing against, mirrored so the
+    -- browse endpoint can show remaining headroom without an RPC round-trip.
+    max_price_stroops     BIGINT NOT NULL CHECK (max_price_stroops > 0),
+    royalty_bps           INTEGER NOT NULL CHECK (royalty_bps BETWEEN 0 AND 10000),
+    status                TEXT NOT NULL DEFAULT 'active'
+                              CHECK (status IN ('active', 'cancelled', 'sold')),
+    -- Populated on settlement.
+    buyer_wallet          TEXT,
+    listing_tx_hash       TEXT,
+    sale_tx_hash          TEXT,
+    sold_at               TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT resale_listings_price_within_cap CHECK (price_stroops <= max_price_stroops)
+);
+
+-- Browse feed: active listings for an event, newest first.
+CREATE INDEX IF NOT EXISTS idx_resale_listings_event_status
+    ON resale_listings (event_id, status, created_at DESC);
+-- "My listings" for a seller.
+CREATE INDEX IF NOT EXISTS idx_resale_listings_seller
+    ON resale_listings (seller_wallet, status);
+
+-- Buyer offers. The buyer's X25519 public key is registered here so the seller
+-- has something to seal the ticket secret to once they accept.
+CREATE TABLE IF NOT EXISTS resale_offers (
+    id                    UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    payment_id            TEXT NOT NULL REFERENCES resale_listings(payment_id) ON DELETE CASCADE,
+    buyer_wallet          TEXT NOT NULL,
+    -- Base64 X25519 public key (32 raw bytes). Distinct from the buyer's
+    -- Stellar Ed25519 signing key: signing keys must not be reused for key
+    -- agreement, so the app derives a separate encryption keypair.
+    buyer_public_key      TEXT NOT NULL,
+    offer_price_stroops   BIGINT NOT NULL CHECK (offer_price_stroops > 0),
+    status                TEXT NOT NULL DEFAULT 'pending'
+                              CHECK (status IN ('pending', 'accepted', 'withdrawn', 'declined')),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- One standing offer per buyer per listing; re-offering updates in place.
+    CONSTRAINT resale_offers_unique_buyer UNIQUE (payment_id, buyer_wallet)
+);
+
+CREATE INDEX IF NOT EXISTS idx_resale_offers_payment
+    ON resale_offers (payment_id, status);
+CREATE INDEX IF NOT EXISTS idx_resale_offers_buyer
+    ON resale_offers (buyer_wallet, status);
+
+-- The sealed ticket secret. Every column below the wallet is opaque to the
+-- server: it stores and returns bytes it cannot read.
+CREATE TABLE IF NOT EXISTS resale_key_envelopes (
+    id                    UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    payment_id            TEXT NOT NULL REFERENCES resale_listings(payment_id) ON DELETE CASCADE,
+    -- Only this wallet may fetch the envelope.
+    buyer_wallet          TEXT NOT NULL,
+    -- Base64 X25519 public key of the seller's ephemeral sending keypair.
+    ephemeral_public_key  TEXT NOT NULL,
+    -- Base64 24-byte XSalsa20 nonce.
+    nonce                 TEXT NOT NULL,
+    -- Base64 NaCl box ciphertext wrapping the ticket's check-in secret.
+    ciphertext            TEXT NOT NULL,
+    -- Set the first time the buyer successfully fetches it, so a seller can
+    -- see the handover completed.
+    claimed_at            TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT resale_key_envelopes_unique UNIQUE (payment_id, buyer_wallet)
+);
+
+CREATE INDEX IF NOT EXISTS idx_resale_key_envelopes_buyer
+    ON resale_key_envelopes (buyer_wallet);
+
+-- Device push tokens, so a seller can be told their ticket sold while the app
+-- is backgrounded.
+CREATE TABLE IF NOT EXISTS push_tokens (
+    id                    UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    wallet_address        TEXT NOT NULL,
+    -- Expo push token, e.g. `ExponentPushToken[xxxxxxxx]`.
+    token                 TEXT NOT NULL UNIQUE,
+    platform              TEXT NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_tokens_wallet ON push_tokens (wallet_address);
+
+CREATE TRIGGER update_resale_listings_updated_at
+    BEFORE UPDATE ON resale_listings
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_resale_offers_updated_at
+    BEFORE UPDATE ON resale_offers
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_push_tokens_updated_at
+    BEFORE UPDATE ON push_tokens
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/server/src/handlers/marketplace.rs
+++ b/server/src/handlers/marketplace.rs
@@ -1,0 +1,1105 @@
+//! # Secondary Ticket Market (Issue #1184)
+//!
+//! The off-chain half of the capped resale protocol. Money and ownership move
+//! atomically on-chain in `contract/contracts/ticket_payment/src/resale.rs`;
+//! this module handles the two things a Soroban contract cannot:
+//!
+//! 1. **A browsable index.** On-chain listings are keyed by `payment_id` with
+//!    no iteration, so buyers cannot discover what is for sale by reading
+//!    ledger state. Sellers mirror their confirmed listing here after the
+//!    listing transaction lands.
+//! 2. **Handing over the ticket secret.** Owning the ticket on-chain is not
+//!    enough to get through the gate — the holder also needs the raw secret
+//!    whose SHA-256 digest the contract stores as the payment's
+//!    `ValidationHash`. That secret has to travel from seller to buyer.
+//!
+//! ## Threat model for the key handover
+//!
+//! The server is a **blind relay**. The seller's device seals the ticket
+//! secret to the buyer's X25519 public key using NaCl `box`
+//! (X25519 key agreement + XSalsa20-Poly1305), and uploads only the
+//! ciphertext, the nonce, and the ephemeral public key. This process never
+//! sees, and cannot derive, the plaintext: opening the box requires the
+//! buyer's X25519 secret key, which never leaves their device.
+//!
+//! What this design does buy:
+//!   * a database dump does not yield a single usable ticket secret;
+//!   * a compromised server cannot mint working tickets for itself.
+//!
+//! What it deliberately does **not** claim:
+//!   * the server chooses which public key it hands the seller, so it could
+//!     substitute its own and mount a MITM. Buyers should pin the key they
+//!     published; a future revision should have the buyer sign their X25519
+//!     key with their Stellar key so the seller can verify it independently.
+//!   * a malicious seller can keep a copy of the secret they sold. That is
+//!     inherent to a shared-secret check-in scheme and is mitigated at the
+//!     gate, not here — check-in is single-use per ticket.
+//!
+//! Envelope fields are validated for encoding and length but are otherwise
+//! opaque; no endpoint here ever attempts to decrypt one.
+//!
+//! ## Endpoints
+//! - `POST   /api/v1/marketplace/listings` — mirror a confirmed on-chain listing
+//! - `GET    /api/v1/marketplace/listings` — browse active listings
+//! - `GET    /api/v1/marketplace/listings/:payment_id` — read one listing
+//! - `DELETE /api/v1/marketplace/listings/:payment_id` — mark a listing cancelled
+//! - `POST   /api/v1/marketplace/listings/:payment_id/offers` — buyer makes an offer
+//! - `GET    /api/v1/marketplace/listings/:payment_id/offers` — seller reads offers
+//! - `POST   /api/v1/marketplace/listings/:payment_id/key-envelope` — seller seals the secret
+//! - `GET    /api/v1/marketplace/listings/:payment_id/key-envelope` — buyer claims it
+//! - `POST   /api/v1/marketplace/push-token` — register a device for sale alerts
+
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use base64::{engine::general_purpose, Engine as _};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::sync::Arc;
+
+use crate::handlers::auth::extract_auth;
+use crate::notifications::{Notification, NotificationService};
+use crate::utils::error::AppError;
+use crate::utils::response::success;
+
+/// Basis-point denominator, mirroring the contract's `MAX_BPS`.
+const MAX_BPS: i64 = 10_000;
+
+/// Raw byte length of an X25519 public key.
+const X25519_PUBLIC_KEY_LEN: usize = 32;
+/// Raw byte length of an XSalsa20 nonce (NaCl `box`).
+const BOX_NONCE_LEN: usize = 24;
+/// Generous ceiling on the sealed payload. The plaintext is a 32-byte ticket
+/// secret plus a small JSON envelope; anything near this is abuse.
+const MAX_CIPHERTEXT_BYTES: usize = 4096;
+
+/// Default page size for the browse feed.
+const DEFAULT_LIMIT: i64 = 20;
+const MAX_LIMIT: i64 = 100;
+
+/// Shared state for the marketplace routes.
+#[derive(Clone)]
+pub struct MarketplaceState {
+    pub pool: PgPool,
+    /// Used to alert a seller when their listing sells. Best-effort — a
+    /// delivery failure never fails the sale.
+    pub notifications: Arc<NotificationService>,
+}
+
+// ---------------------------------------------------------------------------
+// Row / DTO types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct ResaleListingRow {
+    pub payment_id: String,
+    pub event_id: String,
+    pub seller_wallet: String,
+    pub price_stroops: i64,
+    pub max_price_stroops: i64,
+    pub royalty_bps: i32,
+    pub status: String,
+    pub buyer_wallet: Option<String>,
+    pub listing_tx_hash: Option<String>,
+    pub sale_tx_hash: Option<String>,
+    pub sold_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A listing plus the figures a buyer needs to decide, derived rather than
+/// stored so they can never drift from `price_stroops` / `royalty_bps`.
+#[derive(Debug, Serialize)]
+pub struct ResaleListingView {
+    #[serde(flatten)]
+    pub listing: ResaleListingRow,
+    /// Portion of the price that goes to the organizer as a royalty.
+    pub royalty_stroops: i64,
+    /// What the seller actually receives (`price - royalty`).
+    pub seller_proceeds_stroops: i64,
+    /// Headroom left under the cap, in stroops. Zero when listed at the cap.
+    pub headroom_stroops: i64,
+}
+
+impl From<ResaleListingRow> for ResaleListingView {
+    fn from(listing: ResaleListingRow) -> Self {
+        // Mirrors `resale::split_proceeds`: royalty rounds down, dust to seller.
+        let royalty_stroops =
+            listing.price_stroops.saturating_mul(listing.royalty_bps as i64) / MAX_BPS;
+        let seller_proceeds_stroops = listing.price_stroops - royalty_stroops;
+        let headroom_stroops = listing.max_price_stroops - listing.price_stroops;
+
+        Self {
+            listing,
+            royalty_stroops,
+            seller_proceeds_stroops,
+            headroom_stroops,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct ResaleOfferRow {
+    pub id: uuid::Uuid,
+    pub payment_id: String,
+    pub buyer_wallet: String,
+    pub buyer_public_key: String,
+    pub offer_price_stroops: i64,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct KeyEnvelopeRow {
+    pub payment_id: String,
+    pub buyer_wallet: String,
+    pub ephemeral_public_key: String,
+    pub nonce: String,
+    pub ciphertext: String,
+    pub claimed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateListingRequest {
+    /// On-chain `payment_id` of the ticket being sold.
+    pub payment_id: String,
+    pub event_id: String,
+    pub price_stroops: i64,
+    /// Ceiling the contract validated the listing against, read back from the
+    /// `ResaleListing` the contract returned.
+    pub max_price_stroops: i64,
+    pub royalty_bps: i32,
+    /// Hash of the transaction that created the listing on-chain.
+    pub listing_tx_hash: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListListingsQuery {
+    /// Restrict to one event.
+    pub event_id: Option<String>,
+    /// Restrict to one seller — powers the "my listings" tab.
+    pub seller_wallet: Option<String>,
+    /// `active` (default), `cancelled`, or `sold`.
+    pub status: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateOfferRequest {
+    /// Base64 X25519 public key (32 raw bytes) the seller should seal to.
+    pub buyer_public_key: String,
+    pub offer_price_stroops: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateKeyEnvelopeRequest {
+    /// Wallet the envelope is sealed for. Must have an offer on this listing.
+    pub buyer_wallet: String,
+    /// Base64 X25519 public key of the seller's ephemeral sending keypair.
+    pub ephemeral_public_key: String,
+    /// Base64 24-byte nonce.
+    pub nonce: String,
+    /// Base64 NaCl box ciphertext.
+    pub ciphertext: String,
+    /// Hash of the settlement transaction, recorded against the listing.
+    pub sale_tx_hash: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterPushTokenRequest {
+    pub token: String,
+    /// `ios`, `android`, or `web`.
+    pub platform: String,
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/// Decodes a base64 field and asserts an exact raw length.
+///
+/// Length is checked on the decoded bytes rather than the base64 text so that
+/// padding variations cannot smuggle a wrong-sized key past the check.
+fn validate_b64_exact(field: &str, value: &str, expected_len: usize) -> Result<(), AppError> {
+    let decoded = general_purpose::STANDARD
+        .decode(value)
+        .map_err(|_| AppError::ValidationError(format!("{field} must be valid base64")))?;
+
+    if decoded.len() != expected_len {
+        return Err(AppError::ValidationError(format!(
+            "{field} must decode to exactly {expected_len} bytes, got {}",
+            decoded.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Decodes a base64 field and asserts a maximum raw length.
+fn validate_b64_max(field: &str, value: &str, max_len: usize) -> Result<(), AppError> {
+    let decoded = general_purpose::STANDARD
+        .decode(value)
+        .map_err(|_| AppError::ValidationError(format!("{field} must be valid base64")))?;
+
+    if decoded.is_empty() {
+        return Err(AppError::ValidationError(format!("{field} must not be empty")));
+    }
+    if decoded.len() > max_len {
+        return Err(AppError::ValidationError(format!(
+            "{field} must decode to at most {max_len} bytes, got {}",
+            decoded.len()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_identifier(field: &str, value: &str) -> Result<(), AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::ValidationError(format!("{field} is required")));
+    }
+    if trimmed.len() > 128 {
+        return Err(AppError::ValidationError(format!(
+            "{field} must be 128 characters or fewer"
+        )));
+    }
+    Ok(())
+}
+
+/// Loads a listing or returns a 404.
+async fn load_listing(pool: &PgPool, payment_id: &str) -> Result<ResaleListingRow, AppError> {
+    sqlx::query_as::<_, ResaleListingRow>(
+        "SELECT * FROM resale_listings WHERE payment_id = $1",
+    )
+    .bind(payment_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| AppError::NotFound(format!("No resale listing for ticket '{payment_id}'")))
+}
+
+/// Loads a listing and asserts the caller owns it.
+async fn load_listing_as_seller(
+    pool: &PgPool,
+    payment_id: &str,
+    caller: &str,
+) -> Result<ResaleListingRow, AppError> {
+    let listing = load_listing(pool, payment_id).await?;
+    if listing.seller_wallet != caller {
+        // Deliberately not 404: the listing is public, so hiding its existence
+        // buys nothing, and a clear 403 is easier for clients to act on.
+        return Err(AppError::Forbidden(
+            "Only the seller of this listing can perform this action".to_string(),
+        ));
+    }
+    Ok(listing)
+}
+
+// ---------------------------------------------------------------------------
+// Listings
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/marketplace/listings`
+///
+/// Mirrors a listing the caller has already created on-chain so it becomes
+/// discoverable. The caller must be the seller; `price_stroops` is re-checked
+/// against the cap the contract reported, so a client cannot advertise a price
+/// the contract would refuse to settle.
+///
+/// Idempotent by `payment_id`: re-posting updates the listing in place, which
+/// is what a seller re-listing a cancelled ticket does.
+pub async fn create_listing(
+    State(state): State<MarketplaceState>,
+    headers: HeaderMap,
+    Json(payload): Json<CreateListingRequest>,
+) -> Response {
+    let seller = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    if let Err(e) = validate_create_listing(&payload) {
+        return e.into_response();
+    }
+
+    // A ticket already sold on this market cannot be re-listed by the same
+    // seller — they no longer own it. Guarding here keeps a stale client from
+    // resurrecting a settled listing.
+    match sqlx::query_scalar::<_, String>(
+        "SELECT status FROM resale_listings WHERE payment_id = $1 AND seller_wallet <> $2",
+    )
+    .bind(&payload.payment_id)
+    .bind(&seller)
+    .fetch_optional(&state.pool)
+    .await
+    {
+        Ok(Some(_)) => {
+            return AppError::Forbidden(
+                "This ticket is listed by a different seller".to_string(),
+            )
+            .into_response()
+        }
+        Ok(None) => {}
+        Err(e) => return AppError::DatabaseError(e).into_response(),
+    }
+
+    let listing = match sqlx::query_as::<_, ResaleListingRow>(
+        r#"
+        INSERT INTO resale_listings (
+            payment_id, event_id, seller_wallet, price_stroops,
+            max_price_stroops, royalty_bps, listing_tx_hash, status
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, 'active')
+        ON CONFLICT (payment_id) DO UPDATE
+            SET event_id          = EXCLUDED.event_id,
+                price_stroops     = EXCLUDED.price_stroops,
+                max_price_stroops = EXCLUDED.max_price_stroops,
+                royalty_bps       = EXCLUDED.royalty_bps,
+                listing_tx_hash   = EXCLUDED.listing_tx_hash,
+                status            = 'active',
+                buyer_wallet      = NULL,
+                sale_tx_hash      = NULL,
+                sold_at           = NULL
+        RETURNING *
+        "#,
+    )
+    .bind(&payload.payment_id)
+    .bind(&payload.event_id)
+    .bind(&seller)
+    .bind(payload.price_stroops)
+    .bind(payload.max_price_stroops)
+    .bind(payload.royalty_bps)
+    .bind(payload.listing_tx_hash.as_deref())
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("Failed to create resale listing: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    (
+        StatusCode::CREATED,
+        Json(ResaleListingView::from(listing)),
+    )
+        .into_response()
+}
+
+fn validate_create_listing(payload: &CreateListingRequest) -> Result<(), AppError> {
+    validate_identifier("payment_id", &payload.payment_id)?;
+    validate_identifier("event_id", &payload.event_id)?;
+
+    if payload.price_stroops <= 0 {
+        return Err(AppError::ValidationError(
+            "price_stroops must be greater than zero".to_string(),
+        ));
+    }
+    if payload.max_price_stroops <= 0 {
+        return Err(AppError::ValidationError(
+            "max_price_stroops must be greater than zero".to_string(),
+        ));
+    }
+    // The contract is the authority on this, but rejecting it here gives the
+    // seller an immediate, readable error instead of a silently unsellable
+    // listing.
+    if payload.price_stroops > payload.max_price_stroops {
+        return Err(AppError::ValidationError(format!(
+            "price_stroops ({}) exceeds the resale cap for this ticket ({})",
+            payload.price_stroops, payload.max_price_stroops
+        )));
+    }
+    if !(0..=MAX_BPS as i32).contains(&payload.royalty_bps) {
+        return Err(AppError::ValidationError(
+            "royalty_bps must be between 0 and 10000".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// `GET /api/v1/marketplace/listings`
+///
+/// Browse feed. Defaults to active listings, newest first.
+pub async fn list_listings(
+    State(state): State<MarketplaceState>,
+    Query(params): Query<ListListingsQuery>,
+) -> Response {
+    let status = params.status.as_deref().unwrap_or("active");
+    if !matches!(status, "active" | "cancelled" | "sold") {
+        return AppError::ValidationError(
+            "status must be one of: active, cancelled, sold".to_string(),
+        )
+        .into_response();
+    }
+
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let offset = params.offset.unwrap_or(0).max(0);
+
+    // `$2 IS NULL OR` keeps this a single prepared statement instead of
+    // concatenating SQL per filter combination.
+    let listings = match sqlx::query_as::<_, ResaleListingRow>(
+        r#"
+        SELECT * FROM resale_listings
+        WHERE status = $1
+          AND ($2::TEXT IS NULL OR event_id = $2)
+          AND ($3::TEXT IS NULL OR seller_wallet = $3)
+        ORDER BY created_at DESC
+        LIMIT $4 OFFSET $5
+        "#,
+    )
+    .bind(status)
+    .bind(params.event_id.as_deref())
+    .bind(params.seller_wallet.as_deref())
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to list resale listings: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    let views: Vec<ResaleListingView> = listings.into_iter().map(Into::into).collect();
+    success(views, "Resale listings retrieved").into_response()
+}
+
+/// `GET /api/v1/marketplace/listings/:payment_id`
+pub async fn get_listing(
+    State(state): State<MarketplaceState>,
+    Path(payment_id): Path<String>,
+) -> Response {
+    match load_listing(&state.pool, &payment_id).await {
+        Ok(listing) => success(
+            ResaleListingView::from(listing),
+            "Resale listing retrieved",
+        )
+        .into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+/// `DELETE /api/v1/marketplace/listings/:payment_id`
+///
+/// Mirrors an on-chain `cancel_resale_listing`. Seller-only. A sold listing
+/// cannot be cancelled — settlement already happened on-chain.
+pub async fn cancel_listing(
+    State(state): State<MarketplaceState>,
+    headers: HeaderMap,
+    Path(payment_id): Path<String>,
+) -> Response {
+    let seller = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    let listing = match load_listing_as_seller(&state.pool, &payment_id, &seller).await {
+        Ok(l) => l,
+        Err(e) => return e.into_response(),
+    };
+
+    if listing.status == "sold" {
+        return AppError::Conflict(
+            "This ticket has already been sold and cannot be unlisted".to_string(),
+        )
+        .into_response();
+    }
+
+    if let Err(e) = sqlx::query(
+        "UPDATE resale_listings SET status = 'cancelled' WHERE payment_id = $1",
+    )
+    .bind(&payment_id)
+    .execute(&state.pool)
+    .await
+    {
+        tracing::error!("Failed to cancel resale listing: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    // Outstanding offers are meaningless once the listing is gone.
+    if let Err(e) = sqlx::query(
+        "UPDATE resale_offers SET status = 'declined' WHERE payment_id = $1 AND status = 'pending'",
+    )
+    .bind(&payment_id)
+    .execute(&state.pool)
+    .await
+    {
+        tracing::error!("Failed to decline offers for cancelled listing: {:?}", e);
+    }
+
+    success(payment_id, "Resale listing cancelled").into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Offers
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/marketplace/listings/:payment_id/offers`
+///
+/// A buyer signals interest and publishes the X25519 public key the seller
+/// should seal the ticket secret to. Re-posting updates the standing offer,
+/// which is also how a buyer rotates their encryption key.
+pub async fn create_offer(
+    State(state): State<MarketplaceState>,
+    headers: HeaderMap,
+    Path(payment_id): Path<String>,
+    Json(payload): Json<CreateOfferRequest>,
+) -> Response {
+    let buyer = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    if let Err(e) = validate_b64_exact(
+        "buyer_public_key",
+        &payload.buyer_public_key,
+        X25519_PUBLIC_KEY_LEN,
+    ) {
+        return e.into_response();
+    }
+    if payload.offer_price_stroops <= 0 {
+        return AppError::ValidationError(
+            "offer_price_stroops must be greater than zero".to_string(),
+        )
+        .into_response();
+    }
+
+    let listing = match load_listing(&state.pool, &payment_id).await {
+        Ok(l) => l,
+        Err(e) => return e.into_response(),
+    };
+
+    if listing.status != "active" {
+        return AppError::Conflict(format!(
+            "This listing is {} and is not accepting offers",
+            listing.status
+        ))
+        .into_response();
+    }
+    if listing.seller_wallet == buyer {
+        return AppError::ValidationError(
+            "You cannot make an offer on your own listing".to_string(),
+        )
+        .into_response();
+    }
+    // The contract settles at the listed price, so an offer below it can never
+    // be accepted as-is. Rejecting it here avoids a dead-end in the UI.
+    if payload.offer_price_stroops < listing.price_stroops {
+        return AppError::ValidationError(format!(
+            "Offer must be at least the listed price ({} stroops)",
+            listing.price_stroops
+        ))
+        .into_response();
+    }
+    if payload.offer_price_stroops > listing.max_price_stroops {
+        return AppError::ValidationError(format!(
+            "Offer exceeds the resale cap for this ticket ({} stroops)",
+            listing.max_price_stroops
+        ))
+        .into_response();
+    }
+
+    let offer = match sqlx::query_as::<_, ResaleOfferRow>(
+        r#"
+        INSERT INTO resale_offers (
+            payment_id, buyer_wallet, buyer_public_key, offer_price_stroops
+        )
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (payment_id, buyer_wallet) DO UPDATE
+            SET buyer_public_key    = EXCLUDED.buyer_public_key,
+                offer_price_stroops = EXCLUDED.offer_price_stroops,
+                status              = 'pending'
+        RETURNING id, payment_id, buyer_wallet, buyer_public_key,
+                  offer_price_stroops, status, created_at
+        "#,
+    )
+    .bind(&payment_id)
+    .bind(&buyer)
+    .bind(&payload.buyer_public_key)
+    .bind(payload.offer_price_stroops)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::error!("Failed to record resale offer: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    (StatusCode::CREATED, Json(offer)).into_response()
+}
+
+/// `GET /api/v1/marketplace/listings/:payment_id/offers`
+///
+/// Seller-only: the buyer public keys on these rows are what the seller seals
+/// to, and exposing the offer book publicly would leak bidding positions.
+pub async fn list_offers(
+    State(state): State<MarketplaceState>,
+    headers: HeaderMap,
+    Path(payment_id): Path<String>,
+) -> Response {
+    let seller = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    if let Err(e) = load_listing_as_seller(&state.pool, &payment_id, &seller).await {
+        return e.into_response();
+    }
+
+    let offers = match sqlx::query_as::<_, ResaleOfferRow>(
+        r#"
+        SELECT id, payment_id, buyer_wallet, buyer_public_key,
+               offer_price_stroops, status, created_at
+        FROM resale_offers
+        WHERE payment_id = $1
+        ORDER BY offer_price_stroops DESC, created_at ASC
+        "#,
+    )
+    .bind(&payment_id)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to list resale offers: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    success(offers, "Resale offers retrieved").into_response()
+}
+
+// ---------------------------------------------------------------------------
+// E2EE key envelope
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/marketplace/listings/:payment_id/key-envelope`
+///
+/// Seller-only. Called after `purchase_resale_ticket` settles on-chain: the
+/// seller uploads the ticket secret sealed to the buyer's X25519 key, and the
+/// listing flips to `sold`.
+///
+/// The three envelope fields are validated for encoding and size only. This
+/// process cannot decrypt them and must not try.
+pub async fn create_key_envelope(
+    State(state): State<MarketplaceState>,
+    headers: HeaderMap,
+    Path(payment_id): Path<String>,
+    Json(payload): Json<CreateKeyEnvelopeRequest>,
+) -> Response {
+    let seller = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    if let Err(e) = validate_envelope(&payload) {
+        return e.into_response();
+    }
+
+    let listing = match load_listing_as_seller(&state.pool, &payment_id, &seller).await {
+        Ok(l) => l,
+        Err(e) => return e.into_response(),
+    };
+
+    if listing.status == "cancelled" {
+        return AppError::Conflict(
+            "This listing was cancelled; re-list the ticket before completing a sale".to_string(),
+        )
+        .into_response();
+    }
+    if payload.buyer_wallet == seller {
+        return AppError::ValidationError(
+            "The buyer and seller must be different wallets".to_string(),
+        )
+        .into_response();
+    }
+
+    // The buyer must have an offer on record — that offer is where their
+    // public key came from, so without it there is nothing to seal against and
+    // the envelope would be addressed to a key nobody published.
+    match sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM resale_offers WHERE payment_id = $1 AND buyer_wallet = $2",
+    )
+    .bind(&payment_id)
+    .bind(&payload.buyer_wallet)
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(0) => {
+            return AppError::ValidationError(
+                "That buyer has no offer on this listing".to_string(),
+            )
+            .into_response()
+        }
+        Ok(_) => {}
+        Err(e) => return AppError::DatabaseError(e).into_response(),
+    }
+
+    // The envelope, the listing status and the offer statuses have to move
+    // together: a sold listing with no envelope leaves the buyer holding a
+    // ticket they cannot check in with.
+    let mut tx = match state.pool.begin().await {
+        Ok(t) => t,
+        Err(e) => return AppError::DatabaseError(e).into_response(),
+    };
+
+    let envelope = match sqlx::query_as::<_, KeyEnvelopeRow>(
+        r#"
+        INSERT INTO resale_key_envelopes (
+            payment_id, buyer_wallet, ephemeral_public_key, nonce, ciphertext
+        )
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (payment_id, buyer_wallet) DO UPDATE
+            SET ephemeral_public_key = EXCLUDED.ephemeral_public_key,
+                nonce                = EXCLUDED.nonce,
+                ciphertext           = EXCLUDED.ciphertext,
+                claimed_at           = NULL
+        RETURNING payment_id, buyer_wallet, ephemeral_public_key, nonce,
+                  ciphertext, claimed_at, created_at
+        "#,
+    )
+    .bind(&payment_id)
+    .bind(&payload.buyer_wallet)
+    .bind(&payload.ephemeral_public_key)
+    .bind(&payload.nonce)
+    .bind(&payload.ciphertext)
+    .fetch_one(&mut *tx)
+    .await
+    {
+        Ok(row) => row,
+        Err(e) => {
+            tracing::error!("Failed to store resale key envelope: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    if let Err(e) = sqlx::query(
+        r#"
+        UPDATE resale_listings
+        SET status       = 'sold',
+            buyer_wallet = $2,
+            sale_tx_hash = COALESCE($3, sale_tx_hash),
+            sold_at      = NOW()
+        WHERE payment_id = $1
+        "#,
+    )
+    .bind(&payment_id)
+    .bind(&payload.buyer_wallet)
+    .bind(payload.sale_tx_hash.as_deref())
+    .execute(&mut *tx)
+    .await
+    {
+        tracing::error!("Failed to mark resale listing sold: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    if let Err(e) = sqlx::query(
+        r#"
+        UPDATE resale_offers
+        SET status = CASE WHEN buyer_wallet = $2 THEN 'accepted' ELSE 'declined' END
+        WHERE payment_id = $1
+        "#,
+    )
+    .bind(&payment_id)
+    .bind(&payload.buyer_wallet)
+    .execute(&mut *tx)
+    .await
+    {
+        tracing::error!("Failed to settle resale offers: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    if let Err(e) = tx.commit().await {
+        tracing::error!("Failed to commit resale settlement: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    // The sale is durable at this point; notifying is best-effort.
+    notify_ticket_sold(&state, &listing, &payload.buyer_wallet).await;
+
+    (StatusCode::CREATED, Json(envelope)).into_response()
+}
+
+fn validate_envelope(payload: &CreateKeyEnvelopeRequest) -> Result<(), AppError> {
+    validate_identifier("buyer_wallet", &payload.buyer_wallet)?;
+    validate_b64_exact(
+        "ephemeral_public_key",
+        &payload.ephemeral_public_key,
+        X25519_PUBLIC_KEY_LEN,
+    )?;
+    validate_b64_exact("nonce", &payload.nonce, BOX_NONCE_LEN)?;
+    validate_b64_max("ciphertext", &payload.ciphertext, MAX_CIPHERTEXT_BYTES)?;
+    Ok(())
+}
+
+/// `GET /api/v1/marketplace/listings/:payment_id/key-envelope`
+///
+/// Buyer-only. Returns the sealed secret addressed to the caller; the caller's
+/// wallet is taken from their token, never from the request, so one buyer
+/// cannot fetch another's envelope.
+pub async fn get_key_envelope(
+    State(state): State<MarketplaceState>,
+    headers: HeaderMap,
+    Path(payment_id): Path<String>,
+) -> Response {
+    let buyer = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    // Stamping `claimed_at` on read gives the seller confirmation the handover
+    // landed. `COALESCE` keeps the first claim time rather than the latest.
+    let envelope = match sqlx::query_as::<_, KeyEnvelopeRow>(
+        r#"
+        UPDATE resale_key_envelopes
+        SET claimed_at = COALESCE(claimed_at, NOW())
+        WHERE payment_id = $1 AND buyer_wallet = $2
+        RETURNING payment_id, buyer_wallet, ephemeral_public_key, nonce,
+                  ciphertext, claimed_at, created_at
+        "#,
+    )
+    .bind(&payment_id)
+    .bind(&buyer)
+    .fetch_optional(&state.pool)
+    .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return AppError::NotFound(
+                "No key envelope is available for you on this ticket yet".to_string(),
+            )
+            .into_response()
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch resale key envelope: {:?}", e);
+            return AppError::DatabaseError(e).into_response();
+        }
+    };
+
+    success(envelope, "Key envelope retrieved").into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Push tokens
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/marketplace/push-token`
+///
+/// Registers this device against the caller's wallet so they can be told when
+/// their listing sells. Tokens are unique, so re-registering a token that has
+/// moved to a different wallet reassigns it.
+pub async fn register_push_token(
+    State(state): State<MarketplaceState>,
+    headers: HeaderMap,
+    Json(payload): Json<RegisterPushTokenRequest>,
+) -> Response {
+    let wallet = match extract_auth(&headers) {
+        Ok(a) => a,
+        Err(e) => return e.into_response(),
+    };
+
+    if let Err(e) = validate_identifier("token", &payload.token) {
+        return e.into_response();
+    }
+    if !matches!(payload.platform.as_str(), "ios" | "android" | "web") {
+        return AppError::ValidationError(
+            "platform must be one of: ios, android, web".to_string(),
+        )
+        .into_response();
+    }
+
+    if let Err(e) = sqlx::query(
+        r#"
+        INSERT INTO push_tokens (wallet_address, token, platform)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (token) DO UPDATE
+            SET wallet_address = EXCLUDED.wallet_address,
+                platform       = EXCLUDED.platform
+        "#,
+    )
+    .bind(&wallet)
+    .bind(payload.token.trim())
+    .bind(&payload.platform)
+    .execute(&state.pool)
+    .await
+    {
+        tracing::error!("Failed to register push token: {:?}", e);
+        return AppError::DatabaseError(e).into_response();
+    }
+
+    success(wallet, "Push token registered").into_response()
+}
+
+/// Pushes a "your ticket sold" alert to every device the seller has registered.
+///
+/// Failures are logged and swallowed: the sale is already settled on-chain and
+/// committed here, so an undeliverable push must not turn into a client error
+/// that makes the seller think the sale failed.
+async fn notify_ticket_sold(
+    state: &MarketplaceState,
+    listing: &ResaleListingRow,
+    buyer_wallet: &str,
+) {
+    let tokens = match sqlx::query_scalar::<_, String>(
+        "SELECT token FROM push_tokens WHERE wallet_address = $1",
+    )
+    .bind(&listing.seller_wallet)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("Could not load push tokens for resale seller: {:?}", e);
+            return;
+        }
+    };
+
+    if tokens.is_empty() {
+        return;
+    }
+
+    let body = format!(
+        "Your ticket sold for {} USDC to {}…{}.",
+        format_stroops(listing.price_stroops),
+        &buyer_wallet[..buyer_wallet.len().min(4)],
+        &buyer_wallet[buyer_wallet.len().saturating_sub(4)..],
+    );
+
+    for token in tokens {
+        let notification = Notification {
+            recipient: token,
+            subject: "Ticket sold".to_string(),
+            body: body.clone(),
+        };
+        if let Err(e) = state.notifications.send(&notification).await {
+            tracing::warn!("Resale sale notification failed: {:?}", e);
+        }
+    }
+}
+
+/// Renders stroops (7 decimal places) as a human-readable USDC amount.
+fn format_stroops(stroops: i64) -> String {
+    format!("{:.2}", stroops as f64 / 10_000_000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b64(bytes: &[u8]) -> String {
+        general_purpose::STANDARD.encode(bytes)
+    }
+
+    #[test]
+    fn accepts_a_correctly_sized_x25519_key() {
+        assert!(validate_b64_exact("k", &b64(&[7u8; 32]), X25519_PUBLIC_KEY_LEN).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_key_of_the_wrong_length() {
+        // 31 bytes base64-encodes to a string that *looks* plausible, so the
+        // check has to be on decoded length, not string length.
+        assert!(validate_b64_exact("k", &b64(&[7u8; 31]), X25519_PUBLIC_KEY_LEN).is_err());
+        assert!(validate_b64_exact("k", &b64(&[7u8; 33]), X25519_PUBLIC_KEY_LEN).is_err());
+    }
+
+    #[test]
+    fn rejects_non_base64() {
+        assert!(validate_b64_exact("k", "not base64!!", X25519_PUBLIC_KEY_LEN).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_and_oversized_ciphertext() {
+        assert!(validate_b64_max("c", "", MAX_CIPHERTEXT_BYTES).is_err());
+        assert!(validate_b64_max("c", &b64(&[0u8; 32]), MAX_CIPHERTEXT_BYTES).is_ok());
+        assert!(
+            validate_b64_max("c", &b64(&vec![0u8; MAX_CIPHERTEXT_BYTES + 1]), MAX_CIPHERTEXT_BYTES)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_a_listing_priced_above_its_cap() {
+        let payload = CreateListingRequest {
+            payment_id: "pay-1".to_string(),
+            event_id: "event-1".to_string(),
+            price_stroops: 1_100_000_001,
+            max_price_stroops: 1_100_000_000,
+            royalty_bps: 500,
+            listing_tx_hash: None,
+        };
+        assert!(validate_create_listing(&payload).is_err());
+    }
+
+    #[test]
+    fn accepts_a_listing_priced_exactly_at_its_cap() {
+        let payload = CreateListingRequest {
+            payment_id: "pay-1".to_string(),
+            event_id: "event-1".to_string(),
+            price_stroops: 1_100_000_000,
+            max_price_stroops: 1_100_000_000,
+            royalty_bps: 500,
+            listing_tx_hash: None,
+        };
+        assert!(validate_create_listing(&payload).is_ok());
+    }
+
+    #[test]
+    fn derives_royalty_and_proceeds_the_same_way_the_contract_does() {
+        let row = ResaleListingRow {
+            payment_id: "pay-1".to_string(),
+            event_id: "event-1".to_string(),
+            seller_wallet: "GSELLER".to_string(),
+            price_stroops: 1_100_000_000, // 110 USDC
+            max_price_stroops: 1_100_000_000,
+            royalty_bps: 500, // 5%
+            status: "active".to_string(),
+            buyer_wallet: None,
+            listing_tx_hash: None,
+            sale_tx_hash: None,
+            sold_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let view = ResaleListingView::from(row);
+        assert_eq!(view.royalty_stroops, 55_000_000);
+        assert_eq!(view.seller_proceeds_stroops, 1_045_000_000);
+        assert_eq!(view.headroom_stroops, 0);
+    }
+
+    #[test]
+    fn rounds_royalty_dust_in_the_sellers_favour() {
+        // 1 stroop at 5% is 0.05, which must floor to 0 rather than round up —
+        // matching `resale::split_proceeds`.
+        let row = ResaleListingRow {
+            payment_id: "pay-1".to_string(),
+            event_id: "event-1".to_string(),
+            seller_wallet: "GSELLER".to_string(),
+            price_stroops: 1,
+            max_price_stroops: 10,
+            royalty_bps: 500,
+            status: "active".to_string(),
+            buyer_wallet: None,
+            listing_tx_hash: None,
+            sale_tx_hash: None,
+            sold_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let view = ResaleListingView::from(row);
+        assert_eq!(view.royalty_stroops, 0);
+        assert_eq!(view.seller_proceeds_stroops, 1);
+        assert_eq!(view.headroom_stroops, 9);
+    }
+}

--- a/server/src/handlers/marketplace.rs
+++ b/server/src/handlers/marketplace.rs
@@ -128,8 +128,10 @@ pub struct ResaleListingView {
 impl From<ResaleListingRow> for ResaleListingView {
     fn from(listing: ResaleListingRow) -> Self {
         // Mirrors `resale::split_proceeds`: royalty rounds down, dust to seller.
-        let royalty_stroops =
-            listing.price_stroops.saturating_mul(listing.royalty_bps as i64) / MAX_BPS;
+        let royalty_stroops = listing
+            .price_stroops
+            .saturating_mul(listing.royalty_bps as i64)
+            / MAX_BPS;
         let seller_proceeds_stroops = listing.price_stroops - royalty_stroops;
         let headroom_stroops = listing.max_price_stroops - listing.price_stroops;
 
@@ -247,7 +249,9 @@ fn validate_b64_max(field: &str, value: &str, max_len: usize) -> Result<(), AppE
         .map_err(|_| AppError::ValidationError(format!("{field} must be valid base64")))?;
 
     if decoded.is_empty() {
-        return Err(AppError::ValidationError(format!("{field} must not be empty")));
+        return Err(AppError::ValidationError(format!(
+            "{field} must not be empty"
+        )));
     }
     if decoded.len() > max_len {
         return Err(AppError::ValidationError(format!(
@@ -273,13 +277,11 @@ fn validate_identifier(field: &str, value: &str) -> Result<(), AppError> {
 
 /// Loads a listing or returns a 404.
 async fn load_listing(pool: &PgPool, payment_id: &str) -> Result<ResaleListingRow, AppError> {
-    sqlx::query_as::<_, ResaleListingRow>(
-        "SELECT * FROM resale_listings WHERE payment_id = $1",
-    )
-    .bind(payment_id)
-    .fetch_optional(pool)
-    .await?
-    .ok_or_else(|| AppError::NotFound(format!("No resale listing for ticket '{payment_id}'")))
+    sqlx::query_as::<_, ResaleListingRow>("SELECT * FROM resale_listings WHERE payment_id = $1")
+        .bind(payment_id)
+        .fetch_optional(pool)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("No resale listing for ticket '{payment_id}'")))
 }
 
 /// Loads a listing and asserts the caller owns it.
@@ -338,10 +340,8 @@ pub async fn create_listing(
     .await
     {
         Ok(Some(_)) => {
-            return AppError::Forbidden(
-                "This ticket is listed by a different seller".to_string(),
-            )
-            .into_response()
+            return AppError::Forbidden("This ticket is listed by a different seller".to_string())
+                .into_response()
         }
         Ok(None) => {}
         Err(e) => return AppError::DatabaseError(e).into_response(),
@@ -384,11 +384,7 @@ pub async fn create_listing(
         }
     };
 
-    (
-        StatusCode::CREATED,
-        Json(ResaleListingView::from(listing)),
-    )
-        .into_response()
+    (StatusCode::CREATED, Json(ResaleListingView::from(listing))).into_response()
 }
 
 fn validate_create_listing(payload: &CreateListingRequest) -> Result<(), AppError> {
@@ -477,11 +473,9 @@ pub async fn get_listing(
     Path(payment_id): Path<String>,
 ) -> Response {
     match load_listing(&state.pool, &payment_id).await {
-        Ok(listing) => success(
-            ResaleListingView::from(listing),
-            "Resale listing retrieved",
-        )
-        .into_response(),
+        Ok(listing) => {
+            success(ResaleListingView::from(listing), "Resale listing retrieved").into_response()
+        }
         Err(e) => e.into_response(),
     }
 }
@@ -512,12 +506,11 @@ pub async fn cancel_listing(
         .into_response();
     }
 
-    if let Err(e) = sqlx::query(
-        "UPDATE resale_listings SET status = 'cancelled' WHERE payment_id = $1",
-    )
-    .bind(&payment_id)
-    .execute(&state.pool)
-    .await
+    if let Err(e) =
+        sqlx::query("UPDATE resale_listings SET status = 'cancelled' WHERE payment_id = $1")
+            .bind(&payment_id)
+            .execute(&state.pool)
+            .await
     {
         tracing::error!("Failed to cancel resale listing: {:?}", e);
         return AppError::DatabaseError(e).into_response();
@@ -735,10 +728,8 @@ pub async fn create_key_envelope(
     .await
     {
         Ok(0) => {
-            return AppError::ValidationError(
-                "That buyer has no offer on this listing".to_string(),
-            )
-            .into_response()
+            return AppError::ValidationError("That buyer has no offer on this listing".to_string())
+                .into_response()
         }
         Ok(_) => {}
         Err(e) => return AppError::DatabaseError(e).into_response(),
@@ -911,10 +902,8 @@ pub async fn register_push_token(
         return e.into_response();
     }
     if !matches!(payload.platform.as_str(), "ios" | "android" | "web") {
-        return AppError::ValidationError(
-            "platform must be one of: ios, android, web".to_string(),
-        )
-        .into_response();
+        return AppError::ValidationError("platform must be one of: ios, android, web".to_string())
+            .into_response();
     }
 
     if let Err(e) = sqlx::query(
@@ -1021,10 +1010,12 @@ mod tests {
     fn rejects_empty_and_oversized_ciphertext() {
         assert!(validate_b64_max("c", "", MAX_CIPHERTEXT_BYTES).is_err());
         assert!(validate_b64_max("c", &b64(&[0u8; 32]), MAX_CIPHERTEXT_BYTES).is_ok());
-        assert!(
-            validate_b64_max("c", &b64(&vec![0u8; MAX_CIPHERTEXT_BYTES + 1]), MAX_CIPHERTEXT_BYTES)
-                .is_err()
-        );
+        assert!(validate_b64_max(
+            "c",
+            &b64(&vec![0u8; MAX_CIPHERTEXT_BYTES + 1]),
+            MAX_CIPHERTEXT_BYTES
+        )
+        .is_err());
     }
 
     #[test]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod categories;
 pub mod events;
 pub mod health;
 pub mod leaderboard;
+pub mod marketplace;
 pub mod monitoring;
 pub mod profile;
 pub mod qr_payload;

--- a/server/src/notifications/mod.rs
+++ b/server/src/notifications/mod.rs
@@ -5,6 +5,7 @@
 //! [`NotificationProvider`] and registering them in [`NotificationService`].
 
 pub mod email;
+pub mod push;
 pub mod sms;
 
 use async_trait::async_trait;

--- a/server/src/notifications/push.rs
+++ b/server/src/notifications/push.rs
@@ -1,0 +1,86 @@
+//! Expo push notification provider.
+//!
+//! The mobile app is an Expo project, so device tokens are Expo push tokens
+//! (`ExponentPushToken[...]`) and delivery goes through Expo's push service
+//! rather than APNs/FCM directly. Expo fans the message out to the right
+//! platform transport for us.
+//!
+//! Delivery is best-effort by design: the caller has already committed the
+//! important state (a completed sale) before notifying, so a push failure is
+//! logged and swallowed rather than failing the request.
+
+use async_trait::async_trait;
+use serde::Serialize;
+
+use super::{Notification, NotificationError, NotificationProvider};
+
+/// Expo's public push endpoint. Unauthenticated for tokens issued to the
+/// project; an access token is only required if the project enables
+/// enhanced security.
+const EXPO_PUSH_URL: &str = "https://exp.host/--/api/v2/push/send";
+
+/// One message in an Expo push request.
+#[derive(Debug, Serialize)]
+struct ExpoPushMessage<'a> {
+    to: &'a str,
+    title: &'a str,
+    body: &'a str,
+    sound: &'static str,
+}
+
+/// Sends notifications to mobile devices via Expo's push service.
+pub struct ExpoPushProvider {
+    client: reqwest::Client,
+    /// Optional `EXPO_ACCESS_TOKEN` for projects with enhanced push security.
+    access_token: Option<String>,
+}
+
+impl ExpoPushProvider {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self {
+            client,
+            access_token: std::env::var("EXPO_ACCESS_TOKEN").ok().filter(|t| !t.is_empty()),
+        }
+    }
+}
+
+#[async_trait]
+impl NotificationProvider for ExpoPushProvider {
+    fn name(&self) -> &'static str {
+        "expo-push"
+    }
+
+    async fn send(&self, notification: &Notification) -> Result<(), NotificationError> {
+        let message = ExpoPushMessage {
+            to: &notification.recipient,
+            title: &notification.subject,
+            body: &notification.body,
+            sound: "default",
+        };
+
+        let mut request = self
+            .client
+            .post(EXPO_PUSH_URL)
+            .header("accept", "application/json")
+            .json(&[message]);
+
+        if let Some(token) = &self.access_token {
+            request = request.bearer_auth(token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| NotificationError::DeliveryFailed(format!("Expo push request failed: {e}")))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(NotificationError::DeliveryFailed(format!(
+                "Expo push returned {status}: {body}"
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/server/src/notifications/push.rs
+++ b/server/src/notifications/push.rs
@@ -39,7 +39,9 @@ impl ExpoPushProvider {
     pub fn new(client: reqwest::Client) -> Self {
         Self {
             client,
-            access_token: std::env::var("EXPO_ACCESS_TOKEN").ok().filter(|t| !t.is_empty()),
+            access_token: std::env::var("EXPO_ACCESS_TOKEN")
+                .ok()
+                .filter(|t| !t.is_empty()),
         }
     }
 }
@@ -68,10 +70,9 @@ impl NotificationProvider for ExpoPushProvider {
             request = request.bearer_auth(token);
         }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| NotificationError::DeliveryFailed(format!("Expo push request failed: {e}")))?;
+        let response = request.send().await.map_err(|e| {
+            NotificationError::DeliveryFailed(format!("Expo push request failed: {e}"))
+        })?;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -52,6 +52,10 @@ use crate::handlers::{
         set_event_featured, submit_event_rating, toggle_event_flag, EventState,
     },
     example_empty_success, example_not_found, example_validation_error,
+    marketplace::{
+        cancel_listing, create_key_envelope, create_listing, create_offer, get_key_envelope,
+        get_listing, list_listings, list_offers, register_push_token, MarketplaceState,
+    },
     health::{
         health_check, health_check_blockchain, health_check_db, health_check_ready,
         health_check_redis,
@@ -214,6 +218,34 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/:id/scan", post(scan_ticket))
         .with_state(pool.clone());
 
+    // Secondary ticket market (Issue #1184). The key-envelope endpoints relay
+    // seller-sealed ticket secrets; see `handlers::marketplace` for the trust
+    // model. Push delivery is the first consumer of `NotificationService`.
+    let mut notification_service = crate::notifications::NotificationService::new();
+    notification_service.register(crate::notifications::push::ExpoPushProvider::new(
+        reqwest::Client::new(),
+    ));
+    let marketplace_state = MarketplaceState {
+        pool: pool.clone(),
+        notifications: std::sync::Arc::new(notification_service),
+    };
+    let marketplace_routes = Router::new()
+        .route("/listings", get(list_listings).post(create_listing))
+        .route(
+            "/listings/:payment_id",
+            get(get_listing).delete(cancel_listing),
+        )
+        .route(
+            "/listings/:payment_id/offers",
+            get(list_offers).post(create_offer),
+        )
+        .route(
+            "/listings/:payment_id/key-envelope",
+            get(get_key_envelope).post(create_key_envelope),
+        )
+        .route("/push-token", post(register_push_token))
+        .with_state(marketplace_state);
+
     // Category routes — listing is Redis-cached (Issue #583); the single-item
     // lookup keeps the bare PgPool state.
     let category_state = CategoryState {
@@ -266,6 +298,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .nest("/events", event_routes)
         .nest("/events", event_qr_routes)
         .nest("/tickets", ticket_routes)
+        .nest("/marketplace", marketplace_routes)
         .nest("/categories", category_routes)
         .nest("/auth", auth_routes)
         .nest("/profile", profile_routes)

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -52,13 +52,13 @@ use crate::handlers::{
         set_event_featured, submit_event_rating, toggle_event_flag, EventState,
     },
     example_empty_success, example_not_found, example_validation_error,
-    marketplace::{
-        cancel_listing, create_key_envelope, create_listing, create_offer, get_key_envelope,
-        get_listing, list_listings, list_offers, register_push_token, MarketplaceState,
-    },
     health::{
         health_check, health_check_blockchain, health_check_db, health_check_ready,
         health_check_redis,
+    },
+    marketplace::{
+        cancel_listing, create_key_envelope, create_listing, create_offer, get_key_envelope,
+        get_listing, list_listings, list_offers, register_push_token, MarketplaceState,
     },
     profile::{
         delete_profile, get_my_profile, get_organizer_stats, get_profile_by_address,


### PR DESCRIPTION
Closes #1184

Implements the capped, E2EE secondary ticket market across all three layers.

## 1. On-chain capped resale contract

New `contract/contracts/ticket_payment/src/resale.rs`, with thin entry points wired into `contract.rs`:

| Function | Purpose |
|---|---|
| `list_for_resale(payment_id, price_usdc)` | List a confirmed ticket, price validated against the ceiling |
| `cancel_resale_listing(payment_id)` | Seller withdraws a listing |
| `purchase_resale_ticket(payment_id, buyer)` | Atomic settlement |
| `get_resale_listing` / `get_max_resale_price` | Reads for client-side validation |
| `set_resale_royalty_bps` / `get_resale_royalty_bps` | Organizer-only royalty config |

**Price ceiling.** Derived from the organizer's `resale_cap_bps` on the event registry entry. Two decisions worth flagging:

- **Face value is `payment.amount`, not `tier.price`.** The existing `transfer_ticket` uses the tier's *current* price, which lets someone who bought at an early-bird discount resell at a markup over the later, higher price. The marketplace pins the cap to what that specific ticket actually cost.
- **An unset cap is no longer uncapped.** `transfer_ticket` treats `resale_cap_bps: None` as a free market. For the marketplace that would defeat the point, so it falls back to `DEFAULT_MAX_RESALE_MARKUP_BPS` (1000 bps = 110% of face value, the figure from the issue). `transfer_ticket`'s behaviour is unchanged. Organizers who genuinely want a free market can set a large explicit cap.

**Royalty.** Default 5% (`DEFAULT_RESALE_ROYALTY_BPS`), configurable per event by the organizer up to 50%, routed to the event's `payment_address` — the same destination primary sales settle to. The rate is captured on the listing at listing time, so an organizer raising it later cannot retroactively change what a seller agreed to.

**Atomicity.** `purchase_resale_ticket` pulls the price from the buyer, pays the royalty and the seller's net proceeds, and moves ownership — all in one invocation. A failure at any step reverts the whole swap. It re-checks the cap at settlement, so a cap tightened after listing still wins.

## 2. Off-chain E2EE key exchange

Owning the ticket on-chain doesn't get the buyer through the gate — they also need the raw secret whose SHA-256 digest the contract holds as `ValidationHash`. `server/src/handlers/marketplace.rs` relays it.

The server is a **blind relay**: the seller's device seals the secret with NaCl `box` (X25519 key agreement + XSalsa20-Poly1305) to the buyer's published X25519 public key, and uploads only ciphertext, nonce and ephemeral public key. The server holds no key that can open it, and no endpoint attempts to.

New tables in `20260816000001_resale_marketplace.sql`: `resale_listings`, `resale_offers`, `resale_key_envelopes`, `push_tokens`.

**Limits of the current design, documented in the module header rather than glossed:**
- The server chooses which public key it hands the seller, so it could substitute its own and mount a MITM. A follow-up should have buyers sign their X25519 key with their Stellar key so sellers can verify it independently.
- A malicious seller can keep a copy of the secret they sold. That's inherent to a shared-secret check-in scheme; it's mitigated at the gate, where check-in is single-use.

## 3. Mobile marketplace UI

`apps/mobile/app/ticket/resale.tsx` plus three services:

- **`resaleCrypto.ts`** — sealing/opening, with the X25519 secret in SecureStore, kept separate from the Stellar signing key.
- **`marketplaceApi.ts`** — server client.
- **`resaleContract.ts`** — the Soroban calls, including the approve-then-buy pair.

The screen reads the cap from the contract before enabling the form, validates live while typing, and shows the royalty and net-proceeds breakdown. It polls the offer book, and "send key" seals this ticket's secret to the chosen buyer and clears the local copy.

## What I'd flag for review

- **`transfer_ticket` is untouched.** It still has its own cap check with the tier-price semantics described above, so the two paths now compute the ceiling differently. Unifying them would change existing behaviour and tests, so I left it — worth a follow-up decision.
- **Listings aren't enumerable on-chain.** They're keyed by `payment_id` with no index, so discovery depends on the server mirror. Adding a sharded per-event index (as the contract does for payments) would remove that dependency; it seemed like scope beyond this issue.
- **No platform fee on resales.** The issue only specifies an organizer royalty, so that's all that's deducted.
- **`push_tokens` has no cleanup path.** Expo returns receipts identifying dead tokens; nothing consumes them yet.
- The mobile `useAuth` store is still the mock JWT stub on `main`, so the authenticated endpoints will need it replaced with the real token before they work end to end.

## Verification

| | |
|---|---|
| `cargo test -p ticket-payment` | 11 new resale tests pass — cap boundary (inclusive at the cap, rejected one stroop over), default-cap fallback, double-listing, cancel/relist, atomic settlement balances, missing allowance leaving state untouched, self-purchase, royalty bounds, captured-rate immutability, soulbound rejection |
| `cargo check` (server) | clean; 8 new marketplace unit tests pass |
| `pnpm typecheck` / `pnpm lint` (mobile) | both clean |
| `pnpm test resaleCrypto` | 9 tests pass — round trip, wrong recipient rejected, tampered ciphertext and nonce rejected, no plaintext in the envelope, fresh nonce per envelope |

I did not run the full pre-existing test suites.
