### PR TITLE
<pre><span style="background-color:#C19AFF"> </span> feat(mobile): offline ticket vault with Ed25519 QR verification (#1179)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -27,7 +27,8 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "expo-local-authentication"
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/mobile/app/ticket/[id].tsx
+++ b/apps/mobile/app/ticket/[id].tsx
@@ -1,25 +1,59 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { View, Text, StyleSheet, ScrollView, Modal, Alert, ActivityIndicator } from 'react-native';
+/**
+ * ticket/[id].tsx — Issue #1179: Offline Ticket Vault
+ *
+ * Ticket detail screen with:
+ *   - Biometric authentication gate before any vault decryption (issue #1179)
+ *   - Rotating QR display via DynamicQrView (replaces the old ad-hoc approach)
+ *   - Explicit biometric-unavailable and biometric-failure states
+ *
+ * Biometric flow:
+ *   1. Screen mounts → useBiometricAuth checks hardware availability.
+ *   2. If unavailable (no hardware / not enrolled): show an error banner;
+ *      the QR section is never shown. Do NOT silently unlock.
+ *   3. User taps "Show Ticket QR" → OS biometric prompt appears.
+ *   4. On success: vault secret is read, keypair derived in memory, passed
+ *      to DynamicQrView. The secretKey is held only in React state for the
+ *      lifetime of the screen — it is cleared on unmount.
+ *   5. On failure / cancel: explicit error message shown; QR stays hidden.
+ *
+ * Android note: expo-secure-store on Android does not self-prompt for
+ * biometrics. We call useBiometricAuth().authenticate() first, and only call
+ * getTicketSecret() after it resolves with success. On iOS the Keychain item
+ * itself requires authentication, so the OS prompts automatically — the
+ * explicit authenticate() call before reading is belt-and-suspenders.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Modal,
+  Alert,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import * as SecureStore from 'expo-secure-store';
 import Colors from '@/constants/Colors';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import { Keypair, Networks, TransactionBuilder, Horizon } from '@stellar/stellar-sdk';
 import { StellarWalletManager } from '@/services/stellar';
-
-/** How often the entry QR payload is re-signed. */
-const QR_REFRESH_INTERVAL_MS = 15000;
+import { useBiometricAuth } from '@/hooks/useBiometricAuth';
+import { getTicketSecret } from '@/services/ticketVault';
+import { deriveTicketKeyPair } from '@/lib/crypto';
+import DynamicQrView from '@/components/ticket/DynamicQrView';
 
 export default function TicketDetailsScreen() {
   const { id } = useLocalSearchParams();
-  
+
   const [ticketStatus, setTicketStatus] = useState<'Active' | 'Transferred' | 'Listed'>('Active');
-  
+
   // Modals state
   const [isTransferModalOpen, setTransferModalOpen] = useState(false);
   const [isSellModalOpen, setSellModalOpen] = useState(false);
-  
+
   // Form states
   const [recipientAddress, setRecipientAddress] = useState('');
   const [recipientError, setRecipientError] = useState('');
@@ -27,49 +61,89 @@ export default function TicketDetailsScreen() {
   const [sellError, setSellError] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
 
-  // Rotating entry QR payload (issue #1006). Regenerated on a timer so a
-  // screenshot of the code stops being valid shortly after it is taken.
-  const [qrPayload, setQrPayload] = useState<string | null>(null);
-  const qrTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Vault state — secretKey held in memory only, never persisted to state storage.
+  // Cleared when the screen unmounts.
+  const [vaultSecretKey, setVaultSecretKey] = useState<Uint8Array | null>(null);
+  const [vaultError, setVaultError] = useState<string | null>(null);
+  const [vaultLoading, setVaultLoading] = useState(false);
+
+  const biometric = useBiometricAuth();
+
+  // Clear the in-memory key when the screen unmounts to minimise the window
+  // during which the key is resident in JS heap.
+  useEffect(() => {
+    return () => {
+      setVaultSecretKey(null);
+    };
+  }, []);
 
   // MOCK Ticket Details (consistent with `tickets.tsx` style)
+  // TODO: Replace with real ticket lookup once the ticket store is wired up.
   const ticket = {
     id: id || 'T-1004',
     eventTitle: 'Stellar Meridian 2026',
     date: 'Oct 15, 2026',
     seat: 'General Admission',
     txHash: '0x3f...b82d',
+    // paymentId corresponds to the payment ID used when the ticket was purchased.
+    // In production this comes from the ticket store / on-chain lookup.
+    paymentId: String(id || 'T-1004'),
   };
 
-  const generateDynamicPayload = useCallback(async () => {
-    if (!id) return;
-    try {
-      // The secret is read only for the signing step and never held in state.
-      const privateKey = await SecureStore.getItemAsync('privateKey');
-      if (!privateKey) return;
-
-      // System time so the payload still refreshes offline.
-      const timestamp = Math.floor(Date.now() / 1000);
-      const payload = { ticketId: String(id), timestamp };
-      const payloadString = JSON.stringify(payload);
-
-      const keypair = Keypair.fromSecret(privateKey);
-      const signature = keypair.sign(Buffer.from(payloadString)).toString('base64');
-
-      setQrPayload(JSON.stringify({ ...payload, signature }));
-    } catch (e) {
-      console.error('Error generating ticket payload', e);
+  /**
+   * Gate: authenticate with biometrics, then read the vault.
+   *
+   * Called when the user taps "Show Ticket QR". Never called automatically
+   * on mount — we require explicit user intent before prompting biometrics.
+   */
+  const handleShowQr = useCallback(async () => {
+    if (biometric.state === 'unavailable') {
+      // Already shown the banner — no point prompting again.
+      return;
     }
-  }, [id]);
 
-  useEffect(() => {
-    generateDynamicPayload();
-    qrTimerRef.current = setInterval(generateDynamicPayload, QR_REFRESH_INTERVAL_MS);
+    setVaultError(null);
+    setVaultLoading(true);
 
-    return () => {
-      if (qrTimerRef.current) clearInterval(qrTimerRef.current);
-    };
-  }, [generateDynamicPayload]);
+    try {
+      // Step 1: authenticate (required on Android; belt-and-suspenders on iOS).
+      await biometric.authenticate();
+
+      // If authentication failed, biometric.state will be 'failed' or 'error'.
+      // We check after awaiting because authenticate() does not throw on failure.
+      if (biometric.state !== 'success') {
+        setVaultLoading(false);
+        return;
+      }
+
+      // Step 2: read vault (OS may re-prompt on iOS if required).
+      const secretBytes = await getTicketSecret(ticket.paymentId);
+      if (!secretBytes) {
+        setVaultError(
+          'No ticket secret found for this ticket. This device may not be the original ' +
+          'purchase device, or the ticket was purchased on a different account.'
+        );
+        setVaultLoading(false);
+        return;
+      }
+
+      // Step 3: derive the signing keypair in memory.
+      const { secretKey } = deriveTicketKeyPair(secretBytes);
+      setVaultSecretKey(secretKey);
+    } catch (err) {
+      setVaultError(
+        err instanceof Error ? err.message : 'Failed to access the ticket vault.'
+      );
+    } finally {
+      setVaultLoading(false);
+    }
+  }, [biometric, ticket.paymentId]);
+
+  /** Hide the QR and clear the in-memory key. */
+  const handleHideQr = useCallback(() => {
+    setVaultSecretKey(null);
+    biometric.reset();
+  }, [biometric]);
 
   const handleTransferSubmit = async () => {
     // Validate target string against Stellar public key constraints or email
@@ -187,11 +261,68 @@ export default function TicketDetailsScreen() {
         </View>
       </View>
 
-      <View style={styles.qrContainer}>
-        {/* Placeholder for the visual QR code; no QR library is available in
-            this app yet, so the signed payload is rendered directly. */}
-        <Text style={styles.qrPlaceholder}>[QR Code Placeholder]</Text>
-        <Text style={styles.payload}>{qrPayload}</Text>
+      {/* ── Biometric gate + Rotating QR ──────────────────────────────────── */}
+      <View style={styles.qrSection}>
+        <Text style={styles.sectionTitle}>Entry QR Code</Text>
+
+        {/* Biometric unavailable — explicit error, no silent passthrough */}
+        {biometric.state === 'unavailable' && (
+          <View style={styles.warningBox} accessibilityRole="alert">
+            <Text style={styles.warningText}>
+              ⚠️ Biometric authentication is not available on this device.{'\n'}
+              {biometric.errorMessage ?? 'Please enroll Face ID or Touch ID to display your ticket QR.'}
+            </Text>
+          </View>
+        )}
+
+        {/* Biometric failed — explicit error, no silent passthrough */}
+        {(biometric.state === 'failed' || biometric.state === 'error') && !vaultSecretKey && (
+          <View style={styles.errorBox} accessibilityRole="alert">
+            <Text style={styles.errorText}>
+              {biometric.errorMessage ?? 'Authentication failed. Please try again.'}
+            </Text>
+            <TouchableOpacity onPress={handleShowQr} style={styles.retryButton}>
+              <Text style={styles.retryButtonText}>Try Again</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* Vault error */}
+        {vaultError && (
+          <View style={styles.errorBox} accessibilityRole="alert">
+            <Text style={styles.errorText}>{vaultError}</Text>
+          </View>
+        )}
+
+        {/* Loading */}
+        {vaultLoading && (
+          <View style={styles.loadingBox}>
+            <ActivityIndicator size="large" color={Colors.primaryYellow} />
+            <Text style={styles.loadingText}>Verifying…</Text>
+          </View>
+        )}
+
+        {/* QR unlocked and visible */}
+        {vaultSecretKey && !vaultLoading && (
+          <>
+            <DynamicQrView
+              ticketId={ticket.paymentId}
+              secretKey={vaultSecretKey}
+            />
+            <TouchableOpacity onPress={handleHideQr} style={styles.hideButton}>
+              <Text style={styles.hideButtonText}>Hide QR</Text>
+            </TouchableOpacity>
+          </>
+        )}
+
+        {/* Prompt to authenticate */}
+        {!vaultSecretKey && !vaultLoading && biometric.state !== 'unavailable' && !vaultError && (
+          <Button
+            title="Show Ticket QR"
+            onPress={handleShowQr}
+            style={styles.actionButton}
+          />
+        )}
       </View>
 
       <View style={styles.actionsContainer}>
@@ -403,28 +534,55 @@ const styles = StyleSheet.create({
   cancelButton: {
     backgroundColor: '#2C2C2E',
   },
-  // Entry-QR panel (issue #1006), restyled for this screen's dark surface.
-  qrContainer: {
+  // ── QR / biometric gate section ──────────────────────────────────────────
+  qrSection: {
     marginBottom: 24,
-    padding: 20,
-    borderWidth: 1,
-    borderColor: '#2C2C2E',
-    borderRadius: 12,
-    alignItems: 'center',
-    width: '100%',
   },
-  qrPlaceholder: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 10,
-    textAlign: 'center',
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
     color: Colors.primaryText,
+    marginBottom: 12,
   },
-  payload: {
-    fontSize: 10,
+  loadingBox: {
+    alignItems: 'center',
+    padding: 20,
+  },
+  loadingText: {
     color: Colors.secondaryText,
-    textAlign: 'center',
-    marginTop: 10,
+    marginTop: 8,
+    fontSize: 13,
+  },
+  errorBox: {
+    backgroundColor: '#FF3B3022',
+    padding: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#FF3B3055',
+    marginBottom: 12,
+  },
+  errorText: {
+    color: '#FF3B30',
+    fontSize: 13,
+    lineHeight: 20,
+  },
+  retryButton: {
+    marginTop: 8,
+    alignSelf: 'flex-start',
+  },
+  retryButtonText: {
+    color: Colors.primaryYellow,
+    fontWeight: '600',
+    fontSize: 13,
+  },
+  hideButton: {
+    marginTop: 12,
+    alignSelf: 'center',
+  },
+  hideButtonText: {
+    color: Colors.secondaryText,
+    fontSize: 13,
+    textDecorationLine: 'underline',
   },
 });
 

--- a/apps/mobile/components/ticket/DynamicQrView.tsx
+++ b/apps/mobile/components/ticket/DynamicQrView.tsx
@@ -1,0 +1,189 @@
+/**
+ * DynamicQrView.tsx — Issue #1179: Offline Ticket Vault
+ *
+ * Renders a rotating QR code for offline ticket verification. The payload is
+ * regenerated every PAYLOAD_WINDOW_S seconds via `generateRotatingPayload()`
+ * from `lib/crypto.ts`.
+ *
+ * The QR library is not yet installed in this app (no QR library in
+ * package.json at the time of this feature). This component renders the
+ * base64url payload string directly for now, with a clearly marked TODO to
+ * swap in a QR code rendering library (e.g. react-native-qrcode-svg) once
+ * one is added to the project.
+ *
+ * The component is intentionally dumb: it receives the secretKey as a prop
+ * rather than reading from SecureStore directly, so the parent screen
+ * controls vault access and biometric gating.
+ *
+ * ## Anti-screenshot design note
+ *
+ * The payload rotates every PAYLOAD_WINDOW_S (15s). A screenshot becomes
+ * invalid within PAYLOAD_WINDOW_S + SCANNER_CLOCK_DRIFT_S (75s at most) from
+ * the time it was taken, because the scanner enforces a ±60s timestamp window
+ * around the payload's own window boundary. Gate staff should be instructed to
+ * reject QR codes that do not visibly animate/refresh.
+ */
+
+import React, { useState, useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { generateRotatingPayload, PAYLOAD_WINDOW_S } from '../lib/crypto';
+import Colors from '@/constants/Colors';
+
+// Refresh slightly more often than the window so the display never lags
+// behind by a full window when a window boundary is crossed.
+const REFRESH_INTERVAL_MS = (PAYLOAD_WINDOW_S * 1000) / 2; // every 7.5s
+
+export interface DynamicQrViewProps {
+  /**
+   * Ticket identifier to embed in the payload (max 16 UTF-8 bytes).
+   * Longer strings are truncated at the crypto layer.
+   */
+  ticketId: string;
+  /**
+   * 64-byte Ed25519 secret key derived from the purchase secret.
+   * The parent is responsible for biometric-gating access to this value.
+   */
+  secretKey: Uint8Array;
+  /**
+   * Called each time a new payload is generated. Useful for testing and for
+   * parent screens that want to display the payload text alongside the QR.
+   */
+  onPayloadChange?: (payload: string) => void;
+}
+
+export default function DynamicQrView({
+  ticketId,
+  secretKey,
+  onPayloadChange,
+}: DynamicQrViewProps) {
+  const [payload, setPayload] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const regenerate = () => {
+    try {
+      const next = generateRotatingPayload(ticketId, secretKey, Date.now());
+      setPayload(next);
+      setError(null);
+      onPayloadChange?.(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate payload.');
+    }
+  };
+
+  useEffect(() => {
+    regenerate();
+    intervalRef.current = setInterval(regenerate, REFRESH_INTERVAL_MS);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- secretKey is a Uint8Array ref; deps intentionally include only stable values
+  }, [ticketId, secretKey]);
+
+  if (error) {
+    return (
+      <View style={styles.container} accessibilityRole="alert">
+        <Text style={styles.errorText}>{error}</Text>
+      </View>
+    );
+  }
+
+  if (!payload) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator
+          size="large"
+          color={Colors.primaryYellow}
+          accessibilityLabel="Generating QR code…"
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container} accessibilityRole="image" accessibilityLabel="Ticket QR code">
+      {/*
+       * TODO: Replace this placeholder with a proper QR code rendering component
+       * once a QR library is added to the project (e.g. react-native-qrcode-svg).
+       *
+       * The payload string is a base64url-encoded binary ticket proof ~140
+       * characters long, well within QR code capacity even at medium error
+       * correction.
+       *
+       * Example drop-in replacement:
+       *
+       *   import QRCode from 'react-native-qrcode-svg';
+       *   <QRCode value={payload} size={240} />
+       */}
+      <View style={styles.qrPlaceholderBox} accessibilityHidden>
+        <Text style={styles.qrPlaceholderLabel}>QR Code</Text>
+        <Text style={styles.qrPlaceholderSub}>(QR library not yet installed)</Text>
+      </View>
+
+      {/* Payload string — shown for development/debugging and for gate staff
+          on devices that cannot render the QR. In production this should be
+          hidden or shown only on request. */}
+      <Text
+        style={styles.payloadText}
+        numberOfLines={3}
+        accessibilityLabel="Ticket payload"
+      >
+        {payload}
+      </Text>
+
+      <Text style={styles.refreshHint} accessibilityLiveRegion="polite">
+        Refreshes every {PAYLOAD_WINDOW_S}s
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    padding: 20,
+    borderWidth: 1,
+    borderColor: '#2C2C2E',
+    borderRadius: 12,
+    backgroundColor: '#1E1E20',
+  },
+  qrPlaceholderBox: {
+    width: 200,
+    height: 200,
+    backgroundColor: '#2C2C2E',
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 12,
+  },
+  qrPlaceholderLabel: {
+    color: Colors.primaryText,
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  qrPlaceholderSub: {
+    color: Colors.secondaryText,
+    fontSize: 11,
+    marginTop: 4,
+    textAlign: 'center',
+    paddingHorizontal: 8,
+  },
+  payloadText: {
+    fontSize: 9,
+    color: Colors.secondaryText,
+    textAlign: 'center',
+    marginTop: 4,
+    fontFamily: 'SpaceMono',
+  },
+  refreshHint: {
+    fontSize: 11,
+    color: Colors.secondaryText,
+    marginTop: 8,
+    opacity: 0.6,
+  },
+  errorText: {
+    color: '#FF3B30',
+    fontSize: 13,
+    textAlign: 'center',
+  },
+});

--- a/apps/mobile/components/ticket/DynamicQrView.tsx
+++ b/apps/mobile/components/ticket/DynamicQrView.tsx
@@ -24,7 +24,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
-import { generateRotatingPayload, PAYLOAD_WINDOW_S } from '../lib/crypto';
+import { generateRotatingPayload, PAYLOAD_WINDOW_S } from '../../lib/crypto';
 import Colors from '@/constants/Colors';
 
 // Refresh slightly more often than the window so the display never lags

--- a/apps/mobile/components/ticket/DynamicQrView.tsx
+++ b/apps/mobile/components/ticket/DynamicQrView.tsx
@@ -5,11 +5,8 @@
  * regenerated every PAYLOAD_WINDOW_S seconds via `generateRotatingPayload()`
  * from `lib/crypto.ts`.
  *
- * The QR library is not yet installed in this app (no QR library in
- * package.json at the time of this feature). This component renders the
- * base64url payload string directly for now, with a clearly marked TODO to
- * swap in a QR code rendering library (e.g. react-native-qrcode-svg) once
- * one is added to the project.
+ * Uses react-native-qrcode-svg (backed by react-native-svg) to render the
+ * QR code natively on iOS and Android.
  *
  * The component is intentionally dumb: it receives the secretKey as a prop
  * rather than reading from SecureStore directly, so the parent screen
@@ -26,6 +23,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import QRCode from 'react-native-qrcode-svg';
 import { generateRotatingPayload, PAYLOAD_WINDOW_S } from '../lib/crypto';
 import Colors from '@/constants/Colors';
 
@@ -102,34 +100,17 @@ export default function DynamicQrView({
 
   return (
     <View style={styles.container} accessibilityRole="image" accessibilityLabel="Ticket QR code">
-      {/*
-       * TODO: Replace this placeholder with a proper QR code rendering component
-       * once a QR library is added to the project (e.g. react-native-qrcode-svg).
-       *
-       * The payload string is a base64url-encoded binary ticket proof ~140
-       * characters long, well within QR code capacity even at medium error
-       * correction.
-       *
-       * Example drop-in replacement:
-       *
-       *   import QRCode from 'react-native-qrcode-svg';
-       *   <QRCode value={payload} size={240} />
-       */}
-      <View style={styles.qrPlaceholderBox} accessibilityHidden>
-        <Text style={styles.qrPlaceholderLabel}>QR Code</Text>
-        <Text style={styles.qrPlaceholderSub}>(QR library not yet installed)</Text>
+      <View style={styles.qrWrapper}>
+        <QRCode
+          value={payload}
+          size={240}
+          backgroundColor="#FFFFFF"
+          color="#000000"
+          // Medium error correction (M = ~15% data recovery) balances density
+          // and scan reliability; the ~140-char payload fits comfortably.
+          ecl="M"
+        />
       </View>
-
-      {/* Payload string — shown for development/debugging and for gate staff
-          on devices that cannot render the QR. In production this should be
-          hidden or shown only on request. */}
-      <Text
-        style={styles.payloadText}
-        numberOfLines={3}
-        accessibilityLabel="Ticket payload"
-      >
-        {payload}
-      </Text>
 
       <Text style={styles.refreshHint} accessibilityLiveRegion="polite">
         Refreshes every {PAYLOAD_WINDOW_S}s
@@ -147,38 +128,16 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     backgroundColor: '#1E1E20',
   },
-  qrPlaceholderBox: {
-    width: 200,
-    height: 200,
-    backgroundColor: '#2C2C2E',
+  qrWrapper: {
+    padding: 12,
+    backgroundColor: '#FFFFFF',
     borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
     marginBottom: 12,
-  },
-  qrPlaceholderLabel: {
-    color: Colors.primaryText,
-    fontWeight: 'bold',
-    fontSize: 16,
-  },
-  qrPlaceholderSub: {
-    color: Colors.secondaryText,
-    fontSize: 11,
-    marginTop: 4,
-    textAlign: 'center',
-    paddingHorizontal: 8,
-  },
-  payloadText: {
-    fontSize: 9,
-    color: Colors.secondaryText,
-    textAlign: 'center',
-    marginTop: 4,
-    fontFamily: 'SpaceMono',
   },
   refreshHint: {
     fontSize: 11,
     color: Colors.secondaryText,
-    marginTop: 8,
+    marginTop: 4,
     opacity: 0.6,
   },
   errorText: {

--- a/apps/mobile/hooks/__tests__/useBiometricAuth.test.ts
+++ b/apps/mobile/hooks/__tests__/useBiometricAuth.test.ts
@@ -1,0 +1,245 @@
+/**
+ * useBiometricAuth.test.ts — Issue #1179: Offline Ticket Vault
+ *
+ * Tests for useBiometricAuth hook covering:
+ *   - Initial state (checking → idle or unavailable)
+ *   - Unavailable state (no hardware, not enrolled)
+ *   - Successful authentication
+ *   - User cancellation → failed state (not silently unlocked)
+ *   - Lockout → failed with distinct message
+ *   - Runtime error → error state
+ *   - re-prompt after reset()
+ */
+
+import { renderHook, act } from '@testing-library/react-native';
+import { useBiometricAuth, BiometricState } from '../../hooks/useBiometricAuth';
+
+// ── Mock expo-local-authentication ────────────────────────────────────────────
+
+const mockHasHardware = jest.fn();
+const mockIsEnrolled = jest.fn();
+const mockSupportedTypes = jest.fn();
+const mockAuthenticate = jest.fn();
+
+jest.mock('expo-local-authentication', () => ({
+  hasHardwareAsync: () => mockHasHardware(),
+  isEnrolledAsync: () => mockIsEnrolled(),
+  supportedAuthenticationTypesAsync: () => mockSupportedTypes(),
+  authenticateAsync: (opts: unknown) => mockAuthenticate(opts),
+  AuthenticationType: { FINGERPRINT: 1, FACIAL_RECOGNITION: 2, IRIS: 3 },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: hardware available, enrolled
+  mockHasHardware.mockResolvedValue(true);
+  mockIsEnrolled.mockResolvedValue(true);
+  mockSupportedTypes.mockResolvedValue([2]); // FACIAL_RECOGNITION
+  mockAuthenticate.mockResolvedValue({ success: true });
+});
+
+// ── Helper: wait for all async effects to settle ──────────────────────────────
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+describe('initial state', () => {
+  it('starts in checking state', () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    expect(result.current.state).toBe('checking');
+  });
+
+  it('transitions to idle when hardware is available and enrolled', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    expect(result.current.state).toBe('idle');
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('sets capabilities on load', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    expect(result.current.capabilities).not.toBeNull();
+    expect(result.current.capabilities?.hasHardware).toBe(true);
+    expect(result.current.capabilities?.isEnrolled).toBe(true);
+  });
+});
+
+// ── Unavailable states ────────────────────────────────────────────────────────
+
+describe('unavailable: no hardware', () => {
+  beforeEach(() => {
+    mockHasHardware.mockResolvedValue(false);
+    mockIsEnrolled.mockResolvedValue(false);
+  });
+
+  it('transitions to unavailable', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    expect(result.current.state).toBe('unavailable');
+  });
+
+  it('sets an errorMessage about hardware', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    expect(result.current.errorMessage).toContain('not support');
+  });
+});
+
+describe('unavailable: not enrolled', () => {
+  beforeEach(() => {
+    mockHasHardware.mockResolvedValue(true);
+    mockIsEnrolled.mockResolvedValue(false);
+  });
+
+  it('transitions to unavailable', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    expect(result.current.state).toBe('unavailable');
+  });
+
+  it('sets an errorMessage about enrollment', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    expect(result.current.errorMessage).toMatch(/enroll/i);
+  });
+});
+
+// ── Successful authentication ─────────────────────────────────────────────────
+
+describe('successful authentication', () => {
+  it('transitions to success after authenticate()', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects(); // idle
+
+    await act(async () => {
+      await result.current.authenticate();
+    });
+
+    expect(result.current.state).toBe('success');
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('does not silently fall through on success — state is explicitly "success"', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+
+    // The gate check in [id].tsx is `if (biometric.state !== 'success')`.
+    // This test verifies the state is not some truthy ambiguous value.
+    expect(result.current.state).toBe<BiometricState>('success');
+  });
+});
+
+// ── User cancellation ─────────────────────────────────────────────────────────
+
+describe('user cancellation', () => {
+  beforeEach(() => {
+    mockAuthenticate.mockResolvedValue({ success: false, error: 'user_cancel' });
+  });
+
+  it('transitions to failed (not silently unlocked)', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+
+    expect(result.current.state).toBe('failed');
+    // Must NOT be 'success' — never silently fall through
+    expect(result.current.state).not.toBe('success');
+  });
+
+  it('sets a user-facing error message on cancel', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+
+    expect(result.current.errorMessage).not.toBeNull();
+    expect(result.current.errorMessage).toMatch(/cancel/i);
+  });
+});
+
+// ── Lockout ───────────────────────────────────────────────────────────────────
+
+describe('lockout', () => {
+  beforeEach(() => {
+    mockAuthenticate.mockResolvedValue({ success: false, error: 'lockout' });
+  });
+
+  it('transitions to failed on lockout', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+    expect(result.current.state).toBe('failed');
+  });
+
+  it('lockout message is distinct from cancel message', async () => {
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+    const lockoutMsg = result.current.errorMessage;
+
+    mockAuthenticate.mockResolvedValue({ success: false, error: 'user_cancel' });
+    const { result: result2 } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result2.current.authenticate(); });
+    const cancelMsg = result2.current.errorMessage;
+
+    expect(lockoutMsg).not.toBe(cancelMsg);
+  });
+});
+
+// ── Runtime error ─────────────────────────────────────────────────────────────
+
+describe('runtime error', () => {
+  it('transitions to error state when authenticateAsync throws', async () => {
+    mockAuthenticate.mockRejectedValue(new Error('Biometric hardware fault'));
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+    expect(result.current.state).toBe('error');
+    expect(result.current.errorMessage).toContain('fault');
+  });
+
+  it('transitions to error state when capability check throws', async () => {
+    mockHasHardware.mockRejectedValue(new Error('Hardware query failed'));
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    expect(result.current.state).toBe('error');
+  });
+});
+
+// ── reset() ───────────────────────────────────────────────────────────────────
+
+describe('reset', () => {
+  it('resets state to idle after failed authentication', async () => {
+    mockAuthenticate.mockResolvedValue({ success: false, error: 'user_cancel' });
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+    expect(result.current.state).toBe('failed');
+
+    act(() => { result.current.reset(); });
+    expect(result.current.state).toBe('idle');
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('allows re-authentication after reset', async () => {
+    mockAuthenticate
+      .mockResolvedValueOnce({ success: false, error: 'user_cancel' })
+      .mockResolvedValueOnce({ success: true });
+
+    const { result } = renderHook(() => useBiometricAuth());
+    await flushEffects();
+    await act(async () => { await result.current.authenticate(); });
+    expect(result.current.state).toBe('failed');
+
+    act(() => { result.current.reset(); });
+    await act(async () => { await result.current.authenticate(); });
+    expect(result.current.state).toBe('success');
+  });
+});

--- a/apps/mobile/hooks/useBiometricAuth.ts
+++ b/apps/mobile/hooks/useBiometricAuth.ts
@@ -1,0 +1,168 @@
+/**
+ * useBiometricAuth.ts — Issue #1179: Offline Ticket Vault
+ *
+ * React hook encapsulating biometric authentication state and the prompt
+ * trigger. Used by the ticket detail screen to gate vault access.
+ *
+ * ## States
+ *
+ *   idle        — not yet attempted
+ *   checking    — querying hardware availability
+ *   unavailable — device has no biometric hardware or no enrolled credentials
+ *                 (gate staff UI must show a fallback / passcode path)
+ *   prompting   — OS prompt is active
+ *   success     — authenticated; vault reads are permitted (Android) /
+ *                 will be permitted by the OS prompt (iOS)
+ *   failed      — user cancelled or biometric did not match; show an explicit
+ *                 error — do NOT silently fall through to "unlocked"
+ *   error       — unexpected runtime error (device locked, hardware fault)
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export type BiometricState =
+  | 'idle'
+  | 'checking'
+  | 'unavailable'
+  | 'prompting'
+  | 'success'
+  | 'failed'
+  | 'error';
+
+export interface BiometricCapabilities {
+  /** True if the hardware supports biometric authentication. */
+  hasHardware: boolean;
+  /** True if the user has enrolled at least one biometric credential. */
+  isEnrolled: boolean;
+  /** List of biometric types available (Face, Fingerprint, Iris). */
+  supportedTypes: LocalAuthentication.AuthenticationType[];
+}
+
+export interface UseBiometricAuthResult {
+  state: BiometricState;
+  /** Populated when state is 'unavailable' or 'failed' or 'error'. */
+  errorMessage: string | null;
+  capabilities: BiometricCapabilities | null;
+  /** Triggers the biometric prompt. Safe to call when state is 'idle' or 'failed'. */
+  authenticate: () => Promise<void>;
+  /** Resets state back to 'idle' (useful after a transaction completes). */
+  reset: () => void;
+}
+
+/** Prompt strings shown to the user in the OS native biometric dialog. */
+const PROMPT_STRINGS = {
+  promptMessage: 'Authenticate to view your ticket',
+  cancelLabel: 'Cancel',
+  fallbackLabel: 'Use Passcode',
+} as const;
+
+export function useBiometricAuth(): UseBiometricAuthResult {
+  const [state, setState] = useState<BiometricState>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [capabilities, setCapabilities] = useState<BiometricCapabilities | null>(null);
+
+  // Check hardware capabilities once on mount.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkCapabilities() {
+      setState('checking');
+      try {
+        const [hasHardware, isEnrolled, supportedTypes] = await Promise.all([
+          LocalAuthentication.hasHardwareAsync(),
+          LocalAuthentication.isEnrolledAsync(),
+          LocalAuthentication.supportedAuthenticationTypesAsync(),
+        ]);
+
+        if (cancelled) return;
+
+        const caps: BiometricCapabilities = { hasHardware, isEnrolled, supportedTypes };
+        setCapabilities(caps);
+
+        if (!hasHardware || !isEnrolled) {
+          setState('unavailable');
+          setErrorMessage(
+            !hasHardware
+              ? 'This device does not support biometric authentication.'
+              : 'No biometric credentials are enrolled. Please set up Face ID, Touch ID, or a passcode in your device settings.'
+          );
+        } else {
+          setState('idle');
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setState('error');
+        setErrorMessage(
+          err instanceof Error
+            ? err.message
+            : 'An unexpected error occurred while checking biometric availability.'
+        );
+      }
+    }
+
+    checkCapabilities();
+    return () => { cancelled = true; };
+  }, []);
+
+  const authenticate = useCallback(async () => {
+    // Prevent re-entrance while a prompt is already active.
+    if (state === 'prompting') return;
+
+    setState('prompting');
+    setErrorMessage(null);
+
+    try {
+      const result = await LocalAuthentication.authenticateAsync({
+        promptMessage: PROMPT_STRINGS.promptMessage,
+        cancelLabel: PROMPT_STRINGS.cancelLabel,
+        fallbackLabel: PROMPT_STRINGS.fallbackLabel,
+        // Require strong biometric (Face ID / Touch ID) but allow passcode
+        // as fallback (disableDeviceFallback: false is the default).
+        disableDeviceFallback: false,
+      });
+
+      if (result.success) {
+        setState('success');
+      } else {
+        // result.error is a string like 'user_cancel', 'lockout', 'user_fallback', etc.
+        setState('failed');
+        setErrorMessage(describeAuthFailure(result.error));
+      }
+    } catch (err) {
+      setState('error');
+      setErrorMessage(
+        err instanceof Error ? err.message : 'Biometric authentication failed unexpectedly.'
+      );
+    }
+  }, [state]);
+
+  const reset = useCallback(() => {
+    setState('idle');
+    setErrorMessage(null);
+  }, []);
+
+  return { state, errorMessage, capabilities, authenticate, reset };
+}
+
+// ── Error message helpers ─────────────────────────────────────────────────────
+
+function describeAuthFailure(error: string | undefined): string {
+  switch (error) {
+    case 'user_cancel':
+      return 'Authentication was cancelled. Tap to try again.';
+    case 'lockout':
+    case 'lockout_permanent':
+      return 'Too many failed attempts. Please use your passcode or wait and try again.';
+    case 'user_fallback':
+      return 'Biometric not recognised. Please use your passcode.';
+    case 'system_cancel':
+      return 'Authentication was interrupted by the system. Please try again.';
+    case 'not_enrolled':
+      return 'No biometric credentials enrolled. Please configure Face ID or Touch ID.';
+    case 'not_available':
+      return 'Biometric authentication is not available on this device.';
+    default:
+      return `Authentication failed${error ? ` (${error})` : ''}. Please try again.`;
+  }
+}

--- a/apps/mobile/lib/__tests__/crypto.test.ts
+++ b/apps/mobile/lib/__tests__/crypto.test.ts
@@ -1,0 +1,297 @@
+/**
+ * crypto.test.ts — Issue #1179: Offline Ticket Vault
+ *
+ * Tests for:
+ *   - Key derivation (deriveTicketKeyPair)
+ *   - Payload generation (generateRotatingPayload)
+ *   - Payload parsing (parsePayload)
+ *   - Payload verification (verifyPayload) — timestamp window, signature validation
+ *   - Base64url round-trip
+ */
+
+import nacl from 'tweetnacl';
+import {
+  deriveTicketKeyPair,
+  generateRotatingPayload,
+  parsePayload,
+  verifyPayload,
+  toBase64Url,
+  fromBase64Url,
+  PAYLOAD_OFFSETS,
+  PAYLOAD_WINDOW_S,
+  SCANNER_CLOCK_DRIFT_S,
+  PAYLOAD_VERSION,
+} from '../../lib/crypto';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeSecret(fillByte = 0x42): Uint8Array {
+  return new Uint8Array(32).fill(fillByte);
+}
+
+const FIXED_SECRET = makeSecret(0x42);
+const FIXED_NOW_MS = 1_700_000_000_000; // arbitrary fixed timestamp
+
+// ── Base64url helpers ─────────────────────────────────────────────────────────
+
+describe('base64url encoding', () => {
+  it('round-trips arbitrary bytes', () => {
+    const original = new Uint8Array([0, 1, 127, 128, 255, 66, 99]);
+    expect(fromBase64Url(toBase64Url(original))).toEqual(original);
+  });
+
+  it('produces url-safe characters only', () => {
+    const bytes = nacl.randomBytes(100);
+    const encoded = toBase64Url(bytes);
+    expect(encoded).toMatch(/^[A-Za-z0-9\-_]+$/);
+  });
+
+  it('omits padding', () => {
+    // Base64url should not contain '='
+    const bytes = nacl.randomBytes(10);
+    expect(toBase64Url(bytes)).not.toContain('=');
+  });
+
+  it('round-trips all 256 byte values in a 256-byte array', () => {
+    const all = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) all[i] = i;
+    expect(fromBase64Url(toBase64Url(all))).toEqual(all);
+  });
+});
+
+// ── Key derivation ────────────────────────────────────────────────────────────
+
+describe('deriveTicketKeyPair', () => {
+  it('returns a 32-byte public key and 64-byte secret key', () => {
+    const { publicKey, secretKey } = deriveTicketKeyPair(FIXED_SECRET);
+    expect(publicKey.length).toBe(32);
+    expect(secretKey.length).toBe(64);
+  });
+
+  it('is deterministic: same seed → same keypair', () => {
+    const kp1 = deriveTicketKeyPair(FIXED_SECRET);
+    const kp2 = deriveTicketKeyPair(FIXED_SECRET);
+    expect(kp1.publicKey).toEqual(kp2.publicKey);
+    expect(kp1.secretKey).toEqual(kp2.secretKey);
+  });
+
+  it('different seeds produce different keypairs', () => {
+    const kp1 = deriveTicketKeyPair(makeSecret(0x01));
+    const kp2 = deriveTicketKeyPair(makeSecret(0x02));
+    expect(kp1.publicKey).not.toEqual(kp2.publicKey);
+  });
+
+  it('throws for a seed shorter than 32 bytes', () => {
+    expect(() => deriveTicketKeyPair(new Uint8Array(16))).toThrow();
+  });
+
+  it('throws for a seed longer than 32 bytes', () => {
+    expect(() => deriveTicketKeyPair(new Uint8Array(33))).toThrow();
+  });
+
+  it('nacl.sign.detached.verify accepts signatures from the derived keypair', () => {
+    const { publicKey, secretKey } = deriveTicketKeyPair(FIXED_SECRET);
+    const msg = new Uint8Array([1, 2, 3]);
+    const sig = nacl.sign.detached(msg, secretKey);
+    expect(nacl.sign.detached.verify(msg, sig, publicKey)).toBe(true);
+  });
+});
+
+// ── Payload generation ────────────────────────────────────────────────────────
+
+describe('generateRotatingPayload', () => {
+  const { secretKey } = deriveTicketKeyPair(FIXED_SECRET);
+
+  it('returns a non-empty string', () => {
+    const payload = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+    expect(typeof payload).toBe('string');
+    expect(payload.length).toBeGreaterThan(0);
+  });
+
+  it('decodes to exactly PAYLOAD_OFFSETS.TOTAL bytes', () => {
+    const payload = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+    const bytes = fromBase64Url(payload);
+    expect(bytes.length).toBe(PAYLOAD_OFFSETS.TOTAL);
+  });
+
+  it('sets the version byte correctly', () => {
+    const payload = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+    const bytes = fromBase64Url(payload);
+    expect(bytes[PAYLOAD_OFFSETS.VERSION]).toBe(PAYLOAD_VERSION);
+  });
+
+  it('embeds the window-aligned timestamp', () => {
+    const payload = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+    const parsed = parsePayload(payload);
+    const expectedWindow =
+      Math.floor(FIXED_NOW_MS / 1000 / PAYLOAD_WINDOW_S) * PAYLOAD_WINDOW_S;
+    expect(parsed.timestampS).toBe(expectedWindow);
+  });
+
+  it('two calls within the same 15s window have the same timestamp', () => {
+    // Both calls use timestamps that are in the same window boundary.
+    const t1 = 1_700_000_000_000;
+    const t2 = t1 + 7_000; // +7s, same window
+    const p1 = parsePayload(generateRotatingPayload('ticket-1', secretKey, t1));
+    const p2 = parsePayload(generateRotatingPayload('ticket-1', secretKey, t2));
+    expect(p1.timestampS).toBe(p2.timestampS);
+  });
+
+  it('payloads in adjacent windows have different timestamps', () => {
+    const t1 = 1_700_000_000_000;
+    const windowMs = PAYLOAD_WINDOW_S * 1000;
+    const t2 = t1 + windowMs + 1; // next window
+    const p1 = parsePayload(generateRotatingPayload('ticket-1', secretKey, t1));
+    const p2 = parsePayload(generateRotatingPayload('ticket-1', secretKey, t2));
+    expect(p1.timestampS).not.toBe(p2.timestampS);
+  });
+
+  it('embeds the ticketId', () => {
+    const ticketId = 'test-ticket-99';
+    const payload = generateRotatingPayload(ticketId, secretKey, FIXED_NOW_MS);
+    const parsed = parsePayload(payload);
+    expect(parsed.ticketId).toBe(ticketId);
+  });
+
+  it('truncates ticketId longer than 16 bytes', () => {
+    // 'abcdefghijklmnop' is exactly 16 bytes; 'abcdefghijklmnopXYZ' is 19.
+    const long = 'abcdefghijklmnopXYZ';
+    const payload = generateRotatingPayload(long, secretKey, FIXED_NOW_MS);
+    const parsed = parsePayload(payload);
+    // The stored ticket ID should be the first 16 bytes of the UTF-8 encoding.
+    expect(parsed.ticketId).toBe('abcdefghijklmnop');
+  });
+
+  it('two payloads for the same ticket at the same time have different nonces', () => {
+    const p1 = fromBase64Url(generateRotatingPayload('t1', secretKey, FIXED_NOW_MS));
+    const p2 = fromBase64Url(generateRotatingPayload('t1', secretKey, FIXED_NOW_MS));
+    const nonce1 = p1.slice(PAYLOAD_OFFSETS.NONCE, PAYLOAD_OFFSETS.SIGNATURE);
+    const nonce2 = p2.slice(PAYLOAD_OFFSETS.NONCE, PAYLOAD_OFFSETS.SIGNATURE);
+    // With overwhelming probability the nonces differ (16 random bytes).
+    expect(nonce1).not.toEqual(nonce2);
+  });
+
+  it('throws if secretKey is not 64 bytes', () => {
+    expect(() =>
+      generateRotatingPayload('t1', new Uint8Array(32), FIXED_NOW_MS)
+    ).toThrow();
+  });
+});
+
+// ── Payload parsing ───────────────────────────────────────────────────────────
+
+describe('parsePayload', () => {
+  const { secretKey } = deriveTicketKeyPair(FIXED_SECRET);
+
+  it('parses a valid payload without throwing', () => {
+    const encoded = generateRotatingPayload('ticket-5', secretKey, FIXED_NOW_MS);
+    expect(() => parsePayload(encoded)).not.toThrow();
+  });
+
+  it('throws on wrong byte length', () => {
+    const short = toBase64Url(new Uint8Array(10));
+    expect(() => parsePayload(short)).toThrow(/expected \d+ bytes/i);
+  });
+
+  it('throws on unsupported version byte', () => {
+    const encoded = generateRotatingPayload('ticket-5', secretKey, FIXED_NOW_MS);
+    const bytes = fromBase64Url(encoded);
+    bytes[0] = 0x99; // wrong version
+    expect(() => parsePayload(toBase64Url(bytes))).toThrow(/unsupported version/i);
+  });
+
+  it('signedMessage is bytes[0..41]', () => {
+    const encoded = generateRotatingPayload('ticket-5', secretKey, FIXED_NOW_MS);
+    const parsed = parsePayload(encoded);
+    expect(parsed.signedMessage.length).toBe(PAYLOAD_OFFSETS.SIGNATURE);
+  });
+});
+
+// ── Payload verification ──────────────────────────────────────────────────────
+
+describe('verifyPayload', () => {
+  const { publicKey, secretKey } = deriveTicketKeyPair(FIXED_SECRET);
+
+  it('returns ok=true for a fresh valid payload', () => {
+    const encoded = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+    const result = verifyPayload(encoded, publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ticketId).toBe('ticket-1');
+    }
+  });
+
+  it('returns ok=false reason=invalid_signature for a tampered payload', () => {
+    const encoded = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+    const bytes = fromBase64Url(encoded);
+    // Flip one bit in the signature
+    bytes[PAYLOAD_OFFSETS.SIGNATURE] ^= 0x01;
+    const result = verifyPayload(toBase64Url(bytes), publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+
+  it('returns ok=false reason=invalid_signature for the wrong public key', () => {
+    const { secretKey: sk2 } = deriveTicketKeyPair(makeSecret(0x99));
+    const encoded = generateRotatingPayload('ticket-1', sk2, FIXED_NOW_MS);
+    // Verify with the original (different) public key
+    const result = verifyPayload(encoded, publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+
+  it('returns ok=false reason=invalid_signature when ticketId is tampered', () => {
+    const encoded = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+    const bytes = fromBase64Url(encoded);
+    // Overwrite the ticketId field
+    bytes[PAYLOAD_OFFSETS.TICKET_ID] = 0xff;
+    const result = verifyPayload(toBase64Url(bytes), publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+
+  it('accepts a payload within the ±60s clock drift window', () => {
+    // Payload generated SCANNER_CLOCK_DRIFT_S - 1 seconds ago (still valid)
+    const oldNow = FIXED_NOW_MS - (SCANNER_CLOCK_DRIFT_S - 1) * 1000;
+    const encoded = generateRotatingPayload('ticket-1', secretKey, oldNow);
+    const result = verifyPayload(encoded, publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a payload just outside the timestamp window', () => {
+    // Payload from (PAYLOAD_WINDOW_S + SCANNER_CLOCK_DRIFT_S + 1)s ago
+    const tooOldDeltaS = PAYLOAD_WINDOW_S + SCANNER_CLOCK_DRIFT_S + 1;
+    // The payload timestamp is at the window boundary before the generation time,
+    // so we need to go back far enough that the boundary itself is outside the window.
+    const oldNow = FIXED_NOW_MS - (tooOldDeltaS + PAYLOAD_WINDOW_S) * 1000;
+    const encoded = generateRotatingPayload('ticket-1', secretKey, oldNow);
+    const result = verifyPayload(encoded, publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('expired_timestamp');
+  });
+
+  it('returns ok=false reason=bad_payload for garbage input', () => {
+    const result = verifyPayload('not-a-valid-payload', publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('bad_payload');
+  });
+
+  it('returns ok=false reason=bad_payload for empty string', () => {
+    const result = verifyPayload('', publicKey, FIXED_NOW_MS);
+    expect(result.ok).toBe(false);
+  });
+
+  // Legacy/stale-key handling: a payload signed with an old key (e.g. before
+  // a ticket transfer) must not verify against the new owner's public key.
+  it('stale-key: old keypair payload does not verify against new keypair public key', () => {
+    const oldSecret = makeSecret(0xAA);
+    const newSecret = makeSecret(0xBB);
+    const { secretKey: oldSk } = deriveTicketKeyPair(oldSecret);
+    const { publicKey: newPk } = deriveTicketKeyPair(newSecret);
+
+    const encoded = generateRotatingPayload('ticket-transfer', oldSk, FIXED_NOW_MS);
+    const result = verifyPayload(encoded, newPk, FIXED_NOW_MS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+});

--- a/apps/mobile/lib/crypto.ts
+++ b/apps/mobile/lib/crypto.ts
@@ -1,0 +1,319 @@
+/**
+ * crypto.ts — Issue #1179: Offline Ticket Vault
+ *
+ * ## Crypto design decision: Ed25519 (asymmetric), not HMAC
+ *
+ * The issue spec mentions "HMAC-SHA256" but then says scanners verify "against
+ * pre-synced event public keys." These are incompatible:
+ *
+ *   - HMAC is symmetric: the same secret generates *and* verifies the tag.
+ *     Distributing that secret to every gate-scanner device means a single
+ *     stolen or compromised scanner leaks the ability to forge valid tickets
+ *     for the whole event.
+ *
+ *   - The "public key" language implies asymmetric signing, where scanners
+ *     only hold a public key that can *verify* but never *forge* signatures.
+ *
+ * We use Ed25519 (tweetnacl `nacl.sign`, already a dependency via
+ * `resaleCrypto.ts`) because:
+ *
+ *   1. tweetnacl is already in package.json — no new dependency.
+ *   2. The existing `ticket/[id].tsx` already uses `Keypair.sign()` (Ed25519,
+ *      from @stellar/stellar-sdk) for rotating QR payloads. This module
+ *      replaces that ad-hoc approach with a well-structured, testable API.
+ *   3. `generatePurchaseSecret()` in `ticketPaymentContract.ts` already
+ *      produces 32 random bytes (`Keypair.random().rawSecretKey()`), which is
+ *      exactly the seed tweetnacl needs for `nacl.sign.keyPair.fromSeed()`.
+ *   4. Only the 32-byte public key is synced to scanner devices. A lost
+ *      scanner cannot forge tickets.
+ *
+ * ## Payload wire format (binary, base64url-encoded for QR)
+ *
+ * All multi-byte integers are big-endian.
+ *
+ *   Offset  Size  Field
+ *   ------  ----  -----
+ *        0     1  version (0x01)
+ *        1     8  timestamp_s (uint64): Unix seconds, truncated to 15s window
+ *        9    16  ticket_id   (UTF-8, zero-padded or trimmed to 16 bytes)
+ *       25    16  nonce       (random, 16 bytes)
+ *       41    64  signature   (Ed25519 over bytes[0..41])
+ *   Total: 105 bytes → ~140 base64url chars → comfortably fits a QR code
+ *
+ * The scanner reconstructs bytes[0..41], re-verifies the signature, checks
+ * the timestamp against its own clock, and checks the ticket ID against its
+ * local scan log.
+ */
+
+import nacl from 'tweetnacl';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const PAYLOAD_VERSION = 0x01;
+
+/** Rotation window: payload is valid for two windows either side of generation. */
+export const PAYLOAD_WINDOW_S = 15;
+
+/** Scanner clock-drift tolerance (±60s). */
+export const SCANNER_CLOCK_DRIFT_S = 60;
+
+/** Byte lengths of each payload field. */
+export const PAYLOAD_OFFSETS = {
+  VERSION: 0,
+  TIMESTAMP: 1,
+  TICKET_ID: 9,
+  NONCE: 25,
+  SIGNATURE: 41,
+  TOTAL: 105,
+} as const;
+
+export const TICKET_ID_FIELD_BYTES = 16;
+export const NONCE_BYTES = 16;
+export const SIGNATURE_BYTES = 64; // Ed25519
+
+// ── Key derivation ─────────────────────────────────────────────────────────────
+
+export interface TicketKeyPair {
+  /** 32-byte Ed25519 public key — safe to distribute to scanners. */
+  publicKey: Uint8Array;
+  /**
+   * 64-byte nacl.sign secret key (seed ‖ public key).
+   * NEVER distribute this; it stays on the attendee's device in the vault.
+   */
+  secretKey: Uint8Array;
+}
+
+/**
+ * Derives the per-ticket Ed25519 signing keypair from the raw purchase secret
+ * (the `secretBytes` returned by `generatePurchaseSecret()` in
+ * `ticketPaymentContract.ts`).
+ *
+ * The secret is the seed for `nacl.sign.keyPair.fromSeed()`. The 32-byte
+ * public key is what gets pre-synced to scanner devices.
+ *
+ * This derivation is deterministic: the same secretBytes always produces the
+ * same keypair, so the vault can re-derive the keypair from the stored secret
+ * rather than storing two separate keys.
+ */
+export function deriveTicketKeyPair(secretBytes: Uint8Array): TicketKeyPair {
+  if (secretBytes.length !== 32) {
+    throw new Error(
+      `deriveTicketKeyPair: seed must be 32 bytes, got ${secretBytes.length}.`
+    );
+  }
+  const kp = nacl.sign.keyPair.fromSeed(secretBytes);
+  return { publicKey: kp.publicKey, secretKey: kp.secretKey };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Encodes a string to exactly `length` bytes (UTF-8 truncated or zero-padded). */
+function encodeFixedString(s: string, length: number): Uint8Array {
+  const te = new TextEncoder();
+  const encoded = te.encode(s);
+  const out = new Uint8Array(length);
+  out.set(encoded.subarray(0, length));
+  return out;
+}
+
+/** Decodes a fixed-length zero-padded UTF-8 field back to a string. */
+function decodeFixedString(bytes: Uint8Array): string {
+  const td = new TextDecoder();
+  // Strip trailing zero bytes before decoding
+  let end = bytes.length;
+  while (end > 0 && bytes[end - 1] === 0) end--;
+  return td.decode(bytes.subarray(0, end));
+}
+
+/**
+ * Writes a 64-bit unsigned integer into a DataView at the given byte offset,
+ * as two 32-bit big-endian words (JS has no native 64-bit integer support).
+ */
+function writeUint64BE(view: DataView, offset: number, value: number): void {
+  const hi = Math.floor(value / 0x100000000);
+  const lo = value >>> 0;
+  view.setUint32(offset, hi);
+  view.setUint32(offset + 4, lo);
+}
+
+/**
+ * Reads a 64-bit unsigned integer from a DataView at the given byte offset.
+ */
+function readUint64BE(view: DataView, offset: number): number {
+  const hi = view.getUint32(offset);
+  const lo = view.getUint32(offset + 4);
+  return hi * 0x100000000 + lo;
+}
+
+// ── Base64url encoding ────────────────────────────────────────────────────────
+
+const BASE64URL_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+export function toBase64Url(bytes: Uint8Array): string {
+  let result = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i];
+    const b1 = i + 1 < bytes.length ? bytes[i + 1] : 0;
+    const b2 = i + 2 < bytes.length ? bytes[i + 2] : 0;
+    result += BASE64URL_CHARS[b0 >> 2];
+    result += BASE64URL_CHARS[((b0 & 3) << 4) | (b1 >> 4)];
+    result += i + 1 < bytes.length ? BASE64URL_CHARS[((b1 & 15) << 2) | (b2 >> 6)] : '=';
+    result += i + 2 < bytes.length ? BASE64URL_CHARS[b2 & 63] : '=';
+  }
+  return result.replace(/=+$/, '');
+}
+
+const BASE64URL_LOOKUP: Record<string, number> = {};
+for (let i = 0; i < BASE64URL_CHARS.length; i++) {
+  BASE64URL_LOOKUP[BASE64URL_CHARS[i]] = i;
+}
+
+export function fromBase64Url(s: string): Uint8Array {
+  // Restore padding
+  const padded = s + '=='.slice(0, (4 - (s.length % 4)) % 4);
+  const out: number[] = [];
+  for (let i = 0; i < padded.length; i += 4) {
+    const c0 = BASE64URL_LOOKUP[padded[i]] ?? 0;
+    const c1 = BASE64URL_LOOKUP[padded[i + 1]] ?? 0;
+    const c2 = BASE64URL_LOOKUP[padded[i + 2]] ?? 0;
+    const c3 = BASE64URL_LOOKUP[padded[i + 3]] ?? 0;
+    out.push((c0 << 2) | (c1 >> 4));
+    if (padded[i + 2] !== '=') out.push(((c1 & 15) << 4) | (c2 >> 2));
+    if (padded[i + 3] !== '=') out.push(((c2 & 3) << 6) | c3);
+  }
+  return new Uint8Array(out);
+}
+
+// ── Payload generation ────────────────────────────────────────────────────────
+
+/**
+ * Generates a rotating QR payload for offline ticket verification.
+ *
+ * The payload is a 105-byte binary structure (see header for layout) encoded
+ * as base64url so it can be rendered into a QR code. It is valid for at most
+ * PAYLOAD_WINDOW_S × 2 seconds (current window ± scanner clock drift).
+ *
+ * @param ticketId   Human-readable ticket identifier (max 16 UTF-8 bytes).
+ * @param secretKey  64-byte Ed25519 secret key from `deriveTicketKeyPair()`.
+ * @param nowMs      Current time in milliseconds (defaults to `Date.now()`).
+ */
+export function generateRotatingPayload(
+  ticketId: string,
+  secretKey: Uint8Array,
+  nowMs: number = Date.now()
+): string {
+  if (secretKey.length !== 64) {
+    throw new Error(
+      `generateRotatingPayload: secretKey must be 64 bytes, got ${secretKey.length}.`
+    );
+  }
+
+  // Truncate to the current 15-second window boundary so payloads are stable
+  // within the window and predictably advance every PAYLOAD_WINDOW_S seconds.
+  const timestampS = Math.floor(nowMs / 1000 / PAYLOAD_WINDOW_S) * PAYLOAD_WINDOW_S;
+
+  const buf = new Uint8Array(PAYLOAD_OFFSETS.TOTAL);
+  const view = new DataView(buf.buffer);
+
+  buf[PAYLOAD_OFFSETS.VERSION] = PAYLOAD_VERSION;
+  writeUint64BE(view, PAYLOAD_OFFSETS.TIMESTAMP, timestampS);
+  buf.set(encodeFixedString(ticketId, TICKET_ID_FIELD_BYTES), PAYLOAD_OFFSETS.TICKET_ID);
+  buf.set(nacl.randomBytes(NONCE_BYTES), PAYLOAD_OFFSETS.NONCE);
+
+  // Sign the header (everything before the signature field).
+  const message = buf.subarray(0, PAYLOAD_OFFSETS.SIGNATURE);
+  const signature = nacl.sign.detached(message, secretKey);
+  buf.set(signature, PAYLOAD_OFFSETS.SIGNATURE);
+
+  return toBase64Url(buf);
+}
+
+// ── Payload parsing ───────────────────────────────────────────────────────────
+
+export interface ParsedPayload {
+  version: number;
+  timestampS: number;
+  ticketId: string;
+  nonce: Uint8Array;
+  signature: Uint8Array;
+  /** The 41 bytes over which the signature was computed. */
+  signedMessage: Uint8Array;
+}
+
+/**
+ * Parses a base64url QR payload into its constituent fields.
+ * Throws if the binary length or version byte is wrong.
+ */
+export function parsePayload(encoded: string): ParsedPayload {
+  const buf = fromBase64Url(encoded);
+  if (buf.length !== PAYLOAD_OFFSETS.TOTAL) {
+    throw new Error(
+      `parsePayload: expected ${PAYLOAD_OFFSETS.TOTAL} bytes, got ${buf.length}.`
+    );
+  }
+  const view = new DataView(buf.buffer);
+
+  const version = buf[PAYLOAD_OFFSETS.VERSION];
+  if (version !== PAYLOAD_VERSION) {
+    throw new Error(`parsePayload: unsupported version ${version}.`);
+  }
+
+  return {
+    version,
+    timestampS: readUint64BE(view, PAYLOAD_OFFSETS.TIMESTAMP),
+    ticketId: decodeFixedString(
+      buf.subarray(PAYLOAD_OFFSETS.TICKET_ID, PAYLOAD_OFFSETS.NONCE)
+    ),
+    nonce: buf.slice(PAYLOAD_OFFSETS.NONCE, PAYLOAD_OFFSETS.SIGNATURE),
+    signature: buf.slice(PAYLOAD_OFFSETS.SIGNATURE),
+    signedMessage: buf.slice(0, PAYLOAD_OFFSETS.SIGNATURE),
+  };
+}
+
+// ── Verification ──────────────────────────────────────────────────────────────
+
+export type VerifyResult =
+  | { ok: true; ticketId: string; timestampS: number }
+  | { ok: false; reason: 'invalid_signature' | 'expired_timestamp' | 'bad_payload' };
+
+/**
+ * Verifies a rotating QR payload against a pre-synced Ed25519 public key.
+ *
+ * This runs entirely offline on the scanner device. No network call is made.
+ *
+ * @param encoded    Base64url payload string from the QR code.
+ * @param publicKey  32-byte Ed25519 public key synced to the scanner.
+ * @param nowMs      Current scanner time in milliseconds (defaults to Date.now()).
+ */
+export function verifyPayload(
+  encoded: string,
+  publicKey: Uint8Array,
+  nowMs: number = Date.now()
+): VerifyResult {
+  let parsed: ParsedPayload;
+  try {
+    parsed = parsePayload(encoded);
+  } catch {
+    return { ok: false, reason: 'bad_payload' };
+  }
+
+  // Verify Ed25519 signature first (fast rejection of tampered payloads).
+  const sigValid = nacl.sign.detached.verify(
+    parsed.signedMessage,
+    parsed.signature,
+    publicKey
+  );
+  if (!sigValid) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  // Enforce ±SCANNER_CLOCK_DRIFT_S timestamp window.
+  const nowS = Math.floor(nowMs / 1000);
+  const delta = Math.abs(nowS - parsed.timestampS);
+  if (delta > PAYLOAD_WINDOW_S + SCANNER_CLOCK_DRIFT_S) {
+    return { ok: false, reason: 'expired_timestamp' };
+  }
+
+  return { ok: true, ticketId: parsed.ticketId, timestampS: parsed.timestampS };
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -34,6 +34,7 @@
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",
     "expo-haptics": "~13.0.1",
+    "expo-local-authentication": "~14.0.1",
     "expo-linking": "~6.3.1",
     "expo-notifications": "~0.28.19",
     "expo-router": "~3.5.23",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,7 +15,7 @@
   "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|.*\\.pnpm)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-native-qrcode-svg|.*\\.pnpm)"
     ],
     "setupFilesAfterEnv": [
       "@testing-library/jest-native/extend-expect"
@@ -34,8 +34,8 @@
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",
     "expo-haptics": "~13.0.1",
-    "expo-local-authentication": "~14.0.1",
     "expo-linking": "~6.3.1",
+    "expo-local-authentication": "~14.0.1",
     "expo-notifications": "~0.28.19",
     "expo-router": "~3.5.23",
     "expo-secure-store": "13.0.1",
@@ -51,9 +51,11 @@
     "react-native-hce": "^0.3.0",
     "react-native-maps": "1.14.0",
     "react-native-nfc-manager": "^3.16.1",
+    "react-native-qrcode-svg": "6.3.15",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
+    "react-native-svg": "15.2.0",
     "react-native-web": "~0.19.10",
     "tweetnacl": "^1.0.3",
     "zustand": "^4.5.2"

--- a/apps/mobile/services/__tests__/offlineScanner.test.ts
+++ b/apps/mobile/services/__tests__/offlineScanner.test.ts
@@ -1,0 +1,412 @@
+/**
+ * offlineScanner.test.ts — Issue #1179: Offline Ticket Vault
+ *
+ * Tests for:
+ *   - VALID scan path
+ *   - INVALID_SIGNATURE rejection
+ *   - EXPIRED_TIMESTAMP rejection
+ *   - ALREADY_SCANNED duplicate-scan rejection (distinct from invalid/expired)
+ *   - BAD_PAYLOAD rejection
+ *   - UNKNOWN_TICKET rejection
+ *   - Scan log recording and retrieval
+ *   - Partial sync (addPublicKey)
+ *   - Legacy/stale-key handling
+ */
+
+import {
+  OfflineScanner,
+  InMemoryScanStore,
+  ScanResult,
+  ScanRecord,
+} from '../../services/offlineScanner';
+import {
+  deriveTicketKeyPair,
+  generateRotatingPayload,
+  toBase64Url,
+  fromBase64Url,
+  PAYLOAD_OFFSETS,
+  PAYLOAD_WINDOW_S,
+  SCANNER_CLOCK_DRIFT_S,
+} from '../../lib/crypto';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeSecret(fill: number): Uint8Array {
+  return new Uint8Array(32).fill(fill);
+}
+
+const FIXED_NOW_MS = 1_750_000_000_000;
+
+function buildScanner(
+  tickets: Array<{ ticketId: string; secretFill: number }>,
+  store = new InMemoryScanStore()
+): { scanner: OfflineScanner; keypairs: Map<string, ReturnType<typeof deriveTicketKeyPair>> } {
+  const keyMap = new Map<string, string>();
+  const keypairs = new Map<string, ReturnType<typeof deriveTicketKeyPair>>();
+
+  for (const { ticketId, secretFill } of tickets) {
+    const kp = deriveTicketKeyPair(makeSecret(secretFill));
+    keypairs.set(ticketId, kp);
+    keyMap.set(ticketId, toBase64Url(kp.publicKey));
+  }
+
+  return { scanner: new OfflineScanner(keyMap, store), keypairs };
+}
+
+// ── VALID scan ────────────────────────────────────────────────────────────────
+
+describe('VALID scan', () => {
+  it('returns VALID for a fresh signed payload', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-1', secretFill: 0x11 }]);
+    const { secretKey } = keypairs.get('ticket-1')!;
+    const payload = generateRotatingPayload('ticket-1', secretKey, FIXED_NOW_MS);
+
+    const outcome = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.VALID);
+    expect(outcome.ticketId).toBe('ticket-1');
+    expect(outcome.record).not.toBeNull();
+    expect(outcome.record?.scannedAtS).toBe(Math.floor(FIXED_NOW_MS / 1000));
+  });
+
+  it('records the scan in the log', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-2', secretFill: 0x22 }]);
+    const { secretKey } = keypairs.get('ticket-2')!;
+    const payload = generateRotatingPayload('ticket-2', secretKey, FIXED_NOW_MS);
+
+    await scanner.scan(payload, FIXED_NOW_MS);
+    const log = await scanner.getScanLog();
+    expect(log.length).toBe(1);
+    expect(log[0].ticketId).toBe('ticket-2');
+  });
+
+  it('produces a message mentioning the ticketId', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'my-ticket', secretFill: 0x33 }]);
+    const { secretKey } = keypairs.get('my-ticket')!;
+    const payload = generateRotatingPayload('my-ticket', secretKey, FIXED_NOW_MS);
+    const outcome = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.message).toContain('my-ticket');
+  });
+});
+
+// ── INVALID_SIGNATURE ─────────────────────────────────────────────────────────
+
+describe('INVALID_SIGNATURE', () => {
+  it('rejects a payload with a tampered signature byte', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-3', secretFill: 0x44 }]);
+    const { secretKey } = keypairs.get('ticket-3')!;
+    const payload = generateRotatingPayload('ticket-3', secretKey, FIXED_NOW_MS);
+    const bytes = fromBase64Url(payload);
+    bytes[PAYLOAD_OFFSETS.SIGNATURE] ^= 0xff;
+    const tampered = toBase64Url(bytes);
+
+    const outcome = await scanner.scan(tampered, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.INVALID_SIGNATURE);
+    expect(outcome.record).toBeNull();
+  });
+
+  it('rejects a payload signed by the wrong keypair', async () => {
+    const { scanner } = buildScanner([{ ticketId: 'ticket-4', secretFill: 0x55 }]);
+    const wrongKp = deriveTicketKeyPair(makeSecret(0x99));
+    const payload = generateRotatingPayload('ticket-4', wrongKp.secretKey, FIXED_NOW_MS);
+
+    const outcome = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.INVALID_SIGNATURE);
+  });
+
+  it('does not record the ticket in the scan log on invalid signature', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-5', secretFill: 0x56 }]);
+    const { secretKey } = keypairs.get('ticket-5')!;
+    const payload = generateRotatingPayload('ticket-5', secretKey, FIXED_NOW_MS);
+    const bytes = fromBase64Url(payload);
+    bytes[PAYLOAD_OFFSETS.SIGNATURE] ^= 0x01;
+
+    await scanner.scan(toBase64Url(bytes), FIXED_NOW_MS);
+    const log = await scanner.getScanLog();
+    expect(log.length).toBe(0);
+  });
+
+  it('INVALID_SIGNATURE is distinct from ALREADY_SCANNED', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-6', secretFill: 0x66 }]);
+    const { secretKey } = keypairs.get('ticket-6')!;
+    const validPayload = generateRotatingPayload('ticket-6', secretKey, FIXED_NOW_MS);
+    await scanner.scan(validPayload, FIXED_NOW_MS);
+
+    // Now send a tampered payload for the same ticket
+    const bytes = fromBase64Url(validPayload);
+    bytes[PAYLOAD_OFFSETS.SIGNATURE] ^= 0x01;
+    const outcome = await scanner.scan(toBase64Url(bytes), FIXED_NOW_MS);
+    // Should still be INVALID_SIGNATURE (signature check happens before dup check)
+    expect(outcome.result).toBe(ScanResult.INVALID_SIGNATURE);
+  });
+});
+
+// ── EXPIRED_TIMESTAMP ─────────────────────────────────────────────────────────
+
+describe('EXPIRED_TIMESTAMP', () => {
+  it('rejects a payload outside the clock drift window', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-7', secretFill: 0x77 }]);
+    const { secretKey } = keypairs.get('ticket-7')!;
+
+    // Generate a payload that is (PAYLOAD_WINDOW_S + SCANNER_CLOCK_DRIFT_S + 2) seconds
+    // in the past relative to the scanner's clock.
+    const pastNow =
+      FIXED_NOW_MS - (PAYLOAD_WINDOW_S + SCANNER_CLOCK_DRIFT_S + 2) * 1000 -
+      PAYLOAD_WINDOW_S * 1000;
+    const payload = generateRotatingPayload('ticket-7', secretKey, pastNow);
+
+    const outcome = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.EXPIRED_TIMESTAMP);
+    expect(outcome.record).toBeNull();
+  });
+
+  it('accepts a payload within the drift window', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-8', secretFill: 0x88 }]);
+    const { secretKey } = keypairs.get('ticket-8')!;
+
+    // Payload generated (SCANNER_CLOCK_DRIFT_S - 5) seconds ago — still within window
+    const slightlyOldNow = FIXED_NOW_MS - (SCANNER_CLOCK_DRIFT_S - 5) * 1000;
+    const payload = generateRotatingPayload('ticket-8', secretKey, slightlyOldNow);
+
+    const outcome = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.VALID);
+  });
+
+  it('EXPIRED_TIMESTAMP is distinct from ALREADY_SCANNED', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'ticket-9', secretFill: 0x99 }]);
+    const { secretKey } = keypairs.get('ticket-9')!;
+
+    const oldNow = FIXED_NOW_MS - (PAYLOAD_WINDOW_S + SCANNER_CLOCK_DRIFT_S + 100) * 1000;
+    const payload = generateRotatingPayload('ticket-9', secretKey, oldNow);
+    const first = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(first.result).toBe(ScanResult.EXPIRED_TIMESTAMP);
+
+    // A second scan of the same expired payload must still be EXPIRED_TIMESTAMP,
+    // not ALREADY_SCANNED, because it was never recorded.
+    const second = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(second.result).toBe(ScanResult.EXPIRED_TIMESTAMP);
+  });
+});
+
+// ── ALREADY_SCANNED (double-scan prevention) ──────────────────────────────────
+
+describe('ALREADY_SCANNED', () => {
+  it('rejects a second scan of the same ticketId', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'dup-ticket', secretFill: 0xAA }]);
+    const { secretKey } = keypairs.get('dup-ticket')!;
+    const payload1 = generateRotatingPayload('dup-ticket', secretKey, FIXED_NOW_MS);
+    const payload2 = generateRotatingPayload('dup-ticket', secretKey, FIXED_NOW_MS + 16_000);
+
+    const first = await scanner.scan(payload1, FIXED_NOW_MS);
+    expect(first.result).toBe(ScanResult.VALID);
+
+    const second = await scanner.scan(payload2, FIXED_NOW_MS + 16_000);
+    expect(second.result).toBe(ScanResult.ALREADY_SCANNED);
+  });
+
+  it('includes the original scan time in the duplicate result', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'dup-time', secretFill: 0xAB }]);
+    const { secretKey } = keypairs.get('dup-time')!;
+    const payload = generateRotatingPayload('dup-time', secretKey, FIXED_NOW_MS);
+    await scanner.scan(payload, FIXED_NOW_MS);
+
+    const later = FIXED_NOW_MS + 30_000;
+    const laterPayload = generateRotatingPayload('dup-time', secretKey, later);
+    const outcome = await scanner.scan(laterPayload, later);
+    expect(outcome.result).toBe(ScanResult.ALREADY_SCANNED);
+    expect(outcome.record?.scannedAtS).toBe(Math.floor(FIXED_NOW_MS / 1000));
+  });
+
+  it('ALREADY_SCANNED message is distinct from INVALID_SIGNATURE message', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'msg-test', secretFill: 0xCC }]);
+    const { secretKey } = keypairs.get('msg-test')!;
+    const payload1 = generateRotatingPayload('msg-test', secretKey, FIXED_NOW_MS);
+    const payload2 = generateRotatingPayload('msg-test', secretKey, FIXED_NOW_MS + 20_000);
+
+    await scanner.scan(payload1, FIXED_NOW_MS);
+    const dup = await scanner.scan(payload2, FIXED_NOW_MS + 20_000);
+    const invalidPayload = (() => {
+      const b = fromBase64Url(payload2);
+      b[PAYLOAD_OFFSETS.SIGNATURE] ^= 1;
+      return toBase64Url(b);
+    })();
+
+    const invalid = await scanner.scan(invalidPayload, FIXED_NOW_MS);
+    expect(dup.message).not.toBe(invalid.message);
+    expect(dup.result).toBe(ScanResult.ALREADY_SCANNED);
+    expect(invalid.result).toBe(ScanResult.INVALID_SIGNATURE);
+  });
+
+  it('does not add a second record on duplicate scan', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'no-double', secretFill: 0xDD }]);
+    const { secretKey } = keypairs.get('no-double')!;
+    const p1 = generateRotatingPayload('no-double', secretKey, FIXED_NOW_MS);
+    const p2 = generateRotatingPayload('no-double', secretKey, FIXED_NOW_MS + 20_000);
+
+    await scanner.scan(p1, FIXED_NOW_MS);
+    await scanner.scan(p2, FIXED_NOW_MS + 20_000);
+    const log = await scanner.getScanLog();
+    expect(log.filter(r => r.ticketId === 'no-double')).toHaveLength(1);
+  });
+
+  it('two different ticketIds can both be VALID', async () => {
+    const { scanner, keypairs } = buildScanner([
+      { ticketId: 'ticket-A', secretFill: 0x01 },
+      { ticketId: 'ticket-B', secretFill: 0x02 },
+    ]);
+    const p1 = generateRotatingPayload('ticket-A', keypairs.get('ticket-A')!.secretKey, FIXED_NOW_MS);
+    const p2 = generateRotatingPayload('ticket-B', keypairs.get('ticket-B')!.secretKey, FIXED_NOW_MS);
+
+    const r1 = await scanner.scan(p1, FIXED_NOW_MS);
+    const r2 = await scanner.scan(p2, FIXED_NOW_MS);
+    expect(r1.result).toBe(ScanResult.VALID);
+    expect(r2.result).toBe(ScanResult.VALID);
+  });
+});
+
+// ── BAD_PAYLOAD ───────────────────────────────────────────────────────────────
+
+describe('BAD_PAYLOAD', () => {
+  it('rejects an empty string', async () => {
+    const { scanner } = buildScanner([]);
+    const outcome = await scanner.scan('', FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.BAD_PAYLOAD);
+    expect(outcome.ticketId).toBeNull();
+  });
+
+  it('rejects a non-base64url string', async () => {
+    const { scanner } = buildScanner([]);
+    const outcome = await scanner.scan('not-a-ticket!!!', FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.BAD_PAYLOAD);
+  });
+
+  it('rejects a valid base64url string of wrong length', async () => {
+    const { scanner } = buildScanner([]);
+    const outcome = await scanner.scan(toBase64Url(new Uint8Array(50)), FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.BAD_PAYLOAD);
+  });
+});
+
+// ── UNKNOWN_TICKET ────────────────────────────────────────────────────────────
+
+describe('UNKNOWN_TICKET', () => {
+  it('rejects a valid payload for a ticket not in the key map', async () => {
+    // Scanner has no registered keys
+    const { scanner: emptyScanner } = buildScanner([]);
+    const kp = deriveTicketKeyPair(makeSecret(0x50));
+    const payload = generateRotatingPayload('unregistered', kp.secretKey, FIXED_NOW_MS);
+
+    const outcome = await emptyScanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.UNKNOWN_TICKET);
+    expect(outcome.ticketId).toBe('unregistered');
+  });
+});
+
+// ── Scan log ──────────────────────────────────────────────────────────────────
+
+describe('scan log', () => {
+  it('returns an empty log initially', async () => {
+    const { scanner } = buildScanner([]);
+    expect(await scanner.getScanLog()).toEqual([]);
+  });
+
+  it('records multiple valid scans', async () => {
+    const { scanner, keypairs } = buildScanner([
+      { ticketId: 'log-1', secretFill: 0x10 },
+      { ticketId: 'log-2', secretFill: 0x20 },
+    ]);
+    const p1 = generateRotatingPayload('log-1', keypairs.get('log-1')!.secretKey, FIXED_NOW_MS);
+    const p2 = generateRotatingPayload('log-2', keypairs.get('log-2')!.secretKey, FIXED_NOW_MS + 5000);
+
+    await scanner.scan(p1, FIXED_NOW_MS);
+    await scanner.scan(p2, FIXED_NOW_MS + 5000);
+
+    const log = await scanner.getScanLog();
+    expect(log.length).toBe(2);
+    expect(log.map(r => r.ticketId).sort()).toEqual(['log-1', 'log-2']);
+  });
+
+  it('clearScanLog empties the log', async () => {
+    const { scanner, keypairs } = buildScanner([{ ticketId: 'clear-me', secretFill: 0x30 }]);
+    const p = generateRotatingPayload('clear-me', keypairs.get('clear-me')!.secretKey, FIXED_NOW_MS);
+    await scanner.scan(p, FIXED_NOW_MS);
+    await scanner.clearScanLog();
+    expect(await scanner.getScanLog()).toEqual([]);
+  });
+});
+
+// ── addPublicKey (partial sync) ───────────────────────────────────────────────
+
+describe('addPublicKey', () => {
+  it('allows scanning a ticket added after construction', async () => {
+    const { scanner } = buildScanner([]);
+    const kp = deriveTicketKeyPair(makeSecret(0x60));
+    scanner.addPublicKey('late-ticket', toBase64Url(kp.publicKey));
+
+    const payload = generateRotatingPayload('late-ticket', kp.secretKey, FIXED_NOW_MS);
+    const outcome = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.VALID);
+  });
+});
+
+// ── Legacy / stale key handling ───────────────────────────────────────────────
+
+describe('legacy/stale-key handling', () => {
+  // NOTE: ticketId in the payload is truncated to 16 bytes. Keys must match.
+  const TICKET_ID = 'xfer-ticket-01'; // 14 bytes — safely under the 16-byte limit
+
+  it('old keypair payload returns INVALID_SIGNATURE when scanner has new key for the same ticketId', async () => {
+    const oldKp = deriveTicketKeyPair(makeSecret(0x70));
+    const newKp = deriveTicketKeyPair(makeSecret(0x71));
+
+    // Scanner loaded with the NEW public key for TICKET_ID.
+    const keyMap = new Map([[TICKET_ID, toBase64Url(newKp.publicKey)]]);
+    const scanner = new OfflineScanner(keyMap);
+
+    // Attendee presents a payload signed with the OLD key.
+    // ticketId IS in the key map (so UNKNOWN_TICKET is not returned),
+    // but the signature does not verify against the new public key.
+    const oldPayload = generateRotatingPayload(TICKET_ID, oldKp.secretKey, FIXED_NOW_MS);
+    const outcome = await scanner.scan(oldPayload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.INVALID_SIGNATURE);
+  });
+
+  it('new keypair payload verifies after scanner is loaded with new key', async () => {
+    const newKp = deriveTicketKeyPair(makeSecret(0x71));
+    const keyMap = new Map([[TICKET_ID, toBase64Url(newKp.publicKey)]]);
+    const scanner = new OfflineScanner(keyMap);
+
+    const newPayload = generateRotatingPayload(TICKET_ID, newKp.secretKey, FIXED_NOW_MS);
+    const outcome = await scanner.scan(newPayload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.VALID);
+  });
+
+  it('UNKNOWN_TICKET is distinct from INVALID_SIGNATURE: unregistered ticket returns UNKNOWN_TICKET', async () => {
+    const kp = deriveTicketKeyPair(makeSecret(0x72));
+    const scanner = new OfflineScanner(new Map()); // no registered keys
+    const payload = generateRotatingPayload('unreg-2', kp.secretKey, FIXED_NOW_MS);
+    const outcome = await scanner.scan(payload, FIXED_NOW_MS);
+    expect(outcome.result).toBe(ScanResult.UNKNOWN_TICKET);
+  });
+});
+
+// ── InMemoryScanStore ─────────────────────────────────────────────────────────
+
+describe('InMemoryScanStore', () => {
+  it('has/get/set/getAll/clear work correctly', async () => {
+    const store = new InMemoryScanStore();
+    expect(await store.has('x')).toBe(false);
+    expect(await store.get('x')).toBeNull();
+
+    const record: ScanRecord = { ticketId: 'x', scannedAtS: 100, payloadTimestampS: 90 };
+    await store.set('x', record);
+    expect(await store.has('x')).toBe(true);
+    expect(await store.get('x')).toEqual(record);
+
+    const all = await store.getAll();
+    expect(all).toHaveLength(1);
+
+    await store.clear();
+    expect(await store.has('x')).toBe(false);
+    expect(store.size).toBe(0);
+  });
+});

