### PR TITLE
feat: integrate interactive event map with React Leaflet (Closes #1139)

### DIFF
--- a/apps/web/__tests__/event-map.test.tsx
+++ b/apps/web/__tests__/event-map.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import EventMap from "@/components/events/event-map";
+
+vi.mock("react-leaflet", () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="marker">{children}</div>
+  ),
+  Popup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popup">{children}</div>
+  ),
+  useMap: () => ({ setView: vi.fn(), fitBounds: vi.fn(), getZoom: () => 13 }),
+}));
+
+vi.mock("leaflet", () => {
+  const iconDefault = {
+    prototype: {} as Record<string, unknown>,
+    mergeOptions: vi.fn(),
+  };
+  const IconCtor = vi.fn(function (
+    this: unknown,
+    opts: Record<string, unknown>
+  ) {
+    return { opts };
+  }) as unknown as {
+    Default: typeof iconDefault;
+    mergeOptions: ReturnType<typeof vi.fn>;
+  };
+  IconCtor.Default = iconDefault;
+  IconCtor.mergeOptions = vi.fn();
+  const mockIcon = vi.fn((_opts: Record<string, unknown>) => ({ _opts }));
+  return {
+    default: {
+      Icon: IconCtor,
+      icon: mockIcon,
+      latLngBounds: vi.fn(() => ({})),
+    },
+    Icon: IconCtor,
+  };
+});
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const sampleEvents = {
+  popularEvents: [
+    {
+      id: "evt-1",
+      title: "Stellar Builders Summit",
+      date: "2026-09-01",
+      location: "Lagos, Nigeria",
+      latitude: 6.5244,
+      longitude: 3.3792,
+      price: "Free",
+      imageUrl: "/images/event1.png",
+      category: "Technology",
+    },
+    {
+      id: "evt-2",
+      title: "Web3 Hackathon",
+      date: "2026-09-05",
+      location: "Accra, Ghana",
+      latitude: 5.6037,
+      longitude: -0.187,
+      price: "50",
+      imageUrl: "/images/event2.png",
+      category: "Web3",
+    },
+  ],
+};
+
+describe("EventMap", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("shows a loading state while fetching events", () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    render(<EventMap />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading map")).toBeInTheDocument();
+  });
+
+  it("renders the map with event markers after fetch", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => sampleEvents,
+    });
+    render(<EventMap />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("map-container")).toBeInTheDocument()
+    );
+    const markers = screen.getAllByTestId("marker");
+    expect(markers).toHaveLength(2);
+  });
+
+  it("shows event details in popups", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => sampleEvents,
+    });
+    render(<EventMap />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("map-container")).toBeInTheDocument()
+    );
+    // Markers render popup content (mocked Marker renders children)
+    expect(screen.getByText("Stellar Builders Summit")).toBeInTheDocument();
+    expect(screen.getByText("Web3 Hackathon")).toBeInTheDocument();
+    expect(screen.getByText("Lagos, Nigeria")).toBeInTheDocument();
+  });
+
+  it("shows an error state when fetching fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, json: async () => ({}) });
+    render(<EventMap />);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByText(/failed to load map data/i)).toBeInTheDocument();
+  });
+
+  it("shows error when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    render(<EventMap />);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+  });
+
+  it("shows empty state when no events are returned", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ popularEvents: [] }),
+    });
+    render(<EventMap />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("map-empty")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/no events to display/i)).toBeInTheDocument();
+  });
+
+  it("renders initial events without fetching", async () => {
+    render(<EventMap initialEvents={sampleEvents.popularEvents as never} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("map-container")).toBeInTheDocument()
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("retries the fetch when the retry button is clicked", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, json: async () => ({}) });
+    render(<EventMap />);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => sampleEvents,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("map-container")).toBeInTheDocument()
+    );
+  });
+});

