### PR TITLE
feat: add EventCardSkeleton with pulse animation for event list loading (Closes #1024)

### DIFF
--- a/apps/mobile/app/discover.tsx
+++ b/apps/mobile/app/discover.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
 import {
-  ActivityIndicator,
   FlatList,
   Image,
   RefreshControl,
@@ -12,6 +11,7 @@ import {
 } from "react-native";
 import MapView, { Marker, Callout } from "react-native-maps";
 import CategorySelector from "@/components/CategorySelector";
+import { EventCardSkeleton } from "@/components/EventCardSkeleton";
 import { useDiscoverEvents } from "@/hooks/useDiscoverEvents";
 import {
   mappableEvents,
@@ -100,7 +100,11 @@ export default function DiscoverScreen() {
       )}
 
       {isLoading ? (
-        <ActivityIndicator style={styles.loader} color="#FACC15" />
+        <View style={styles.skeletonList} testID="discover-skeleton">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <EventCardSkeleton key={`skeleton-${index}`} />
+          ))}
+        </View>
       ) : mode === "list" ? (
         <FlatList
           data={events}
@@ -172,6 +176,7 @@ const styles = StyleSheet.create({
   },
   offlineText: { color: "#FACC15", fontSize: 12 },
   loader: { marginTop: 32 },
+  skeletonList: { paddingTop: 8 },
   map: { flex: 1 },
   row: { flexDirection: "row", gap: 12, paddingHorizontal: 16, paddingVertical: 10 },
   thumb: { width: 64, height: 64, borderRadius: 8 },

--- a/apps/mobile/components/EventCardSkeleton.tsx
+++ b/apps/mobile/components/EventCardSkeleton.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, StyleSheet, View } from "react-native";
+
+/**
+ * EventCardSkeleton — placeholder skeleton for the event list
+ * (issue #1024).
+ *
+ * Mimics the layout of EventRow: a 64×64 thumbnail on the left and
+ * three text lines on the right.  A looping pulse animation fades the
+ * skeleton's opacity between 30 % and 70 % to communicate loading.
+ */
+
+const SKELETON_COLOR = "#27272A";
+const PULSE_MIN = 0.3;
+const PULSE_MAX = 0.7;
+const PULSE_DURATION = 1000; // ms
+
+export function EventCardSkeleton({ testID }: { testID?: string }) {
+  const opacity = useRef(new Animated.Value(PULSE_MIN)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: PULSE_MAX,
+          duration: PULSE_DURATION / 2,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: PULSE_MIN,
+          duration: PULSE_DURATION / 2,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[styles.row, { opacity }]}
+      testID={testID ?? "event-card-skeleton"}
+    >
+      <View style={styles.thumb} />
+      <View style={styles.body}>
+        <View style={styles.lineTitle} />
+        <View style={styles.lineMeta} />
+        <View style={styles.lineDate} />
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  thumb: {
+    width: 64,
+    height: 64,
+    borderRadius: 8,
+    backgroundColor: SKELETON_COLOR,
+  },
+  body: {
+    flex: 1,
+    justifyContent: "center",
+    gap: 6,
+  },
+  lineTitle: {
+    height: 14,
+    width: "70%",
+    borderRadius: 4,
+    backgroundColor: SKELETON_COLOR,
+  },
+  lineMeta: {
+    height: 10,
+    width: "50%",
+    borderRadius: 4,
+    backgroundColor: SKELETON_COLOR,
+  },
+  lineDate: {
+    height: 10,
+    width: "40%",
+    borderRadius: 4,
+    backgroundColor: SKELETON_COLOR,
+  },
+});
+
+export default EventCardSkeleton;

--- a/apps/mobile/components/__tests__/EventCardSkeleton-test.tsx
+++ b/apps/mobile/components/__tests__/EventCardSkeleton-test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { EventCardSkeleton } from "../EventCardSkeleton";
+
+/** Issue #1024 — event list skeleton loaders. */
+
+describe("EventCardSkeleton", () => {
+  it("renders the skeleton container", () => {
+    const { getByTestId } = render(<EventCardSkeleton />);
+    expect(getByTestId("event-card-skeleton")).toBeTruthy();
+  });
+
+  it("renders the thumbnail placeholder matching the event row layout", () => {
+    const { getByTestId } = render(<EventCardSkeleton />);
+    const container = getByTestId("event-card-skeleton");
+    // The container has 2 children: the thumb box and the text body.
+    expect(container.children.length).toBe(2);
+  });
+
+  it("is animated (starts the pulse loop)", () => {
+    // Animated.loop with useNativeDriver should not throw; the element
+    // must be present immediately so the list can swap it in without flicker.
+    const { getByTestId } = render(<EventCardSkeleton testID="skeleton-test" />);
+    expect(getByTestId("skeleton-test")).toBeTruthy();
+  });
+
+  it("accepts a custom testID", () => {
+    const { getByTestId } = render(<EventCardSkeleton testID="custom-skeleton" />);
+    expect(getByTestId("custom-skeleton")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a skeleton loading state for the event list on the Discover screen (issue #1024).

### Changes

- **`apps/mobile/components/EventCardSkeleton.tsx`** (new): A skeleton card that mimics the `EventRow` layout — a 64×64 rounded thumbnail on the left and three text lines on the right. A looping `Animated` pulse fades the skeleton between 30% and 70% opacity (1000 ms cycle) using the native driver, so the loop stays smooth and stops cleanly on unmount.
- **`apps/mobile/components/__tests__/EventCardSkeleton-test.tsx`** (new): Tests covering rendering, layout structure (thumb + body), and custom `testID` support.
- **`apps/mobile/app/discover.tsx`**: Replaces the single `ActivityIndicator` loader with a list of 4 `EventCardSkeleton` rows while the Discover feed loads, so the loading state matches the final layout instead of a spinner.

### Acceptance criteria

- ✅ Pulse loop runs smoothly without memory leaks — `animation.stop()` on unmount, `useNativeDriver: true`
- ✅ Skeleton alignment matches the event list card structure (64×64 thumb + 3 lines, same paddings/gaps as `EventRow`)

### Tests

```bash
cd apps/mobile
NODE_ENV=test npx jest --no-coverage components/__tests__/EventCardSkeleton-test.tsx
# 4 passed
```

Closes #1024