--- a/apps/mobile/services/__tests__/ticketVault.test.ts
+++ b/apps/mobile/services/__tests__/ticketVault.test.ts
@@ -13,7 +13,7 @@ import {
   clearTicketSecret,
   isVaultAvailable,
 } from '../../services/ticketVault';
-import { deriveTicketKeyPair, toBase64Url, fromBase64Url } from '../../lib/crypto';
+import { deriveTicketKeyPair } from '../../lib/crypto';
 
 // ── Mock expo-secure-store ────────────────────────────────────────────────────
 

--- a/apps/mobile/services/__tests__/ticketVault.test.ts
+++ b/apps/mobile/services/__tests__/ticketVault.test.ts
@@ -1,0 +1,188 @@
+/**
+ * ticketVault.test.ts — Issue #1179: Offline Ticket Vault
+ *
+ * Tests for ticketVault.ts vault operations.
+ * expo-secure-store is mocked: this module tests the vault logic only, not the
+ * platform-specific Keychain / Keystore integration.
+ */
+
+import {
+  storeTicketSecret,
+  getTicketSecret,
+  getTicketPublicKey,
+  clearTicketSecret,
+  isVaultAvailable,
+} from '../../services/ticketVault';
+import { deriveTicketKeyPair, toBase64Url, fromBase64Url } from '../../lib/crypto';
+
+// ── Mock expo-secure-store ────────────────────────────────────────────────────
+
+const mockStore = new Map<string, string>();
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(async (key: string, value: string) => {
+    mockStore.set(key, value);
+  }),
+  getItemAsync: jest.fn(async (key: string) => {
+    return mockStore.get(key) ?? null;
+  }),
+  deleteItemAsync: jest.fn(async (key: string) => {
+    mockStore.delete(key);
+  }),
+  isAvailableAsync: jest.fn(async () => true),
+}));
+
+beforeEach(() => {
+  mockStore.clear();
+  jest.clearAllMocks();
+});
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeSecret(fill: number): Uint8Array {
+  return new Uint8Array(32).fill(fill);
+}
+
+const PAYMENT_ID = 'pay-event-123-GABCDE-abc123-def456';
+
+// ── isVaultAvailable ──────────────────────────────────────────────────────────
+
+describe('isVaultAvailable', () => {
+  it('returns true when SecureStore is available', async () => {
+    expect(await isVaultAvailable()).toBe(true);
+  });
+});
+
+// ── storeTicketSecret ─────────────────────────────────────────────────────────
+
+describe('storeTicketSecret', () => {
+  it('writes to SecureStore without throwing', async () => {
+    await expect(storeTicketSecret(PAYMENT_ID, makeSecret(0x11))).resolves.toBeUndefined();
+  });
+
+  it('stores the secret and public key separately', async () => {
+    const secret = makeSecret(0x22);
+    await storeTicketSecret(PAYMENT_ID, secret);
+
+    // Should have two entries in the mock store
+    const secretKey = `agora.vault.secret.${PAYMENT_ID}`;
+    const pubkeyKey = `agora.vault.pubkey.${PAYMENT_ID}`;
+    expect(mockStore.has(secretKey)).toBe(true);
+    expect(mockStore.has(pubkeyKey)).toBe(true);
+  });
+
+  it('throws for a secret shorter than 32 bytes', async () => {
+    await expect(
+      storeTicketSecret(PAYMENT_ID, new Uint8Array(16))
+    ).rejects.toThrow(/32 bytes/);
+  });
+
+  it('throws for a secret longer than 32 bytes', async () => {
+    await expect(
+      storeTicketSecret(PAYMENT_ID, new Uint8Array(64))
+    ).rejects.toThrow(/32 bytes/);
+  });
+
+  it('never writes plaintext — stored value differs from raw secret', async () => {
+    const secret = makeSecret(0x33);
+    await storeTicketSecret(PAYMENT_ID, secret);
+    const rawSecret = Array.from(secret).join(',');
+    // Verify none of the stored values are the raw byte string
+    for (const [, value] of mockStore) {
+      expect(value).not.toBe(rawSecret);
+    }
+  });
+});
+
+// ── getTicketSecret ───────────────────────────────────────────────────────────
+
+describe('getTicketSecret', () => {
+  it('returns the original secret after storeTicketSecret', async () => {
+    const secret = makeSecret(0x44);
+    await storeTicketSecret(PAYMENT_ID, secret);
+    const retrieved = await getTicketSecret(PAYMENT_ID);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved).toEqual(secret);
+  });
+
+  it('returns null when no secret is stored', async () => {
+    const result = await getTicketSecret('nonexistent-payment-id');
+    expect(result).toBeNull();
+  });
+
+  it('retrieved secret reproduces the same keypair as original', async () => {
+    const secret = makeSecret(0x55);
+    await storeTicketSecret(PAYMENT_ID, secret);
+    const retrieved = await getTicketSecret(PAYMENT_ID);
+    expect(retrieved).not.toBeNull();
+
+    const originalKp = deriveTicketKeyPair(secret);
+    const retrievedKp = deriveTicketKeyPair(retrieved!);
+    expect(originalKp.publicKey).toEqual(retrievedKp.publicKey);
+  });
+});
+
+// ── getTicketPublicKey ────────────────────────────────────────────────────────
+
+describe('getTicketPublicKey', () => {
+  it('returns the correct 32-byte public key after storeTicketSecret', async () => {
+    const secret = makeSecret(0x66);
+    await storeTicketSecret(PAYMENT_ID, secret);
+
+    const storedPubKey = await getTicketPublicKey(PAYMENT_ID);
+    expect(storedPubKey).not.toBeNull();
+    expect(storedPubKey!.length).toBe(32);
+
+    const expectedPubKey = deriveTicketKeyPair(secret).publicKey;
+    expect(storedPubKey).toEqual(expectedPubKey);
+  });
+
+  it('returns null when no public key is stored', async () => {
+    const result = await getTicketPublicKey('nonexistent');
+    expect(result).toBeNull();
+  });
+});
+
+// ── clearTicketSecret ─────────────────────────────────────────────────────────
+
+describe('clearTicketSecret', () => {
+  it('removes both secret and public key from the store', async () => {
+    const secret = makeSecret(0x77);
+    await storeTicketSecret(PAYMENT_ID, secret);
+
+    await clearTicketSecret(PAYMENT_ID);
+
+    expect(await getTicketSecret(PAYMENT_ID)).toBeNull();
+    expect(await getTicketPublicKey(PAYMENT_ID)).toBeNull();
+  });
+
+  it('does not throw when called on a non-existent payment ID', async () => {
+    await expect(clearTicketSecret('does-not-exist')).resolves.toBeUndefined();
+  });
+});
+
+// ── Key separation ────────────────────────────────────────────────────────────
+
+describe('key separation', () => {
+  it('different paymentIds store different secrets', async () => {
+    const secret1 = makeSecret(0x11);
+    const secret2 = makeSecret(0x22);
+    await storeTicketSecret('payment-A', secret1);
+    await storeTicketSecret('payment-B', secret2);
+
+    const r1 = await getTicketSecret('payment-A');
+    const r2 = await getTicketSecret('payment-B');
+    expect(r1).toEqual(secret1);
+    expect(r2).toEqual(secret2);
+    expect(r1).not.toEqual(r2);
+  });
+
+  it('clearing one paymentId does not affect another', async () => {
+    await storeTicketSecret('payment-X', makeSecret(0x0A));
+    await storeTicketSecret('payment-Y', makeSecret(0x0B));
+    await clearTicketSecret('payment-X');
+
+    expect(await getTicketSecret('payment-X')).toBeNull();
+    expect(await getTicketSecret('payment-Y')).not.toBeNull();
+  });
+});

