### PR TITLE
feat: add Map Discovery page with responsive layout and loading states (Closes #1138)

### DIFF
--- a/apps/web/__tests__/map-discovery-page.test.tsx
+++ b/apps/web/__tests__/map-discovery-page.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MapDiscoveryPage } from "../components/events/map-discovery-page";
+
+// Mock Navbar as a lightweight stub (full render causes OOM with framer-motion)
+vi.mock("@/components/layout/navbar", () => ({
+  Navbar: () => <nav data-testid="navbar" />,
+}));
+
+vi.mock("@/components/layout/footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+// LoadingBar uses next/navigation hooks — mock them
+vi.mock("@/components/ui/loading-bar", () => ({
+  default: () => <div data-testid="loading-bar" />,
+}));
+
+describe("MapDiscoveryPage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows a loading state initially", () => {
+    render(<MapDiscoveryPage />);
+
+    expect(screen.getByText(/loading map data/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: /event discovery map/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+  });
+
+  it("renders the page heading and description", () => {
+    render(<MapDiscoveryPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /explore events on the map/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/discover events happening near you/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows the map placeholder once loading completes", () => {
+    render(<MapDiscoveryPage />);
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(screen.getByTestId("map-placeholder")).toBeInTheDocument();
+    expect(screen.getByText(/map ready to explore/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/discover/map/page.tsx
+++ b/apps/web/app/discover/map/page.tsx
@@ -1,0 +1,13 @@
+import { buildMetadata } from "@/components/layout/seo";
+import { MapDiscoveryPage } from "@/components/events/map-discovery-page";
+
+export const metadata = buildMetadata({
+  title: "Explore Events on the Map",
+  description:
+    "Discover events happening near you with Agora's interactive map. Browse by location and find your next experience.",
+  path: "/discover/map",
+});
+
+export default function MapDiscoveryRoute() {
+  return <MapDiscoveryPage />;
+}

--- a/apps/web/components/events/map-discovery-page.tsx
+++ b/apps/web/components/events/map-discovery-page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Navbar } from "@/components/layout/navbar";
+import { Footer } from "@/components/layout/footer";
+import LoadingBar from "@/components/ui/loading-bar";
+
+/**
+ * Map Discovery Page — renders the `/discover/map` route layout.
+ *
+ * Displays a header, a placeholder map container where the interactive
+ * map will be integrated (see #1139), and loading / ready states.
+ *
+ * #1138 — Map Discovery Page
+ */
+export function MapDiscoveryPage() {
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Simulate initial data loading (e.g. fetching map data from backend).
+  // The placeholder appears immediately after the brief loading phase.
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <main className="flex min-h-screen flex-col bg-base">
+      <Navbar />
+
+      <div className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:py-12">
+        {/* Header section */}
+        <div className="mb-8">
+          <p className="text-sm font-bold uppercase tracking-[0.18em] text-accent-dark">
+            Map Discovery
+          </p>
+          <h1 className="mt-2 text-4xl font-bold text-ink-deep sm:text-5xl">
+            Explore events on the map
+          </h1>
+          <p className="mt-3 max-w-2xl text-sand">
+            Discover events happening near you. Browse by location, zoom in
+            for details, and find your next experience.
+          </p>
+        </div>
+
+        {/* Map container — placeholder ready for #1139 integration */}
+        <div
+          className="relative w-full overflow-hidden rounded-2xl border border-border-warm bg-surface"
+          style={{ minHeight: 400 }}
+          role="region"
+          aria-label="Event discovery map"
+        >
+          {isLoading ? (
+            /* Loading state */
+            <div className="flex h-full w-full items-center justify-center py-20">
+              <div className="flex flex-col items-center gap-4">
+                <LoadingBar />
+                <span className="text-sm font-medium text-sand">
+                  Loading map data...
+                </span>
+              </div>
+            </div>
+          ) : (
+            /* Placeholder ready for interactive map (#1139) */
+            <div
+              className="flex h-full w-full flex-col items-center justify-center py-20"
+              data-testid="map-placeholder"
+            >
+              <svg
+                className="mb-4 h-16 w-16 text-sand"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z"
+                />
+              </svg>
+              <p className="text-lg font-semibold text-ink-soft">
+                Map ready to explore
+              </p>
+              <p className="mt-1 text-sm text-sand">
+                Zoom and pan controls will be available after map integration.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Event count hint */}
+        <div className="mt-6 text-sm text-sand">
+          <p>
+            Interactive event markers, clustering, and search are coming soon.
+          </p>
+        </div>
+      </div>
+
+      <Footer />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds the **Map Discovery Page** at `/discover/map`, providing the page layout and placeholder container for the interactive event map (to be integrated in #1139).

### Changes

- **New route**: `/discover/map` with SEO metadata via `buildMetadata`
- **New component**: `MapDiscoveryPage` — responsive layout with header, placeholder map container, and loading states
- **Loading state**: Brief loading animation using `LoadingBar` component, then shows the map placeholder ready for interactive integration
- **Tests**: 3 test cases covering loading state, heading rendering, and completion state

### Acceptance Criteria

- [x] Route renders successfully at `/discover/map`
- [x] Layout is responsive (mobile + desktop via Tailwind responsive classes)
- [x] Placeholder map container is ready for #1139 integration (with `data-testid="map-placeholder"`)
- [x] Loading states display correctly (initial loading bar → placeholder)
- [x] Tests pass (3/3)

### Dependencies

- Closes #1138
- Prerequisite for #1139 (Interactive Event Map)