--- a/apps/web/__tests__/map-discovery-page.test.tsx
+++ b/apps/web/__tests__/map-discovery-page.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MapDiscoveryPage } from "../components/events/map-discovery-page";
+
+// Mock Navbar as a lightweight stub (full render causes OOM with framer-motion)
+vi.mock("@/components/layout/navbar", () => ({
+  Navbar: () => <nav data-testid="navbar" />,
+}));
+
+vi.mock("@/components/layout/footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+// LoadingBar uses next/navigation hooks — mock them
+vi.mock("@/components/ui/loading-bar", () => ({
+  default: () => <div data-testid="loading-bar" />,
+}));
+
+// EventMapClient is a dynamic import of react-leaflet — mock it
+vi.mock("@/components/events/event-map-client", () => ({
+  default: () => <div data-testid="event-map-client" />,
+}));
+
+describe("MapDiscoveryPage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows a loading state initially", () => {
+    render(<MapDiscoveryPage />);
+
+    expect(screen.getByText(/loading map data/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: /event discovery map/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+  });
+
+  it("renders the page heading and description", () => {
+    render(<MapDiscoveryPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /explore events on the map/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/discover events happening near you/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the interactive map after loading completes", () => {
+    render(<MapDiscoveryPage />);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByTestId("event-map-client")).toBeInTheDocument();
+    expect(screen.getByText(/click on markers/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/api/events/discover/route.ts
+++ b/apps/web/app/api/events/discover/route.ts
@@ -31,6 +31,8 @@ export const GET = withErrorHandler(async () => {
       title: event.title,
       date: event.startsAt.toLocaleString(),
       location: event.location,
+      latitude: event.latitude,
+      longitude: event.longitude,
       price: event.ticketPrice === 0 ? "Free" : String(event.ticketPrice),
       imageUrl: event.imageUrl,
       category: event.category,

--- a/apps/web/components/events/event-map-client.tsx
+++ b/apps/web/components/events/event-map-client.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const EventMap = dynamic(() => import("@/components/events/event-map"), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex h-full w-full items-center justify-center bg-black/5 animate-pulse"
+      role="status"
+      aria-label="Loading map"
+    >
+      <span className="font-heading text-sm font-medium text-black/50">
+        Loading map...
+      </span>
+    </div>
+  ),
+});
+
+export default function EventMapClient() {
+  return <EventMap />;
+}

--- a/apps/web/components/events/event-map.tsx
+++ b/apps/web/components/events/event-map.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import {
+  MapContainer,
+  TileLayer,
+  Marker,
+  Popup,
+  useMap,
+} from "react-leaflet";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+// Fix default icon path issues with webpack/Next.js
+delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)
+  ._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl:
+    "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+});
+
+const customIcon = new L.Icon({
+  iconUrl: "/icons/map-pin.svg",
+  iconSize: [40, 40],
+  iconAnchor: [20, 40],
+  popupAnchor: [0, -40],
+});
+
+/**
+ * Default centre: Lagos, Nigeria (West Africa region).
+ * Falls back to this when no events with coordinates are found.
+ */
+const DEFAULT_CENTER: [number, number] = [8.5, 4.5];
+const DEFAULT_ZOOM = 5;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface MapEvent {
+  id: string;
+  title: string;
+  date: string;
+  location: string;
+  latitude: number | null;
+  longitude: number | null;
+  price: string;
+  imageUrl: string;
+  category: string;
+}
+
+interface MapViewState {
+  center: [number, number];
+  zoom: number;
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+/** Updates the map viewport when the centre/zoom changes. */
+function ChangeView({ center, zoom }: MapViewState) {
+  const map = useMap();
+  useEffect(() => {
+    map.setView(center, zoom);
+  }, [center, zoom, map]);
+  return null;
+}
+
+/** Fits the map bounds to all event markers, or falls back to default. */
+function FitBounds({ events }: { events: MapEvent[] }) {
+  const map = useMap();
+  useEffect(() => {
+    const coords = events
+      .filter((e) => e.latitude != null && e.longitude != null)
+      .map((e) => [e.latitude!, e.longitude!] as [number, number]);
+
+    if (coords.length > 0) {
+      const bounds = L.latLngBounds(coords);
+      map.fitBounds(bounds, { padding: [50, 50], maxZoom: 14 });
+    }
+  }, [events, map]);
+  return null;
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+interface EventMapProps {
+  /** Optional: pre-fetched events to display. When omitted, the component
+   *  fetches events from the discover API. */
+  initialEvents?: MapEvent[];
+}
+
+export default function EventMap({ initialEvents }: EventMapProps) {
+  const [events, setEvents] = useState<MapEvent[]>(initialEvents ?? []);
+  const [isLoading, setIsLoading] = useState(!initialEvents);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedEvent, setSelectedEvent] = useState<MapEvent | null>(null);
+
+  const fetchEvents = useCallback(async () => {
+    if (initialEvents) return;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/events/discover");
+      if (!response.ok) {
+        throw new Error("Failed to fetch event data");
+      }
+      const data = await response.json();
+      // The discover API returns popularEvents with latitude/longitude
+      const mapEvents: MapEvent[] = (data.popularEvents ?? []) as MapEvent[];
+      setEvents(mapEvents);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "An unexpected error occurred"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [initialEvents]);
+
+  useEffect(() => {
+    fetchEvents();
+  }, [fetchEvents]);
+
+  // Filter events that have coordinates
+  const eventsWithCoords = events.filter(
+    (e) => e.latitude != null && e.longitude != null
+  );
+
+  // ── Loading state ──────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center"
+        role="status"
+        aria-label="Loading map"
+      >
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-accent border-t-transparent" />
+          <span className="text-sm font-medium text-sand">
+            Loading events map...
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error state ────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center"
+        role="alert"
+      >
+        <div className="flex flex-col items-center gap-2 text-center">
+          <svg
+            className="h-10 w-10 text-red-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+            />
+          </svg>
+          <p className="text-sm font-medium text-red-500">
+            Failed to load map data
+          </p>
+          <p className="text-xs text-sand">{error}</p>
+          <button
+            onClick={fetchEvents}
+            className="mt-2 rounded-lg bg-accent px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-dark"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Empty state ────────────────────────────────────────────────────────
+  if (events.length === 0) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center"
+        data-testid="map-empty"
+      >
+        <div className="flex flex-col items-center gap-2 text-center">
+          <svg
+            className="h-12 w-12 text-sand"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z"
+            />
+          </svg>
+          <p className="text-lg font-semibold text-ink-soft">
+            No events to display
+          </p>
+          <p className="text-sm text-sand">
+            Events with location data will appear here on the map.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Determine the map centre: use the first event's coordinates, or default
+  const centre: [number, number] =
+    eventsWithCoords.length > 0
+      ? [eventsWithCoords[0].latitude!, eventsWithCoords[0].longitude!]
+      : DEFAULT_CENTER;
+
+  return (
+    <div className="h-full w-full" data-testid="event-map">
+      <MapContainer
+        center={centre}
+        zoom={DEFAULT_ZOOM}
+        className="h-full w-full"
+        scrollWheelZoom
+        zoomControl
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+
+        <FitBounds events={eventsWithCoords} />
+
+        {eventsWithCoords.map((event) => (
+          <Marker
+            key={event.id}
+            position={[event.latitude!, event.longitude!]}
+            icon={customIcon}
+          >
+            <Popup>
+              <div className="min-w-[180px]">
+                {event.imageUrl && (
+                  <img
+                    src={event.imageUrl}
+                    alt={event.title}
+                    className="mb-2 h-24 w-full rounded-lg object-cover"
+                  />
+                )}
+                <h3 className="text-sm font-semibold text-gray-900">
+                  {event.title}
+                </h3>
+                <p className="mt-1 text-xs text-gray-600">{event.date}</p>
+                <p className="text-xs text-gray-500">{event.location}</p>
+                <p className="mt-1 text-xs font-medium text-gray-800">
+                  {event.price === "Free" ? "Free" : `${event.price}`}
+                </p>
+              </div>
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  );
+}

--- a/apps/web/components/events/map-discovery-page.tsx
+++ b/apps/web/components/events/map-discovery-page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Navbar } from "@/components/layout/navbar";
+import { Footer } from "@/components/layout/footer";
+import LoadingBar from "@/components/ui/loading-bar";
+import EventMapClient from "@/components/events/event-map-client";
+
+/**
+ * Map Discovery Page — renders the `/discover/map` route layout.
+ *
+ * Displays a header, an interactive event map (see #1139), and
+ * loading / ready states.
+ *
+ * Tasks:
+ * - #1138 — Map Discovery Page (route + layout + placeholder)
+ * - #1139 — Interactive Event Map integration
+ */
+export function MapDiscoveryPage() {
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Brief initial load phase for page layout
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 400);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <main className="flex min-h-screen flex-col bg-base">
+      <Navbar />
+
+      <div className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:py-12">
+        {/* Header section */}
+        <div className="mb-8">
+          <p className="text-sm font-bold uppercase tracking-[0.18em] text-accent-dark">
+            Map Discovery
+          </p>
+          <h1 className="mt-2 text-4xl font-bold text-ink-deep sm:text-5xl">
+            Explore events on the map
+          </h1>
+          <p className="mt-3 max-w-2xl text-sand">
+            Discover events happening near you. Browse by location, zoom in
+            for details, and find your next experience.
+          </p>
+        </div>
+
+        {/* Interactive map container */}
+        <div
+          className="relative w-full overflow-hidden rounded-2xl border border-border-warm bg-surface"
+          style={{ minHeight: 500 }}
+          role="region"
+          aria-label="Event discovery map"
+        >
+          {isLoading ? (
+            /* Initial page layout loading state */
+            <div className="flex h-full w-full items-center justify-center py-20">
+              <div className="flex flex-col items-center gap-4">
+                <LoadingBar />
+                <span className="text-sm font-medium text-sand">
+                  Loading map data...
+                </span>
+              </div>
+            </div>
+          ) : (
+            /* Interactive map with event markers */
+            <div className="h-full w-full" data-testid="map-container">
+              <EventMapClient />
+            </div>
+          )}
+        </div>
+
+        {/* Event count info */}
+        <div className="mt-6 text-sm text-sand">
+          <p>
+            Click on markers to see event details. Zoom in for a closer look
+            at specific areas.
+          </p>
+        </div>
+      </div>
+
+      <Footer />
+    </main>
+  );
+}

--- a/apps/web/utils/api.ts
+++ b/apps/web/utils/api.ts
@@ -9,6 +9,8 @@ export type DiscoverEvent = {
   title: string;
   date: string;
   location: string;
+  latitude: number | null;
+  longitude: number | null;
   price: string;
   imageUrl: string;
   category: string;

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
 
+// Force test environment — NODE_ENV=production (inherited from the shell)
+// loads React production builds where React.act is stripped, crashing
+// @testing-library/react with "React.act is not a function".
+process.env.NODE_ENV = 'test';
+
 export default defineConfig({
   test: {
     environment: 'jsdom',

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -2,6 +2,9 @@ import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach } from 'vitest';
 
+// React 19 requires this global flag for testing-library's act()
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
 // Cleanup after each test
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary

This PR integrates an **interactive event map** into the Map Discovery page using **React Leaflet** (already a project dependency). Events with WGS84 coordinates render as markers with detailed popups.

### Changes

- **`EventMap` component** (`components/events/event-map.tsx`): React Leaflet map with:
  - Event markers with custom map-pin icon and popups (image, title, date, location, price)
  - `FitBounds` — viewport auto-adjusts to all event markers
  - Loading state with spinner (role="status")
  - Error state with retry button (role="alert")
  - Empty state when no events exist
  - Optional `initialEvents` prop for server-side pre-fetching
- **`EventMapClient`**: dynamic SSR-off wrapper (Next.js leaflet compatibility)
- **Discover API** (`app/api/events/discover/route.ts`): now returns `latitude`/`longitude` for each event
- **`DiscoverEvent` type**: adds `latitude`/`longitude` fields
- **Map Discovery page** (`map-discovery-page.tsx`): placeholder replaced with live `EventMapClient`
- **Tests**: 11 tests covering loading, markers, popups, error, empty, retry, and pre-fetched states

### Acceptance Criteria

- [x] Interactive map renders successfully (React Leaflet)
- [x] Event markers load from the backend (discover API returns lat/lon)
- [x] Loading and error states are handled correctly (spinner + retry)
- [x] Map performs well on supported devices (responsive height, scrollWheelZoom, zoom controls)

### Dependencies

- Closes #1139
- Builds on the `/discover/map` route from #1138 (PR #1206)