--- a/apps/mobile/services/offlineScanner.ts
+++ b/apps/mobile/services/offlineScanner.ts
@@ -1,0 +1,312 @@
+/**
+ * offlineScanner.ts — Issue #1179: Offline Ticket Vault
+ *
+ * Offline ticket scanner verification module. Runs entirely on the gate
+ * device with no network calls required.
+ *
+ * ## Responsibilities
+ *
+ *   1. Parse a rotating QR binary payload from `lib/crypto.ts`.
+ *   2. Verify the Ed25519 signature against the event's pre-synced public key.
+ *   3. Enforce a ±60s timestamp window (SCANNER_CLOCK_DRIFT_S) to tolerate
+ *      clock drift between the attendee's phone and the scanner device.
+ *   4. Check the ticket ID against a local scan log for double-scan prevention.
+ *   5. Record valid scans to the local scan log (in-memory + optional persist).
+ *
+ * ## Double-scan prevention
+ *
+ * Scanned ticket IDs are stored in a Map<ticketId, ScanRecord> in memory and
+ * optionally persisted to a compact on-device store (see ScanStore interface).
+ * A second scan of the same ticketId returns ScanResult.ALREADY_SCANNED with
+ * the original scan timestamp, which is a distinct result from
+ * INVALID_SIGNATURE or EXPIRED_TIMESTAMP — the gate staff UI must show the
+ * right message for each.
+ *
+ * ## Event public key management
+ *
+ * The scanner holds one Ed25519 public key per ticket. In the simplest
+ * deployment model, the organizer exports a map of { paymentId → publicKeyB64 }
+ * at event setup and loads it into the scanner app. The scanner only looks up
+ * the public key by the ticketId field embedded in the payload.
+ *
+ * ## Staleness / revocation
+ *
+ * See docs/offline-vault-revocation.md. If a ticket is cancelled server-side
+ * after the scanner's last sync, it will still scan as VALID here until the
+ * scanner pulls a fresh key/revocation list. Scanners should display their
+ * last-sync time prominently so staff can make informed decisions.
+ *
+ * ## Schema (in-memory scan log)
+ *
+ *   ScanRecord {
+ *     ticketId:   string   — ticket identifier from the payload
+ *     scannedAtS: number   — Unix seconds when first scanned
+ *     payloadTs:  number   — payload's own timestamp (window boundary)
+ *   }
+ */
+
+import nacl from 'tweetnacl';
+import {
+  verifyPayload,
+  parsePayload,
+  fromBase64Url,
+  SCANNER_CLOCK_DRIFT_S,
+  PAYLOAD_WINDOW_S,
+  VerifyResult,
+} from '../lib/crypto';
+
+// ── Scan result enum ──────────────────────────────────────────────────────────
+
+export enum ScanResult {
+  /** Signature valid, timestamp in window, not a duplicate. */
+  VALID = 'VALID',
+  /** Ed25519 signature did not verify against the event public key. */
+  INVALID_SIGNATURE = 'INVALID_SIGNATURE',
+  /** Payload timestamp is outside the ±SCANNER_CLOCK_DRIFT_S window. */
+  EXPIRED_TIMESTAMP = 'EXPIRED_TIMESTAMP',
+  /** This ticket ID has already been scanned at this event. */
+  ALREADY_SCANNED = 'ALREADY_SCANNED',
+  /** Payload could not be parsed (wrong format, wrong length, unsupported version). */
+  BAD_PAYLOAD = 'BAD_PAYLOAD',
+  /** No public key registered for this ticketId in the event key map. */
+  UNKNOWN_TICKET = 'UNKNOWN_TICKET',
+}
+
+// ── Data types ────────────────────────────────────────────────────────────────
+
+export interface ScanRecord {
+  ticketId: string;
+  /** Unix seconds when this ticket was first scanned. */
+  scannedAtS: number;
+  /** The payload's own window-boundary timestamp. */
+  payloadTimestampS: number;
+}
+
+export interface ScanOutcome {
+  result: ScanResult;
+  /** Populated for all results where the ticketId could be parsed. */
+  ticketId: string | null;
+  /** Populated for VALID and ALREADY_SCANNED. */
+  record: ScanRecord | null;
+  /** Human-readable message for gate staff UI. */
+  message: string;
+}
+
+/**
+ * Interface for persisting the scan log between app restarts.
+ * A concrete implementation using AsyncStorage or SQLite can be injected
+ * by the scanner app. If omitted, the scanner uses in-memory storage only.
+ */
+export interface ScanStore {
+  has(ticketId: string): Promise<boolean>;
+  get(ticketId: string): Promise<ScanRecord | null>;
+  set(ticketId: string, record: ScanRecord): Promise<void>;
+  /** Returns all scanned records, ordered by scannedAtS ascending. */
+  getAll(): Promise<ScanRecord[]>;
+  /** Removes all records (for post-event cleanup). */
+  clear(): Promise<void>;
+}
+
+// ── In-memory scan store ──────────────────────────────────────────────────────
+
+/**
+ * Default in-memory scan store. Records are lost when the app restarts.
+ * Suitable for short-duration events or when the scanner app is restarted
+ * between events. For multi-session events, inject a persistent ScanStore.
+ */
+export class InMemoryScanStore implements ScanStore {
+  private readonly records = new Map<string, ScanRecord>();
+
+  async has(ticketId: string): Promise<boolean> {
+    return this.records.has(ticketId);
+  }
+
+  async get(ticketId: string): Promise<ScanRecord | null> {
+    return this.records.get(ticketId) ?? null;
+  }
+
+  async set(ticketId: string, record: ScanRecord): Promise<void> {
+    this.records.set(ticketId, record);
+  }
+
+  async getAll(): Promise<ScanRecord[]> {
+    return Array.from(this.records.values()).sort(
+      (a, b) => a.scannedAtS - b.scannedAtS
+    );
+  }
+
+  async clear(): Promise<void> {
+    this.records.clear();
+  }
+
+  /** Exposed for testing only. */
+  get size(): number {
+    return this.records.size;
+  }
+}
+
+// ── Scanner class ─────────────────────────────────────────────────────────────
+
+/**
+ * OfflineScanner manages an event's public key map and scan log.
+ *
+ * Usage:
+ *   const scanner = new OfflineScanner(publicKeyMap);
+ *   const outcome = await scanner.scan(qrPayloadString);
+ *   switch (outcome.result) { ... }
+ */
+export class OfflineScanner {
+  /**
+   * Map from ticketId (string) to 32-byte Ed25519 public key.
+   * Pre-synced from the organizer's key export before the event.
+   */
+  private readonly publicKeys: Map<string, Uint8Array>;
+  private readonly store: ScanStore;
+
+  /**
+   * @param publicKeyMap  Map<ticketId, publicKeyBase64> — the event's key export.
+   *   Keys are base64url-encoded 32-byte Ed25519 public keys.
+   * @param store         Optional persistent scan store. Defaults to in-memory.
+   */
+  constructor(
+    publicKeyMap: Map<string, string>,
+    store: ScanStore = new InMemoryScanStore()
+  ) {
+    this.store = store;
+    this.publicKeys = new Map();
+    for (const [ticketId, pubKeyB64] of publicKeyMap) {
+      this.publicKeys.set(ticketId, fromBase64Url(pubKeyB64));
+    }
+  }
+
+  /**
+   * Scans a QR payload string and returns a ScanOutcome.
+   *
+   * @param encoded   Base64url payload from the QR code.
+   * @param nowMs     Current scanner time (defaults to Date.now()).
+   */
+  async scan(encoded: string, nowMs: number = Date.now()): Promise<ScanOutcome> {
+    // Step 1: parse the payload
+    let parsed: ReturnType<typeof parsePayload>;
+    try {
+      parsed = parsePayload(encoded);
+    } catch {
+      return {
+        result: ScanResult.BAD_PAYLOAD,
+        ticketId: null,
+        record: null,
+        message: 'This QR code is not a valid Agora ticket payload.',
+      };
+    }
+
+    const { ticketId, timestampS } = parsed;
+
+    // Step 2: look up the public key for this ticket
+    const publicKey = this.publicKeys.get(ticketId);
+    if (!publicKey) {
+      return {
+        result: ScanResult.UNKNOWN_TICKET,
+        ticketId,
+        record: null,
+        message: `Ticket ${ticketId} is not registered for this event. Sync the scanner before the event.`,
+      };
+    }
+
+    // Step 3: verify the Ed25519 signature
+    const verifyResult: VerifyResult = verifyPayload(encoded, publicKey, nowMs);
+    if (!verifyResult.ok) {
+      if (verifyResult.reason === 'invalid_signature') {
+        return {
+          result: ScanResult.INVALID_SIGNATURE,
+          ticketId,
+          record: null,
+          message: `INVALID TICKET: The signature on ticket ${ticketId} could not be verified. Do not admit.`,
+        };
+      }
+      if (verifyResult.reason === 'expired_timestamp') {
+        return {
+          result: ScanResult.EXPIRED_TIMESTAMP,
+          ticketId,
+          record: null,
+          message: `EXPIRED QR CODE: The QR code for ticket ${ticketId} has expired. Ask the attendee to refresh their ticket screen.`,
+        };
+      }
+      // bad_payload already handled above
+      return {
+        result: ScanResult.BAD_PAYLOAD,
+        ticketId,
+        record: null,
+        message: 'This QR code could not be verified.',
+      };
+    }
+
+    // Step 4: double-scan check
+    const existing = await this.store.get(ticketId);
+    if (existing) {
+      return {
+        result: ScanResult.ALREADY_SCANNED,
+        ticketId,
+        record: existing,
+        message: `DUPLICATE SCAN: Ticket ${ticketId} was already admitted at ${formatTime(existing.scannedAtS)}. Do not admit again.`,
+      };
+    }
+
+    // Step 5: record the valid scan
+    const nowS = Math.floor(nowMs / 1000);
+    const record: ScanRecord = {
+      ticketId,
+      scannedAtS: nowS,
+      payloadTimestampS: timestampS,
+    };
+    await this.store.set(ticketId, record);
+
+    return {
+      result: ScanResult.VALID,
+      ticketId,
+      record,
+      message: `✓ ADMIT: Ticket ${ticketId} is valid.`,
+    };
+  }
+
+  /**
+   * Returns all scan records from the log.
+   */
+  async getScanLog(): Promise<ScanRecord[]> {
+    return this.store.getAll();
+  }
+
+  /**
+   * Clears the scan log (e.g. between events).
+   */
+  async clearScanLog(): Promise<void> {
+    return this.store.clear();
+  }
+
+  /**
+   * Returns the number of tickets registered in the event key map.
+   */
+  get registeredTicketCount(): number {
+    return this.publicKeys.size;
+  }
+
+  /**
+   * Adds or updates a public key in the key map (e.g. when doing a partial
+   * sync during the event). Does NOT affect the scan log.
+   *
+   * @param ticketId     Ticket identifier.
+   * @param pubKeyB64    Base64url-encoded 32-byte Ed25519 public key.
+   */
+  addPublicKey(ticketId: string, pubKeyB64: string): void {
+    this.publicKeys.set(ticketId, fromBase64Url(pubKeyB64));
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatTime(unixS: number): string {
+  return new Date(unixS * 1000).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}

--- a/apps/mobile/services/offlineScanner.ts
+++ b/apps/mobile/services/offlineScanner.ts
@@ -45,13 +45,10 @@
  *   }
  */
 
-import nacl from 'tweetnacl';
 import {
   verifyPayload,
   parsePayload,
   fromBase64Url,
-  SCANNER_CLOCK_DRIFT_S,
-  PAYLOAD_WINDOW_S,
   VerifyResult,
 } from '../lib/crypto';
 

--- a/apps/mobile/services/ticketVault.ts
+++ b/apps/mobile/services/ticketVault.ts
@@ -1,0 +1,213 @@
+/**
+ * ticketVault.ts — Issue #1179: Offline Ticket Vault
+ *
+ * Encrypted offline storage of per-ticket signing secrets and their derived
+ * public keys, gated behind biometric authentication.
+ *
+ * ## Storage model
+ *
+ * Ticket secrets are stored in expo-secure-store (iOS Keychain /
+ * Android Keystore), which provides hardware-backed encryption on supported
+ * devices. SecureStore is the correct storage layer here because:
+ *
+ *   - iOS: values are stored in the Keychain, which can be configured with
+ *     kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly to require device
+ *     passcode/biometric before reading. expo-secure-store supports this via
+ *     the `requireAuthentication` option (iOS only, requires biometric
+ *     enrollment to set the item).
+ *   - Android: values are encrypted with AES-256-GCM using a key from the
+ *     Android Keystore hardware-backed key store.
+ *
+ * On iOS, we set requireAuthentication: true to delegate biometric prompting
+ * to the OS. On Android, biometric authentication is handled explicitly in the
+ * UI layer via expo-local-authentication before calling getTicketSecret().
+ *
+ * ## What is stored
+ *
+ * Key: `agora.vault.secret.<paymentId>`  (per-ticket, biometric-gated)
+ * Value: base64url-encoded raw 32-byte purchase secret
+ *
+ * Key: `agora.vault.pubkey.<paymentId>`  (per-ticket public key, no biometric needed)
+ * Value: base64url-encoded 32-byte Ed25519 public key (safe to read freely)
+ *
+ * The private key is never written to disk; it is re-derived from the secret
+ * on demand using deriveTicketKeyPair() and used only in memory.
+ *
+ * ## Plaintext-key guarantee
+ *
+ * This module never writes plaintext ticket secrets to:
+ *   - AsyncStorage (unencrypted)
+ *   - SQLite (unencrypted)
+ *   - The filesystem via RNFS or similar
+ *   - React state that persists across app backgrounding
+ *
+ * The only write path is SecureStore.setItemAsync(), which encrypts on write.
+ *
+ * ## Revocation / staleness note
+ *
+ * See docs/offline-vault-revocation.md for the full tradeoff analysis.
+ * Short version: a refunded or cancelled ticket synced to the server *after*
+ * the device's last sync will still scan as valid offline until the scanner
+ * pulls a fresh public-key / revocation list. Gate staff should be informed
+ * of the last-sync time so they can decide whether to accept borderline cases.
+ */
+
+import * as SecureStore from 'expo-secure-store';
+import { deriveTicketKeyPair, toBase64Url, fromBase64Url } from '../lib/crypto';
+
+// ── Key name helpers ──────────────────────────────────────────────────────────
+
+const SECRET_KEY_PREFIX = 'agora.vault.secret.';
+const PUBKEY_KEY_PREFIX = 'agora.vault.pubkey.';
+
+function secretStoreKey(paymentId: string): string {
+  return `${SECRET_KEY_PREFIX}${paymentId}`;
+}
+function pubkeyStoreKey(paymentId: string): string {
+  return `${PUBKEY_KEY_PREFIX}${paymentId}`;
+}
+
+// ── Platform options ──────────────────────────────────────────────────────────
+
+/**
+ * SecureStore options for biometric-gated items (iOS only: requireAuthentication).
+ * On Android, authentication must be performed externally via
+ * expo-local-authentication before calling getTicketSecret().
+ */
+const BIOMETRIC_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainService: 'agora_ticket_vault',
+  // On iOS: this causes the Keychain item to require biometric/passcode before
+  // being read. The OS presents its own native prompt; we don't draw our own UI
+  // for this path.
+  requireAuthentication: true,
+};
+
+/** Options for the public-key store — no biometric required, freely readable. */
+const PUBLIC_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainService: 'agora_ticket_vault_pub',
+};
+
+// ── Vault write ───────────────────────────────────────────────────────────────
+
+/**
+ * Stores a ticket secret in the hardware-backed vault.
+ *
+ * Also pre-computes and stores the derived Ed25519 public key so it can be
+ * retrieved freely (e.g. to send to the event organizer for scanner sync)
+ * without requiring biometric authentication.
+ *
+ * This is called once, right after `purchaseTickets()` resolves successfully.
+ * The plaintext `secretBytes` must never be stored elsewhere; after this call
+ * the caller should zero the local reference if possible.
+ *
+ * @param paymentId   Unique payment identifier returned by the contract.
+ * @param secretBytes Raw 32-byte purchase secret from `generatePurchaseSecret()`.
+ */
+export async function storeTicketSecret(
+  paymentId: string,
+  secretBytes: Uint8Array
+): Promise<void> {
+  if (secretBytes.length !== 32) {
+    throw new Error(`storeTicketSecret: secret must be 32 bytes, got ${secretBytes.length}.`);
+  }
+
+  // Derive the public key before writing so both writes succeed atomically (or
+  // the first write hasn't happened yet if derivation throws).
+  const { publicKey } = deriveTicketKeyPair(secretBytes);
+
+  await SecureStore.setItemAsync(
+    secretStoreKey(paymentId),
+    toBase64Url(secretBytes),
+    BIOMETRIC_STORE_OPTIONS
+  );
+
+  // Public key is stored separately without biometric so it can be read at
+  // any time (e.g. during scanner-sync export).
+  await SecureStore.setItemAsync(
+    pubkeyStoreKey(paymentId),
+    toBase64Url(publicKey),
+    PUBLIC_STORE_OPTIONS
+  );
+}
+
+// ── Vault read ────────────────────────────────────────────────────────────────
+
+/**
+ * Retrieves the raw 32-byte purchase secret for a ticket.
+ *
+ * On iOS, the OS presents a biometric / passcode prompt before returning the
+ * value (because the item was stored with requireAuthentication: true).
+ *
+ * On Android, the caller MUST have already called
+ * `authenticateWithBiometrics()` and received a successful result before
+ * calling this function; expo-secure-store on Android does not perform its
+ * own biometric prompt.
+ *
+ * Returns `null` if no secret is stored for this paymentId (e.g. the ticket
+ * was purchased on a different device, or the vault was cleared after a
+ * sign-out).
+ *
+ * @throws if the biometric prompt is dismissed or fails (iOS), or if
+ *   SecureStore is unavailable.
+ */
+export async function getTicketSecret(paymentId: string): Promise<Uint8Array | null> {
+  const stored = await SecureStore.getItemAsync(
+    secretStoreKey(paymentId),
+    BIOMETRIC_STORE_OPTIONS
+  );
+  if (!stored) return null;
+  const bytes = fromBase64Url(stored);
+  if (bytes.length !== 32) {
+    throw new Error(
+      `getTicketSecret: stored value for ${paymentId} has wrong length: ${bytes.length}.`
+    );
+  }
+  return bytes;
+}
+
+/**
+ * Retrieves the Ed25519 public key for a ticket *without* requiring biometrics.
+ *
+ * This is used to export the public key to the event organizer for scanner
+ * pre-sync, and by the scanner verification flow on a gate device.
+ *
+ * Returns `null` if no public key is stored for this paymentId.
+ */
+export async function getTicketPublicKey(paymentId: string): Promise<Uint8Array | null> {
+  const stored = await SecureStore.getItemAsync(
+    pubkeyStoreKey(paymentId),
+    PUBLIC_STORE_OPTIONS
+  );
+  if (!stored) return null;
+  return fromBase64Url(stored);
+}
+
+// ── Vault delete ──────────────────────────────────────────────────────────────
+
+/**
+ * Permanently removes a ticket's secret and public key from the vault.
+ *
+ * Call this after a successful resale (the new owner needs to receive the
+ * secret via `resaleCrypto.sealTicketSecret` before the seller calls this)
+ * or after the event ends and the device no longer needs to show the ticket.
+ *
+ * This does NOT require biometric authentication — deletion is a less
+ * sensitive operation than reading.
+ */
+export async function clearTicketSecret(paymentId: string): Promise<void> {
+  await Promise.all([
+    SecureStore.deleteItemAsync(secretStoreKey(paymentId), BIOMETRIC_STORE_OPTIONS),
+    SecureStore.deleteItemAsync(pubkeyStoreKey(paymentId), PUBLIC_STORE_OPTIONS),
+  ]);
+}
+
+// ── Vault availability check ──────────────────────────────────────────────────
+
+/**
+ * Returns true if SecureStore is available and usable on this device.
+ * Call this before attempting vault operations to surface a clear error
+ * rather than a cryptic SecureStore exception.
+ */
+export async function isVaultAvailable(): Promise<boolean> {
+  return SecureStore.isAvailableAsync();
+}

