### PR TITLE
Add tests for ticket polling, events route, price parsing, and a dev seed script

### DIFF
--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -196,6 +196,30 @@ http://localhost:3000
 
 If you have not already installed workspace dependencies from the repo root, do that first with `pnpm install`.
 
+### Seed local development data
+
+The events shown in `lib/events-store.ts` are in-memory mock data only and
+never reach Postgres, so a fresh checkout starts with an empty database.
+Run the frontend's seed script to populate it with ~10 sample events across
+several categories (spanning past and future dates), a few organizer
+profiles, and a handful of tickets:
+
+```bash
+cd apps/web
+pnpm exec prisma db seed
+```
+
+Or, using the shortcut script:
+
+```bash
+pnpm --filter web run db:seed
+```
+
+This requires `DATABASE_URL` to be set (see `server/.env`) and the schema
+to already be migrated. The seed script (`apps/web/prisma/seed.ts`) uses
+`upsert` with fixed ids, so it is safe to run repeatedly -- re-running it
+will not create duplicate records.
+
 ## 7. Run Contract Tests
 
 Open another terminal and run the Soroban contract test suite:

--- a/apps/web/__tests__/api-events-route.test.ts
+++ b/apps/web/__tests__/api-events-route.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    event: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuthFromRequest: vi.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { getAuthFromRequest } from "@/lib/auth";
+import { GET } from "@/app/api/events/route";
+
+const findManyMock = prisma.event.findMany as unknown as ReturnType<
+  typeof vi.fn
+>;
+const getAuthMock = getAuthFromRequest as unknown as ReturnType<typeof vi.fn>;
+
+function makeRequest(pathAndQuery: string) {
+  return new NextRequest(`http://localhost:3000${pathAndQuery}`);
+}
+
+// A no-op params context, satisfying the RouteHandler<T> signature the
+// route is wrapped with (withErrorHandler always passes a context object).
+const emptyContext = { params: Promise.resolve({}) };
+
+describe("GET /api/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findManyMock.mockResolvedValue([]);
+    getAuthMock.mockReturnValue(null);
+  });
+
+  it("returns 400 for an invalid tab value", async () => {
+    const response = await GET(makeRequest("/api/events?tab=bogus"), emptyContext);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/invalid tab/i);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for type=my without auth", async () => {
+    getAuthMock.mockReturnValue(null);
+
+    const response = await GET(makeRequest("/api/events?type=my"), emptyContext);
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toMatch(/unauthorized/i);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("builds a startsAt: { lt: now } where-clause for type=my&tab=past", async () => {
+    getAuthMock.mockReturnValue({ email: "host@agora.dev" });
+
+    const before = new Date();
+    const response = await GET(
+      makeRequest("/api/events?type=my&tab=past"),
+      emptyContext,
+    );
+    const after = new Date();
+
+    expect(response.status).toBe(200);
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+
+    const callArg = findManyMock.mock.calls[0][0];
+    expect(callArg.where.hostEmail).toBe("host@agora.dev");
+    expect(callArg.where.startsAt).toHaveProperty("lt");
+    expect(callArg.where.startsAt.lt).toBeInstanceOf(Date);
+    expect(callArg.where.startsAt.lt.getTime()).toBeGreaterThanOrEqual(
+      before.getTime(),
+    );
+    expect(callArg.where.startsAt.lt.getTime()).toBeLessThanOrEqual(
+      after.getTime(),
+    );
+    expect(callArg.orderBy).toEqual({ startsAt: "asc" });
+
+    const body = await response.json();
+    expect(body.tab).toBe("past");
+    expect(body.type).toBe("my");
+  });
+
+  it("builds a startsAt: { gte: now } where-clause for type=my&tab=upcoming", async () => {
+    getAuthMock.mockReturnValue({ email: "host@agora.dev" });
+
+    const response = await GET(
+      makeRequest("/api/events?type=my&tab=upcoming"),
+      emptyContext,
+    );
+
+    expect(response.status).toBe(200);
+    const callArg = findManyMock.mock.calls[0][0];
+    expect(callArg.where.hostEmail).toBe("host@agora.dev");
+    expect(callArg.where.startsAt).toHaveProperty("gte");
+    expect(callArg.where.startsAt.gte).toBeInstanceOf(Date);
+    expect(callArg.orderBy).toEqual({ startsAt: "asc" });
+  });
+
+  it("treats type=my&tab=hosting the same as upcoming (gte now)", async () => {
+    getAuthMock.mockReturnValue({ email: "host@agora.dev" });
+
+    const response = await GET(
+      makeRequest("/api/events?type=my&tab=hosting"),
+      emptyContext,
+    );
+
+    expect(response.status).toBe(200);
+    const callArg = findManyMock.mock.calls[0][0];
+    expect(callArg.where.startsAt).toHaveProperty("gte");
+  });
+
+  it("returns all events ordered by startsAt ascending for the default (no params) path", async () => {
+    const events = [{ id: "1" }, { id: "2" }];
+    findManyMock.mockResolvedValue(events);
+
+    const response = await GET(makeRequest("/api/events"), emptyContext);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.items).toEqual(events);
+    expect(body.tab).toBe("upcoming");
+    expect(body.type).toBe("all");
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const callArg = findManyMock.mock.calls[0][0];
+    expect(callArg).toEqual({ orderBy: { startsAt: "asc" } });
+    expect(callArg.where).toBeUndefined();
+
+    // No real database should ever be touched -- the prisma client is fully
+    // mocked above via vi.mock("@/lib/prisma", ...).
+    expect(getAuthMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/parse-price-value.test.ts
+++ b/apps/web/__tests__/parse-price-value.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { parsePriceValue } from "@/lib/validation";
+
+describe("parsePriceValue", () => {
+  it("parses a plain number string", () => {
+    expect(parsePriceValue("25")).toBe(25);
+  });
+
+  it("parses a value with a dollar prefix", () => {
+    expect(parsePriceValue("$25")).toBe(25);
+  });
+
+  it("parses a value with a thousands separator", () => {
+    expect(parsePriceValue("$1,200")).toBe(1200);
+  });
+
+  it("parses a price range and returns the minimum value", () => {
+    expect(parsePriceValue("$10 - $50")).toBe(10);
+  });
+
+  it('parses the literal "free" (lowercase) as 0', () => {
+    expect(parsePriceValue("free")).toBe(0);
+  });
+
+  it('parses "Free" case-insensitively as 0', () => {
+    expect(parsePriceValue("Free")).toBe(0);
+  });
+
+  it('parses the literal "0" as 0', () => {
+    expect(parsePriceValue("0")).toBe(0);
+  });
+
+  it("returns 0 for an empty string", () => {
+    expect(parsePriceValue("")).toBe(0);
+  });
+
+  it("returns 0 for undefined input", () => {
+    expect(parsePriceValue(undefined as unknown as string)).toBe(0);
+  });
+
+  it("returns 0 for a whitespace-only string", () => {
+    expect(parsePriceValue("   ")).toBe(0);
+  });
+
+  it("returns 0 (not NaN) for a non-numeric string like 'TBA'", () => {
+    const result = parsePriceValue("TBA");
+    expect(result).toBe(0);
+    expect(Number.isNaN(result)).toBe(false);
+  });
+
+  it("returns 0 (not NaN) for other unparseable input", () => {
+    const result = parsePriceValue("call for pricing");
+    expect(result).toBe(0);
+    expect(Number.isNaN(result)).toBe(false);
+  });
+
+  it("handles a range without dollar signs, returning the minimum value", () => {
+    expect(parsePriceValue("10-50")).toBe(10);
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(parsePriceValue("  $25  ")).toBe(25);
+  });
+});

--- a/apps/web/__tests__/use-ticket-availability.test.tsx
+++ b/apps/web/__tests__/use-ticket-availability.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import type { ReactNode } from "react";
+import { useTicketAvailability } from "@/hooks/useTicketAvailability";
+
+const mockData = {
+  totalTickets: 100,
+  mintedTickets: 40,
+  availableTickets: 60,
+  isSoldOut: false,
+  percentageSold: 40,
+};
+
+/**
+ * Fresh SWR cache per test so polling/dedup state from one test can't leak
+ * into the next (mirrors the pattern used in useEventDetails.test.tsx).
+ */
+function createWrapper() {
+  return ({ children }: { children: ReactNode }) => (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("useTicketAvailability", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setVisibility("visible");
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Fail loudly if React ever warned about a state update on an
+    // unmounted component -- that's exactly the bug this hook must avoid.
+    const unmountWarning = consoleErrorSpy.mock.calls.some((args) =>
+      args.some(
+        (arg) =>
+          typeof arg === "string" &&
+          arg.includes("state update on an unmounted component"),
+      ),
+    );
+    expect(unmountWarning).toBe(false);
+
+    consoleErrorSpy.mockRestore();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches immediately on mount", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(
+      () => useTicketAvailability("evt_1", { pollInterval: 5000 }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/events/evt_1/availability",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    await waitFor(() => expect(result.current.data).toEqual(mockData));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeFalsy();
+  });
+
+  it("re-fetches after the polling interval elapses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useTicketAvailability("evt_2", { pollInterval: 5000 }), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops polling while hidden and resumes (with an immediate refetch) when visible again", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useTicketAvailability("evt_3", { pollInterval: 5000 }), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setVisibility("hidden");
+    });
+
+    // Plenty of time for several poll intervals to have elapsed, but the
+    // tab is hidden so no additional fetches should occur.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setVisibility("visible");
+    });
+
+    // Becoming visible again triggers an immediate re-fetch to catch missed
+    // updates.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Polling resumes on the configured interval afterwards.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops all timers and fetches after unmount", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { unmount } = renderHook(
+      () => useTicketAvailability("evt_4", { pollInterval: 5000 }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const callsBeforeUnmount = fetchMock.mock.calls.length;
+    expect(callsBeforeUnmount).toBeGreaterThan(0);
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(callsBeforeUnmount);
+  });
+
+  it("surfaces an error state without crashing when the fetch fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(
+      () => useTicketAvailability("evt_5", { pollInterval: 5000 }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,11 @@
     "storybook": "storybook dev -p 6006",
     "prebuild-storybook": "node ../../scripts/fix-storybook-next.js",
     "build-storybook": "storybook build",
-    "chromatic": "chromatic --exit-zero-on-changes"
+    "chromatic": "chromatic --exit-zero-on-changes",
+    "db:seed": "prisma db seed"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "^7.8.0",
@@ -65,6 +69,7 @@
     "prisma": "^7.8.0",
     "storybook": "^10.5.3",
     "tailwindcss": "^4",
+    "tsx": "^4.19.2",
     "typescript": "^5",
     "vite": "^7.0.0",
     "vitest": "^3.2.4",

--- a/apps/web/prisma/seed.ts
+++ b/apps/web/prisma/seed.ts
@@ -1,0 +1,323 @@
+/**
+ * Local development seed script.
+ *
+ * The in-memory mock data in `lib/events-store.ts` never reaches Postgres,
+ * so a fresh checkout has an empty database and pages like the wallet view
+ * or the organizer analytics dashboard have nothing to render.
+ *
+ * This script seeds a small, representative dataset directly through
+ * Prisma: ~10 events across several categories spanning past and future
+ * dates, a few organizer profiles, and a handful of tickets.
+ *
+ * All records use fixed ids and are written with `upsert`, so running this
+ * script multiple times (e.g. after `prisma migrate reset`) is safe and
+ * will not create duplicates.
+ *
+ * Usage:
+ *   pnpm --filter web exec prisma db seed
+ *   (or, from apps/web:  npx prisma db seed)
+ */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+/** Builds a deterministic, Stellar-looking public key (56 chars, starts with "G"). */
+function wallet(seed: string): string {
+  return `G${seed.toUpperCase()}`.padEnd(56, "X").slice(0, 56);
+}
+
+const ORGANIZER_WALLETS = {
+  stellarWestAfrica: wallet("STELLARWESTAFRICA"),
+  agoraBuilders: wallet("AGORABUILDERS"),
+  fintechOrbit: wallet("FINTECHORBIT"),
+};
+
+const organizerProfiles = [
+  {
+    address: ORGANIZER_WALLETS.stellarWestAfrica,
+    displayName: "Stellar West Africa",
+    bio: "Community-run meetups and workshops for builders on Stellar.",
+    avatarUrl: "/images/organizers/stellar-west-africa.png",
+    socials: { twitter: "https://x.com/stellarwestafrica" },
+  },
+  {
+    address: ORGANIZER_WALLETS.agoraBuilders,
+    displayName: "Agora Builders",
+    bio: "Networking and demo nights for the local ecosystem.",
+    avatarUrl: "/images/organizers/agora-builders.png",
+    socials: { website: "https://agora.dev" },
+  },
+  {
+    address: ORGANIZER_WALLETS.fintechOrbit,
+    displayName: "Fintech Orbit",
+    bio: "Panels and summits on the future of payments.",
+    avatarUrl: "/images/organizers/fintech-orbit.png",
+    socials: { twitter: "https://x.com/fintechorbit" },
+  },
+];
+
+// Fixed ids keep this script idempotent across repeated runs.
+const events = [
+  {
+    id: "seed-event-dev-meetup-past",
+    title: "Stellar Developer Meetup",
+    description: "Hands-on workshop for building with Stellar tooling.",
+    startsAt: new Date("2026-05-01T18:00:00.000Z"), // past
+    location: "Lagos",
+    category: "Tech",
+    organizerName: "Stellar West Africa",
+    organizerWallet: ORGANIZER_WALLETS.stellarWestAfrica,
+    imageUrl: "/images/event1.png",
+    ticketPrice: 0,
+    totalTickets: 200,
+    mintedTickets: 178,
+    hostEmail: "host@agora.dev",
+  },
+  {
+    id: "seed-event-builder-night-past",
+    title: "Community Builder Night",
+    description: "Networking event for local ecosystem builders.",
+    startsAt: new Date("2026-03-01T17:00:00.000Z"), // past
+    location: "Online",
+    category: "Party",
+    organizerName: "Agora Builders",
+    organizerWallet: ORGANIZER_WALLETS.agoraBuilders,
+    imageUrl: "/images/event2.png",
+    ticketPrice: 15,
+    totalTickets: 120,
+    mintedTickets: 120,
+    followersOnly: true,
+    hostEmail: "community@agora.dev",
+  },
+  {
+    id: "seed-event-payments-summit-future",
+    title: "Future of Payments Summit",
+    description: "Panel and demos on modern payment rails.",
+    startsAt: new Date("2026-10-20T09:00:00.000Z"), // future
+    location: "London",
+    category: "Crypto",
+    organizerName: "Fintech Orbit",
+    organizerWallet: ORGANIZER_WALLETS.fintechOrbit,
+    imageUrl: "/images/event3.png",
+    ticketPrice: 30,
+    totalTickets: 400,
+    mintedTickets: 40,
+    hostEmail: "payments@agora.dev",
+  },
+  {
+    id: "seed-event-summer-music-fest-future",
+    title: "Summer Music Festival",
+    description: "An open-air festival featuring local and touring acts.",
+    startsAt: new Date("2026-09-12T16:00:00.000Z"), // future
+    location: "Accra",
+    category: "Music",
+    organizerName: "Agora Builders",
+    organizerWallet: ORGANIZER_WALLETS.agoraBuilders,
+    imageUrl: "/images/event2.png",
+    ticketPrice: 40,
+    totalTickets: 500,
+    mintedTickets: 210,
+    hostEmail: "community@agora.dev",
+  },
+  {
+    id: "seed-event-art-walk-past",
+    title: "Downtown Art Walk",
+    description: "Self-guided tour through local galleries and pop-up shows.",
+    startsAt: new Date("2026-02-14T15:00:00.000Z"), // past
+    location: "Nairobi",
+    category: "Art",
+    organizerName: "Stellar West Africa",
+    organizerWallet: ORGANIZER_WALLETS.stellarWestAfrica,
+    imageUrl: "/images/event1.png",
+    ticketPrice: 0,
+    totalTickets: 150,
+    mintedTickets: 96,
+    hostEmail: "host@agora.dev",
+  },
+  {
+    id: "seed-event-charity-run-future",
+    title: "Charity 5K Fun Run",
+    description: "A community run supporting local education initiatives.",
+    startsAt: new Date("2026-11-08T07:00:00.000Z"), // future
+    location: "Kigali",
+    category: "Sports",
+    organizerName: "Agora Builders",
+    organizerWallet: ORGANIZER_WALLETS.agoraBuilders,
+    imageUrl: "/images/event2.png",
+    ticketPrice: 10,
+    totalTickets: 300,
+    mintedTickets: 55,
+    hostEmail: "community@agora.dev",
+  },
+  {
+    id: "seed-event-food-festival-future",
+    title: "Street Food Festival",
+    description: "A weekend celebration of regional street food vendors.",
+    startsAt: new Date("2026-09-26T11:00:00.000Z"), // future
+    location: "Lagos",
+    category: "Food",
+    organizerName: "Stellar West Africa",
+    organizerWallet: ORGANIZER_WALLETS.stellarWestAfrica,
+    imageUrl: "/images/event1.png",
+    ticketPrice: 5,
+    totalTickets: 600,
+    mintedTickets: 312,
+    hostEmail: "host@agora.dev",
+  },
+  {
+    id: "seed-event-founders-forum-past",
+    title: "Founders Forum",
+    description: "A closed-door working session for early-stage founders.",
+    startsAt: new Date("2026-04-18T13:00:00.000Z"), // past
+    location: "Cape Town",
+    category: "Business",
+    organizerName: "Fintech Orbit",
+    organizerWallet: ORGANIZER_WALLETS.fintechOrbit,
+    imageUrl: "/images/event3.png",
+    ticketPrice: 50,
+    totalTickets: 80,
+    mintedTickets: 80,
+    followersOnly: true,
+    hostEmail: "payments@agora.dev",
+  },
+  {
+    id: "seed-event-wellness-retreat-future",
+    title: "Mindfulness & Wellness Retreat",
+    description: "A day of guided sessions on stress management and health.",
+    startsAt: new Date("2026-12-05T08:00:00.000Z"), // future
+    location: "Zanzibar",
+    category: "Health",
+    organizerName: "Agora Builders",
+    organizerWallet: ORGANIZER_WALLETS.agoraBuilders,
+    imageUrl: "/images/event2.png",
+    ticketPrice: 60,
+    totalTickets: 100,
+    mintedTickets: 18,
+    hostEmail: "community@agora.dev",
+  },
+  {
+    id: "seed-event-web3-bootcamp-future",
+    title: "Web3 Bootcamp",
+    description: "A three-day intensive on building on Soroban and Stellar.",
+    startsAt: new Date("2026-10-05T09:00:00.000Z"), // future
+    location: "Online",
+    category: "Education",
+    organizerName: "Stellar West Africa",
+    organizerWallet: ORGANIZER_WALLETS.stellarWestAfrica,
+    imageUrl: "/images/event1.png",
+    ticketPrice: 0,
+    totalTickets: 1000,
+    mintedTickets: 430,
+    hostEmail: "host@agora.dev",
+  },
+];
+
+const tickets = [
+  {
+    id: "seed-ticket-01",
+    eventId: "seed-event-dev-meetup-past",
+    buyerWallet: wallet("BUYERALICE"),
+    ownerWallet: wallet("BUYERALICE"),
+    quantity: 2,
+    utmSource: "twitter",
+    utmMedium: "social",
+    utmCampaign: "dev-meetup-launch",
+  },
+  {
+    id: "seed-ticket-02",
+    eventId: "seed-event-dev-meetup-past",
+    buyerWallet: wallet("BUYERBOB"),
+    ownerWallet: wallet("BUYERBOB"),
+    quantity: 1,
+  },
+  {
+    id: "seed-ticket-03",
+    eventId: "seed-event-builder-night-past",
+    buyerWallet: wallet("BUYERCARLA"),
+    ownerWallet: wallet("BUYERCARLA"),
+    quantity: 3,
+    utmSource: "newsletter",
+    utmMedium: "email",
+    utmCampaign: "builder-night",
+  },
+  {
+    id: "seed-ticket-04",
+    eventId: "seed-event-payments-summit-future",
+    buyerWallet: wallet("BUYERDAVID"),
+    ownerWallet: wallet("BUYERDAVID"),
+    quantity: 1,
+  },
+  {
+    id: "seed-ticket-05",
+    eventId: "seed-event-summer-music-fest-future",
+    buyerWallet: wallet("BUYERELLA"),
+    // Gifted to a different wallet than the buyer.
+    ownerWallet: wallet("RECIPIENTFRANK"),
+    quantity: 2,
+    utmSource: "instagram",
+    utmMedium: "social",
+    utmCampaign: "summer-music-fest",
+  },
+  {
+    id: "seed-ticket-06",
+    eventId: "seed-event-web3-bootcamp-future",
+    buyerWallet: wallet("BUYERGRACE"),
+    ownerWallet: wallet("BUYERGRACE"),
+    quantity: 1,
+  },
+];
+
+const analyticsEvents = [
+  { id: "seed-analytics-01", eventId: "seed-event-dev-meetup-past", type: "view" },
+  { id: "seed-analytics-02", eventId: "seed-event-dev-meetup-past", type: "purchase" },
+  { id: "seed-analytics-03", eventId: "seed-event-summer-music-fest-future", type: "view" },
+  { id: "seed-analytics-04", eventId: "seed-event-summer-music-fest-future", type: "purchase" },
+  { id: "seed-analytics-05", eventId: "seed-event-web3-bootcamp-future", type: "view" },
+];
+
+async function main() {
+  for (const profile of organizerProfiles) {
+    await prisma.organizerProfile.upsert({
+      where: { address: profile.address },
+      update: profile,
+      create: profile,
+    });
+  }
+  console.log(`Seeded ${organizerProfiles.length} organizer profiles.`);
+
+  for (const event of events) {
+    await prisma.event.upsert({
+      where: { id: event.id },
+      update: event,
+      create: event,
+    });
+  }
+  console.log(`Seeded ${events.length} events.`);
+
+  for (const ticket of tickets) {
+    await prisma.ticket.upsert({
+      where: { id: ticket.id },
+      update: ticket,
+      create: ticket,
+    });
+  }
+  console.log(`Seeded ${tickets.length} tickets.`);
+
+  for (const analyticsEvent of analyticsEvents) {
+    await prisma.analyticsEvent.upsert({
+      where: { id: analyticsEvent.id },
+      update: analyticsEvent,
+      create: analyticsEvent,
+    });
+  }
+  console.log(`Seeded ${analyticsEvents.length} analytics events.`);
+}
+
+main()
+  .catch((error) => {
+    console.error("Seed failed:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Closes #1292
Closes #1291
Closes #1289
Closes #1288

## Summary

This PR batches four small, independent additions:

- **#1292 - `useTicketAvailability` polling hook tests** (`apps/web/__tests__/use-ticket-availability.test.tsx`): uses `renderHook` + Vitest fake timers to verify the initial fetch on mount, re-fetching on the polling interval, pausing polling when `document.visibilityState` becomes `"hidden"` and resuming (with an immediate refetch) on `"visible"`, no timers/fetches firing after unmount, and that a failed fetch surfaces an error state instead of throwing. Each test asserts no "state update on an unmounted component" warning was logged.
- **#1291 - `GET /api/events` route handler tests** (`apps/web/__tests__/api-events-route.test.ts`): fully mocks `@/lib/prisma` and `@/lib/auth` via `vi.mock` (no real DB connection is ever opened) and covers the 400 on an invalid `tab`, the 401 for `type=my` without auth, the `startsAt: { lt: now }` / `{ gte: now }` where-clauses built for `tab=past` / `tab=upcoming` (and `hosting`), and the default path returning all events ordered by `startsAt` ascending.
- **#1289 - `parsePriceValue` unit tests** (`apps/web/__tests__/parse-price-value.test.ts`): covers plain numbers, `$` prefixes, thousands separators, ranges (asserting the minimum is returned), `"free"`/`"Free"`/`"0"`, and edge cases (empty string, `undefined`, whitespace-only, non-numeric input) asserting `0` rather than `NaN` is returned.
- **#1288 - Local dev seed script** (`apps/web/prisma/seed.ts`): seeds ~10 events across several categories spanning past and future dates, 3 organizer profiles, a handful of tickets, and a few analytics events, all via idempotent `upsert` calls keyed on fixed ids. Registered under `"prisma": { "seed": "tsx prisma/seed.ts" }` in `apps/web/package.json` (added `tsx` as a dev dependency, since neither `tsx` nor `ts-node` was present), with a `db:seed` script shortcut, and documented in `DEVELOPMENT_SETUP.md`.

## Test plan

- [ ] `pnpm --filter web test` runs the three new Vitest suites and they pass
- [ ] `pnpm --filter web exec prisma db seed` populates events/organizer profiles/tickets/analytics events against a migrated local Postgres database, and can be re-run safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wxp7wTANcFYARsQrFN9ZmE