### PR TITLE
feat: add mobile event preview bottom sheet with swipe-to-close (Closes #1141)

### DIFF
--- a/apps/web/__tests__/event-preview-bottom-sheet.test.tsx
+++ b/apps/web/__tests__/event-preview-bottom-sheet.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { EventPreviewBottomSheet } from "@/components/events/event-preview-bottom-sheet";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt, ...props }: { src: string; alt: string; [key: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} {...props} />
+  ),
+}));
+
+const mockEvent = {
+  id: 1,
+  title: "Tech Conference 2026",
+  date: "Sat, 15 Aug 2026",
+  venue: "San Francisco, CA",
+  imageUrl: "https://example.com/event.jpg",
+};
+
+describe("EventPreviewBottomSheet", () => {
+  it("renders event details when open", () => {
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={vi.fn()}
+        event={mockEvent}
+      />
+    );
+
+    expect(screen.getByText("Tech Conference 2026")).toBeInTheDocument();
+    expect(screen.getByText("Sat, 15 Aug 2026")).toBeInTheDocument();
+    expect(screen.getByText("San Francisco, CA")).toBeInTheDocument();
+  });
+
+  it("has role=dialog and aria-modal when open", () => {
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={vi.fn()}
+        event={mockEvent}
+      />
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("does not render when isOpen is false", () => {
+    render(
+      <EventPreviewBottomSheet
+        isOpen={false}
+        onClose={vi.fn()}
+        event={mockEvent}
+      />
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not render when event is null", () => {
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={vi.fn()}
+        event={null}
+      />
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("contains a link to the event details page", () => {
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={vi.fn()}
+        event={mockEvent}
+      />
+    );
+
+    const link = screen.getByRole("link", { name: /view event details/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/events/1");
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={onClose}
+        event={mockEvent}
+      />
+    );
+
+    const closeButton = screen.getByLabelText("Close preview");
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={onClose}
+        event={mockEvent}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders the event image when imageUrl is provided", () => {
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={vi.fn()}
+        event={mockEvent}
+      />
+    );
+
+    const img = screen.getByAltText("Tech Conference 2026");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/event.jpg");
+  });
+
+  it("renders without image when imageUrl is not provided", () => {
+    const eventWithoutImage = { ...mockEvent, imageUrl: undefined };
+    render(
+      <EventPreviewBottomSheet
+        isOpen={true}
+        onClose={vi.fn()}
+        event={eventWithoutImage}
+      />
+    );
+
+    expect(screen.getByText("Tech Conference 2026")).toBeInTheDocument();
+    expect(screen.queryByAltText("Tech Conference 2026")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/events/event-preview-bottom-sheet.tsx
+++ b/apps/web/components/events/event-preview-bottom-sheet.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { motion, AnimatePresence, type PanInfo } from "framer-motion";
+import Image from "next/image";
+import Link from "next/link";
+import { Overlay } from "@/components/ui/overlay";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { X, ArrowRight } from "@/components/ui/icons";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface EventPreview {
+  id: number | string;
+  title: string;
+  date: string;
+  venue: string;
+  imageUrl?: string;
+}
+
+interface EventPreviewBottomSheetProps {
+  /** Whether the bottom sheet is visible */
+  isOpen: boolean;
+  /** Callback when the sheet should close */
+  onClose: () => void;
+  /** Event data to display */
+  event: EventPreview | null;
+}
+
+// ─── Animation constants ──────────────────────────────────────────────────────
+
+const SHEET_HEIGHT = 340; // px — approximate height of the sheet content
+const SWIPE_THRESHOLD = 80; // px — minimum drag distance to trigger close
+
+const sheetVariants = {
+  hidden: { y: SHEET_HEIGHT },
+  visible: { y: 0 },
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function EventPreviewBottomSheet({
+  isOpen,
+  onClose,
+  event,
+}: EventPreviewBottomSheetProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>(isOpen, onClose);
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  const handleDragEnd = useCallback(
+    (_: unknown, info: PanInfo) => {
+      if (info.offset.y > SWIPE_THRESHOLD) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  // Don't render anything when closed and no event data
+  if (!event) return null;
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center lg:hidden">
+          {/* Backdrop */}
+          <Overlay isOpen={isOpen} onClose={onClose} zIndex={50} />
+
+          {/* Bottom Sheet */}
+          <motion.div
+            ref={focusTrapRef as React.Ref<HTMLDivElement>}
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Event preview: ${event.title}`}
+            className="relative z-50 w-full max-w-lg rounded-t-2xl bg-white shadow-[-4px_-4px_0_rgba(0,0,0,1)] border border-black"
+            variants={sheetVariants}
+            initial="hidden"
+            animate="visible"
+            exit="hidden"
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            drag="y"
+            dragConstraints={{ top: 0, bottom: SHEET_HEIGHT }}
+            dragElastic={{ top: 0, bottom: 0.5 }}
+            onDragEnd={handleDragEnd}
+            style={{ touchAction: "pan-y" }}
+          >
+            {/* Drag Handle */}
+            <div className="flex justify-center pt-3 pb-1">
+              <div className="w-10 h-1 rounded-full bg-gray-300" />
+            </div>
+
+            {/* Close Button */}
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 p-1 rounded-full hover:bg-gray-100 transition-colors z-10"
+              aria-label="Close preview"
+            >
+              <X size={20} />
+            </button>
+
+            {/* Content */}
+            <div className="px-5 pb-6 pt-2" ref={sheetRef}>
+              {/* Event Image */}
+              {event.imageUrl && (
+                <div className="relative w-full h-40 rounded-lg overflow-hidden mb-4">
+                  <Image
+                    src={event.imageUrl}
+                    alt={event.title}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 512px) 100vw, 512px"
+                  />
+                </div>
+              )}
+
+              {/* Event Title */}
+              <h3 className="font-semibold text-lg leading-tight mb-1">
+                {event.title}
+              </h3>
+
+              {/* Event Date */}
+              <div className="flex items-center gap-2 text-sm text-gray-600 mb-1">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                  <line x1="16" y1="2" x2="16" y2="6" />
+                  <line x1="8" y1="2" x2="8" y2="6" />
+                  <line x1="3" y1="10" x2="21" y2="10" />
+                </svg>
+                <span>{event.date}</span>
+              </div>
+
+              {/* Event Venue */}
+              <div className="flex items-center gap-2 text-sm text-gray-600 mb-5">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                <span>{event.venue}</span>
+              </div>
+
+              {/* CTA Button */}
+              <Link
+                href={`/events/${event.id}`}
+                className="flex items-center justify-center gap-2 w-full py-3 px-6 rounded-full border border-black font-semibold bg-white shadow-[-4px_4px_0_rgba(0,0,0,1)] hover:-translate-x-[2px] hover:translate-y-[2px] hover:shadow-[-2px_2px_0_rgba(0,0,0,1)] active:-translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all"
+                onClick={onClose}
+              >
+                View Event Details
+                <ArrowRight size={18} />
+              </Link>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary

Build a mobile-friendly bottom sheet that displays a preview of an event whenever a user taps an event marker on the map.

### Changes

- **New component:** `EventPreviewBottomSheet` — reusable bottom sheet with framer-motion animations
- **Swipe-to-close:** Drag down gesture support via framer-motion `drag="y"`
- **Overlay backdrop:** Uses existing `Overlay` component for semi-transparent background
- **Focus trap:** Accessibility via `useFocusTrap` hook (Escape closes, Tab cycling)
- **Event display:** Shows event image, title, date, and venue
- **CTA button:** Link to event details page (`/events/[id]`)
- **Tests:** 9 unit tests covering rendering, accessibility, close behavior, and edge cases

### Acceptance Criteria

- [x] Bottom sheet opens when an event marker is selected (via `isOpen` prop)
- [x] Event information displays correctly
- [x] Users can navigate to the Event Details page
- [x] Component works smoothly on mobile devices
- [x] Swipe-to-close interaction works
- [x] 9/9 tests passing

**Closes #1141**