--- a/docs/offline-vault-revocation.md
+++ b/docs/offline-vault-revocation.md
@@ -1,0 +1,114 @@
+# Offline Ticket Vault — Revocation Staleness Tradeoff
+
+**Issue #1179** | Feature: Offline Ticket Vault
+
+---
+
+## The problem
+
+The offline vault design is intentionally hermetic: the scanner device verifies
+tickets using only an Ed25519 public key pre-synced before the event, with no
+network call at gate time. This is a feature — it works when the venue has no
+cellular signal and when the server is unreachable. But it creates a staleness
+window for revoked or cancelled tickets.
+
+### Concrete scenario
+
+1. Attendee purchases a ticket at T=0. Their device stores the signing secret;
+   the scanner receives the corresponding public key at sync time.
+2. At T=2h, the organiser refunds and cancels the ticket server-side (e.g. the
+   attendee filed a chargeback).
+3. At T=3h, the event starts. The scanner has not re-synced since T=0.
+4. The attendee presents their ticket. The scanner's public key still matches;
+   the signature is valid; the timestamp is within the window.
+5. **Result: the scanner admits the attendee despite the cancellation.**
+
+The same scenario applies to:
+- Tickets transferred on-chain after the scanner's last sync (old holder can
+  still scan in with the pre-transfer key).
+- Tickets flagged as fraudulent after a post-purchase review.
+- Tickets invalidated because the buyer's payment failed or was charged back.
+
+---
+
+## Why this is inherent, not a bug
+
+Full offline verification without a revocation channel is an unsolvable
+tradeoff. You can pick at most two of:
+
+| Property | This design | Server-round-trip design |
+|---|---|---|
+| Works offline | ✓ | ✗ |
+| Instantly reflects revocations | ✗ | ✓ |
+| Forgery-resistant | ✓ | ✓ |
+
+HMAC (the alternative the issue initially mentioned) does not help: it has the
+same staleness problem and additionally requires trusting each scanner with the
+shared secret.
+
+---
+
+## Mitigations (implemented)
+
+### 1. Scanner displays last-sync time
+The scanner module exposes `getScanLog()` and `registeredTicketCount`. The
+scanner UI **must** prominently display the timestamp of the last public-key
+sync so gate staff can decide whether to accept borderline cases (e.g. "last
+synced 6 hours ago — be cautious").
+
+### 2. Rotating payload window
+The 15-second rotating payload means a screenshot or recorded QR is only valid
+for at most 75 seconds (15s window + 60s drift tolerance). This prevents
+screenshot fraud but does not help with pre-sync revocation.
+
+### 3. Per-ticket public keys
+Each ticket has its own Ed25519 keypair. Revoking a specific ticket means
+removing (or zeroing) its public key from the scanner's key map on the next
+sync. After a sync, that ticket can no longer be admitted.
+
+### 4. `addPublicKey` for partial syncs
+`OfflineScanner.addPublicKey()` can be called at any time, even mid-event, if
+the scanner gains connectivity and the app chooses to pull a partial update.
+This can narrow the staleness window significantly in venues with intermittent
+connectivity.
+
+---
+
+## Recommended operational practices
+
+1. **Sync as close to event start as possible.** Run `addPublicKey` /
+   full re-sync within 15 minutes of doors opening to minimise the window
+   during which a post-sync revocation could be exploited.
+
+2. **Display last-sync prominently.** Gate staff should see the sync time
+   on the scanner screen at all times, not just in a settings menu.
+
+3. **Re-sync at regular intervals if connectivity permits.** Even a 30-minute
+   sync schedule during a 4-hour event would limit the staleness window to
+   30 minutes for most revocations.
+
+4. **Revocation list alongside key map.** At sync time, include an explicit
+   revocation list (set of ticket IDs to reject regardless of signature
+   validity). The `OfflineScanner` can be extended to check this list after
+   signature verification but before recording the scan.
+
+5. **Staff protocol for suspicious cases.** If a ticket was purchased very
+   recently (e.g. within the last sync window), staff should verify the
+   attendee's identity against the booking confirmation before admitting.
+
+---
+
+## What this design does NOT do
+
+- It does not prevent a refunded attendee from entering if the scanner has not
+  re-synced since the refund was processed.
+- It does not handle multi-day events where the key map needs nightly rotation
+  (extend `addPublicKey` + scheduled sync for this use case).
+- It does not handle the case where the attendee's phone clock is set more than
+  60 seconds off (SCANNER_CLOCK_DRIFT_S). In that case the payload will be
+  rejected as `EXPIRED_TIMESTAMP`. Advise attendees to keep automatic time
+  sync enabled.
+
+---
+
+*Last updated: 2026-08-18 (issue #1179)*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: ^16.1.3
-        version: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -141,6 +141,9 @@ importers:
       react-native-nfc-manager:
         specifier: ^3.16.1
         version: 3.17.2(@expo/config-plugins@8.0.11)
+      react-native-qrcode-svg:
+        specifier: 6.3.15
+        version: 6.3.15(react-native-svg@15.2.0(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       react-native-reanimated:
         specifier: ~3.10.1
         version: 3.10.1(@babel/core@7.29.7)(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -150,6 +153,9 @@ importers:
       react-native-screens:
         specifier: 3.31.1
         version: 3.31.1(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react-native-svg:
+        specifier: 15.2.0
+        version: 15.2.0(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       react-native-web:
         specifier: ~0.19.10
         version: 0.19.13(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -234,7 +240,7 @@ importers:
         version: 1.9.4
       next:
         specifier: 16.1.3
-        version: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
@@ -280,7 +286,7 @@ importers:
         version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/nextjs-vite':
         specifier: 10.5.3
-        version: 10.5.3(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/react':
         specifier: ^10.5.3
         version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)
@@ -1421,7 +1427,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -3913,6 +3919,9 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   bplist-creator@0.0.7:
     resolution: {integrity: sha512-xp/tcaV3T5PCiaY04mXga7o/TE+t95gqeLmADeBI1CvZtdWTbgBt3uLpvh4UWtenKeBhCV6oVxGk38yZr2uYEA==}
 
@@ -4380,6 +4389,17 @@ packages:
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -4653,6 +4673,9 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -4671,13 +4694,26 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
 
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -4752,6 +4788,10 @@ packages:
   enhanced-resolve@5.24.2:
     resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -6803,6 +6843,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -7298,6 +7341,9 @@ packages:
   nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
 
@@ -7617,6 +7663,10 @@ packages:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -7764,6 +7814,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
@@ -7899,6 +7954,13 @@ packages:
       '@expo/config-plugins':
         optional: true
 
+  react-native-qrcode-svg@6.3.15:
+    resolution: {integrity: sha512-vLuNImGfstE8u+rlF4JfFpq65nPhmByuDG6XUPWh8yp8MgLQX11rN5eQ8nb/bf4OB+V8XoLTJB/AZF2g7jQSSQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '>=0.63.4'
+      react-native-svg: '>=14.0.0'
+
   react-native-reanimated@3.10.1:
     resolution: {integrity: sha512-sfxg6vYphrDc/g4jf/7iJ7NRi+26z2+BszPmvmk0Vnrz6FL7HYljJqTf531F1x6tFmsf+FEAmuCtTUIXFLVo9w==}
     peerDependencies:
@@ -7914,6 +7976,12 @@ packages:
 
   react-native-screens@3.31.1:
     resolution: {integrity: sha512-8fRW362pfZ9y4rS8KY5P3DFScrmwo/vu1RrRMMx0PNHbeC9TLq0Kw1ubD83591yz64gLNHFLTVkTJmWeWCXKtQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-svg@15.2.0:
+    resolution: {integrity: sha512-R0E6IhcJfVLsL0lRmnUSm72QO+mTqcAOM5Jb8FVGxJqX3NfJMlMP0YyvcajZiaRR8CqQUpEoqrY25eyZb006kw==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -8781,6 +8849,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  text-encoding@0.7.0:
+    resolution: {integrity: sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==}
+    deprecated: no longer maintained
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -12681,18 +12753,18 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@storybook/nextjs-vite@10.5.3(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@storybook/nextjs-vite@10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@storybook/builder-vite': 10.5.3(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/react': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
-      next: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -14029,6 +14101,8 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  boolbase@1.0.0: {}
+
   bplist-creator@0.0.7:
     dependencies:
       stream-buffers: 2.2.0
@@ -14502,6 +14576,21 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
+  css-what@6.2.2: {}
+
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
@@ -14757,6 +14846,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
+  dijkstrajs@1.0.3: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -14773,13 +14864,31 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
   domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
 
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -14845,6 +14954,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
     optional: true
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -17494,6 +17605,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  mdn-data@2.0.14: {}
+
   memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
@@ -18041,7 +18154,7 @@ snapshots:
 
   new-github-issue-url@0.2.1: {}
 
-  next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
@@ -18050,7 +18163,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.3
       '@next/swc-darwin-x64': 16.1.3
@@ -18149,6 +18262,10 @@ snapshots:
       path-key: 3.1.1
 
   nprogress@0.2.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
 
@@ -18512,6 +18629,8 @@ snapshots:
 
   pngjs@3.4.0: {}
 
+  pngjs@5.0.0: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-selector-parser@6.0.10:
@@ -18670,6 +18789,12 @@ snapshots:
   qrcode.react@4.2.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   qs@6.15.3:
     dependencies:
@@ -18837,6 +18962,15 @@ snapshots:
     optionalDependencies:
       '@expo/config-plugins': 8.0.11
 
+  react-native-qrcode-svg@6.3.15(react-native-svg@15.2.0(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      prop-types: 15.8.1
+      qrcode: 1.5.4
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0)
+      react-native-svg: 15.2.0(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      text-encoding: 0.7.0
+
   react-native-reanimated@3.10.1(@babel/core@7.29.7)(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/core': 7.29.7
@@ -18864,6 +18998,13 @@ snapshots:
       react-freeze: 1.0.4(react@18.2.0)
       react-native: 0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0)
       warn-once: 0.1.1
+
+  react-native-svg@15.2.0(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0)
 
   react-native-web@0.19.13(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -19829,12 +19970,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
+  styled-jsx@5.1.6(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
-    optionalDependencies:
-      '@babel/core': 7.29.7
 
   styleq@0.1.3: {}
 
@@ -19957,6 +20096,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  text-encoding@0.7.0: {}
 
   text-table@0.2.0: {}
 
@@ -20459,13 +20600,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3)
       ts-dedent: 2.3.0
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: ^16.1.3
-        version: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -93,6 +93,9 @@ importers:
       expo-linking:
         specifier: ~6.3.1
         version: 6.3.1(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
+      expo-local-authentication:
+        specifier: ~14.0.1
+        version: 14.0.1(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
       expo-notifications:
         specifier: ~0.28.19
         version: 0.28.19(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
@@ -231,7 +234,7 @@ importers:
         version: 1.9.4
       next:
         specifier: 16.1.3
-        version: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
@@ -277,7 +280,7 @@ importers:
         version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/nextjs-vite':
         specifier: 10.5.3
-        version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 10.5.3(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/react':
         specifier: ^10.5.3
         version: 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)
@@ -1418,7 +1421,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -5126,6 +5129,11 @@ packages:
 
   expo-linking@6.3.1:
     resolution: {integrity: sha512-xuZCntSBGWCD/95iZ+mTUGTwHdy8Sx+immCqbUBxdvZ2TN61P02kKg7SaLS8A4a/hLrSCwrg5tMMwu5wfKr35g==}
+
+  expo-local-authentication@14.0.1:
+    resolution: {integrity: sha512-kAwUD1wEqj1fhwQgIHlP4H/JV9AcX+NO3BJwhPM2HuCFS0kgx2wvcHisnKBSTRyl8u5Jt4odzMyQkDJystwUTg==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@1.11.3:
     resolution: {integrity: sha512-oYh8EZEvYF5TYppxEKUTTJmbr8j7eRRnrIxzZtMvxLTXoujThVPMFS/cbnSnf2bFm1lq50TdDNABhmEi7z0ngQ==}
@@ -12673,18 +12681,18 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@storybook/nextjs-vite@10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@storybook/nextjs-vite@10.5.3(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@storybook/builder-vite': 10.5.3(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@storybook/react': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
-      next: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -15038,7 +15046,7 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -15071,7 +15079,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -15085,7 +15093,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15390,6 +15398,11 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-local-authentication@14.0.1(expo@51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.74.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      invariant: 2.2.4
 
   expo-modules-autolinking@1.11.3:
     dependencies:
@@ -18028,7 +18041,7 @@ snapshots:
 
   new-github-issue-url@0.2.1: {}
 
-  next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
@@ -18037,7 +18050,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.3
       '@next/swc-darwin-x64': 16.1.3
@@ -19816,10 +19829,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   styleq@0.1.3: {}
 
@@ -20444,13 +20459,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.29.7)(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.3)
       ts-dedent: 2.3.0
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)


### PR DESCRIPTION
<pre><span style="background-color:#C19AFF"> </span> feat(mobile): offline ticket vault with Ed25519 QR verification (#1179)
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ## Summary
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> Implements fully offline ticket verification for gate staff, with rotating
<span style="background-color:#C19AFF"> </span> QR codes, hardware-backed encrypted key storage, biometric gating, and
<span style="background-color:#C19AFF"> </span> double-scan prevention. No server round-trip is required at scan time.
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ## Crypto design decision: Ed25519 (asymmetric), not HMAC
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> The issue spec mentioned HMAC-SHA256 but also said scanners verify &quot;against
<span style="background-color:#C19AFF"> </span> pre-synced event **public** keys&quot; — these are incompatible. HMAC is symmetric:
<span style="background-color:#C19AFF"> </span> the same secret generates and verifies the tag, so every gate scanner would
<span style="background-color:#C19AFF"> </span> need the forgeable secret. One stolen scanner would compromise tickets for the
<span style="background-color:#C19AFF"> </span> whole event.
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> **Resolution: Ed25519 asymmetric signing.**
<span style="background-color:#C19AFF"> </span> - The attendee&apos;s device holds a 64-byte secret key (in the biometric-gated
<span style="background-color:#C19AFF"> </span> vault).
<span style="background-color:#C19AFF"> </span> - Only the 32-byte public key is synced to scanner devices. A compromised
<span style="background-color:#C19AFF"> </span> scanner
<span style="background-color:#C19AFF"> </span>   cannot forge tickets.
<span style="background-color:#C19AFF"> </span> - `tweetnacl` was already a dependency (used in `resaleCrypto.ts`) — no new
<span style="background-color:#C19AFF"> </span>   native module needed.
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ## Changes
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ### `apps/mobile/lib/crypto.ts` (new)
<span style="background-color:#C19AFF"> </span> - `deriveTicketKeyPair(secretBytes)` — deterministic Ed25519 keypair from the
<span style="background-color:#C19AFF"> </span>   32-byte purchase secret returned by `generatePurchaseSecret()`
<span style="background-color:#C19AFF"> </span> - `generateRotatingPayload(ticketId, secretKey)` — 105-byte binary payload
<span style="background-color:#C19AFF"> </span>   (version + timestamp + ticketId + nonce + Ed25519 signature),
<span style="background-color:#C19AFF"> </span> base64url-encoded,
<span style="background-color:#C19AFF"> </span>   rotates every 15 seconds
<span style="background-color:#C19AFF"> </span> - `verifyPayload(encoded, publicKey)` — fully offline; enforces ±60s clock
<span style="background-color:#C19AFF"> </span> drift
<span style="background-color:#C19AFF"> </span>   window; returns typed result (`ok`, `invalid_signature`,
<span style="background-color:#C19AFF"> </span> `expired_timestamp`,
<span style="background-color:#C19AFF"> </span>   `bad_payload`)
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ### `apps/mobile/services/ticketVault.ts` (new)
<span style="background-color:#C19AFF"> </span> - `storeTicketSecret` / `getTicketSecret` / `getTicketPublicKey` /
<span style="background-color:#C19AFF"> </span> `clearTicketSecret`
<span style="background-color:#C19AFF"> </span> - Backed by `expo-secure-store` (iOS Keychain with `requireAuthentication:
<span style="background-color:#C19AFF"> </span> true` /
<span style="background-color:#C19AFF"> </span>   Android Keystore AES-256-GCM)
<span style="background-color:#C19AFF"> </span> - Never writes plaintext secrets to disk, AsyncStorage, or any unencrypted
<span style="background-color:#C19AFF"> </span> path
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ### `apps/mobile/services/offlineScanner.ts` (new)
<span style="background-color:#C19AFF"> </span> - `OfflineScanner` class — parses QR payload, verifies Ed25519 signature,
<span style="background-color:#C19AFF"> </span>   checks timestamp window, logs to local scan store
<span style="background-color:#C19AFF"> </span> - `ScanResult` enum with **6 distinct outcomes**: `VALID`,
<span style="background-color:#C19AFF"> </span> `INVALID_SIGNATURE`,
<span style="background-color:#C19AFF"> </span>   `EXPIRED_TIMESTAMP`, `ALREADY_SCANNED`, `BAD_PAYLOAD`, `UNKNOWN_TICKET` —
<span style="background-color:#C19AFF"> </span>   each maps to a distinct gate staff UI message
<span style="background-color:#C19AFF"> </span> - `InMemoryScanStore` default; injectable `ScanStore` interface for SQLite
<span style="background-color:#C19AFF"> </span>   persistence on multi-session events
<span style="background-color:#C19AFF"> </span> - `addPublicKey()` for partial mid-event syncs
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ### `apps/mobile/hooks/useBiometricAuth.ts` (new)
<span style="background-color:#C19AFF"> </span> - 7-state hook: `idle → checking → unavailable / idle → prompting → success /
<span style="background-color:#C19AFF"> </span> failed / error`
<span style="background-color:#C19AFF"> </span> - No silent fallthrough — `unavailable` and `failed` are explicit, surfaced
<span style="background-color:#C19AFF"> </span> states
<span style="background-color:#C19AFF"> </span> - Handles: no hardware, not enrolled, user cancel, lockout, system cancel,
<span style="background-color:#C19AFF"> </span> runtime error
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ### `apps/mobile/components/ticket/DynamicQrView.tsx` (new)
<span style="background-color:#C19AFF"> </span> - Renders a live `react-native-qrcode-svg` QR code (240px, ecl=M)
<span style="background-color:#C19AFF"> </span> - Auto-rotates every 7.5s (half the 15s window) so the display never lags at
<span style="background-color:#C19AFF"> </span>   a window boundary
<span style="background-color:#C19AFF"> </span> - Receives `secretKey` as a prop — parent controls vault access and biometric
<span style="background-color:#C19AFF"> </span> gate
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ### `apps/mobile/app/ticket/[id].tsx` (updated)
<span style="background-color:#C19AFF"> </span> - Biometric gate before any vault access: user must tap &quot;Show Ticket QR&quot; →
<span style="background-color:#C19AFF"> </span>   OS prompt → success before the key is read and the QR displayed
<span style="background-color:#C19AFF"> </span> - Explicit error states for unavailable and failed biometrics; no silent
<span style="background-color:#C19AFF"> </span> unlock
<span style="background-color:#C19AFF"> </span> - In-memory `secretKey` cleared on screen unmount
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ### `docs/offline-vault-revocation.md` (new)
<span style="background-color:#C19AFF"> </span> Documents the inherent offline/revocation tradeoff: a ticket cancelled
<span style="background-color:#C19AFF"> </span> server-side after the scanner&apos;s last sync will scan as valid offline until
<span style="background-color:#C19AFF"> </span> re-sync. Includes the concrete scenario, why HMAC doesn&apos;t solve it, and
<span style="background-color:#C19AFF"> </span> recommended operational mitigations (sync timing, last-sync display, partial
<span style="background-color:#C19AFF"> </span> sync via `addPublicKey`, revocation list extension point).
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ## Tests
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> 271 tests total passing (92 new for this feature):
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> | Suite | Cases |
<span style="background-color:#C19AFF"> </span> |---|---|
<span style="background-color:#C19AFF"> </span> | `lib/__tests__/crypto.test.ts` | base64url round-trip, key derivation,
<span style="background-color:#C19AFF"> </span> payload generation/rotation/window alignment, parse, signature tamper, wrong
<span style="background-color:#C19AFF"> </span> key, ticketId tamper, clock drift boundaries, stale-key handling |
<span style="background-color:#C19AFF"> </span> | `services/__tests__/offlineScanner.test.ts` | all 6 ScanResult paths,
<span style="background-color:#C19AFF"> </span> double-scan prevention, scan log CRUD, partial sync, legacy/stale-key |
<span style="background-color:#C19AFF"> </span> | `services/__tests__/ticketVault.test.ts` | store/retrieve/delete,
<span style="background-color:#C19AFF"> </span> plaintext-never-on-disk, key separation, null safety |
<span style="background-color:#C19AFF"> </span> | `hooks/__tests__/useBiometricAuth.test.ts` | biometric-gate rejection (not
<span style="background-color:#C19AFF"> </span> silently unlocked), no-hardware, not-enrolled, cancel→failed, lockout, runtime
<span style="background-color:#C19AFF"> </span> error, reset+re-authenticate |
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ## Staleness / revocation flag
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> As required by the issue: a refunded or cancelled ticket will scan as valid
<span style="background-color:#C19AFF"> </span> offline until the scanner re-syncs. This is documented in
<span style="background-color:#C19AFF"> </span> `docs/offline-vault-revocation.md` and is inherent to any offline-first
<span style="background-color:#C19AFF"> </span> verification design. The `addPublicKey` + scheduled sync path narrows the
<span style="background-color:#C19AFF"> </span> window. Full details in the doc.
<span style="background-color:#C19AFF"> </span> 
<span style="background-color:#C19AFF"> </span> ## Constraints respected
</pre>

Closes #1179