### PR TITLE
Db/event schema hardening

### DIFF
--- a/apps/web/app/api/events/route.ts
+++ b/apps/web/app/api/events/route.ts
@@ -40,6 +40,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   }
 
   const items = await prisma.event.findMany({
+    where: { status: "PUBLISHED" },
     orderBy: { startsAt: "asc" },
   });
 

--- a/apps/web/app/api/events/route.ts
+++ b/apps/web/app/api/events/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { type Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { getAuthFromRequest } from "@/lib/auth";
 import { withErrorHandler } from "@/lib/api-handler";
 import { throwApiError } from "@/lib/api-errors";
+import { slugify, withRandomSuffix } from "@/lib/slugify";
 
 const VALID_TABS = new Set(["upcoming", "hosting", "past"]);
 
@@ -67,22 +68,44 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     }
   }
 
-  const created = await prisma.event.create({
-    data: {
-      title: payload.title as string,
-      description: typeof payload.description === "string" ? payload.description : "",
-      startsAt: new Date(payload.startsAt as string),
-      location: payload.location as string,
-      category: payload.category as string,
-      organizerName: payload.organizerName as string,
-      organizerWallet: payload.organizerWallet as string,
-      imageUrl: typeof payload.imageUrl === "string" ? payload.imageUrl : undefined,
-      ticketPrice: typeof payload.ticketPrice === "number" ? payload.ticketPrice : 0,
-      totalTickets: typeof payload.totalTickets === "number" ? payload.totalTickets : 100,
-      followersOnly: typeof payload.followersOnly === "boolean" ? payload.followersOnly : false,
-      hostEmail: auth.email,
-    },
-  });
+  const baseSlug = slugify(payload.title as string);
+  let slug = baseSlug;
+  let created;
+
+  // Retry with a random suffix instead of failing the insert on a slug collision.
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      created = await prisma.event.create({
+        data: {
+          slug,
+          title: payload.title as string,
+          description: typeof payload.description === "string" ? payload.description : "",
+          startsAt: new Date(payload.startsAt as string),
+          location: payload.location as string,
+          category: payload.category as string,
+          organizerName: payload.organizerName as string,
+          organizerWallet: payload.organizerWallet as string,
+          imageUrl: typeof payload.imageUrl === "string" ? payload.imageUrl : undefined,
+          ticketPrice: typeof payload.ticketPrice === "number" ? payload.ticketPrice : 0,
+          totalTickets: typeof payload.totalTickets === "number" ? payload.totalTickets : 100,
+          followersOnly: typeof payload.followersOnly === "boolean" ? payload.followersOnly : false,
+          hostEmail: auth.email,
+        },
+      });
+      break;
+    } catch (error) {
+      const isSlugConflict =
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002" &&
+        (error.meta?.target as string[] | undefined)?.includes("slug");
+
+      if (!isSlugConflict || attempt >= 4) {
+        throw error;
+      }
+
+      slug = withRandomSuffix(baseSlug);
+    }
+  }
 
   return NextResponse.json({ event: created }, { status: 201 });
 });

--- a/apps/web/lib/events-store.ts
+++ b/apps/web/lib/events-store.ts
@@ -3,6 +3,7 @@ export type EventRecord = {
   title: string;
   description: string;
   startsAt: string;
+  endsAt?: string;
   location: string;
   category: string;
   organizerName: string;
@@ -19,6 +20,7 @@ type CreateEventInput = {
   title: string;
   description?: string;
   startsAt: string;
+  endsAt?: string;
   location: string;
   category: string;
   organizerName: string;
@@ -92,6 +94,7 @@ export function createEvent(input: CreateEventInput, hostEmail: string): EventRe
     title: input.title,
     description: input.description || "",
     startsAt: input.startsAt,
+    endsAt: input.endsAt,
     location: input.location,
     category: input.category,
     organizerName: input.organizerName,

--- a/apps/web/lib/slugify.ts
+++ b/apps/web/lib/slugify.ts
@@ -1,0 +1,29 @@
+const MAX_SLUG_LENGTH = 80;
+const SUFFIX_LENGTH = 6;
+
+/**
+ * Converts a title into a URL-safe slug: lowercase, diacritics stripped,
+ * non-alphanumeric runs collapsed into single hyphens, trimmed to 80 characters.
+ */
+export function slugify(title: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, "");
+
+  return slug || "event";
+}
+
+/**
+ * Appends a short random suffix to a slug, used to recover from a unique
+ * constraint collision instead of failing the insert.
+ */
+export function withRandomSuffix(slug: string): string {
+  const suffix = Math.random().toString(36).slice(2, 2 + SUFFIX_LENGTH);
+  const base = slug.slice(0, MAX_SLUG_LENGTH - SUFFIX_LENGTH - 1).replace(/-+$/g, "");
+  return `${base}-${suffix}`;
+}

--- a/apps/web/prisma/migrations/20260826000001_add_event_ends_at/migration.sql
+++ b/apps/web/prisma/migrations/20260826000001_add_event_ends_at/migration.sql
@@ -1,0 +1,7 @@
+-- Add an optional end time to Event (Issue #1283)
+ALTER TABLE "Event" ADD COLUMN "endsAt" TIMESTAMP(3);
+
+-- An end time, when present, must come after the start time.
+ALTER TABLE "Event"
+ADD CONSTRAINT "Event_endsAt_after_startsAt_check"
+CHECK ("endsAt" IS NULL OR "endsAt" > "startsAt");

--- a/apps/web/prisma/migrations/20260826000002_add_event_status/migration.sql
+++ b/apps/web/prisma/migrations/20260826000002_add_event_status/migration.sql
@@ -1,0 +1,8 @@
+-- Add a lifecycle status to Event (Issue #1284)
+CREATE TYPE "EventStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'CANCELLED');
+
+-- Existing rows are all live, so they backfill to PUBLISHED via the default.
+ALTER TABLE "Event"
+ADD COLUMN "status" "EventStatus" NOT NULL DEFAULT 'PUBLISHED';
+
+CREATE INDEX "Event_status_startsAt_idx" ON "Event"("status", "startsAt");

--- a/apps/web/prisma/migrations/20260826000003_add_event_slug/migration.sql
+++ b/apps/web/prisma/migrations/20260826000003_add_event_slug/migration.sql
@@ -1,0 +1,24 @@
+-- Add a unique, human-readable slug to Event (Issue #1286)
+ALTER TABLE "Event" ADD COLUMN "slug" TEXT;
+
+-- Backfill from the title using the same rules as lib/slugify.ts.
+UPDATE "Event"
+SET "slug" = NULLIF(
+    trim(both '-' from left(regexp_replace(lower("title"), '[^a-z0-9]+', '-', 'g'), 80)),
+    ''
+);
+
+UPDATE "Event" SET "slug" = 'event' WHERE "slug" IS NULL;
+
+-- Disambiguate titles that collapse to the same slug.
+UPDATE "Event" AS e
+SET "slug" = trim(both '-' from left(e."slug", 73)) || '-' || substr(md5(e."id"), 1, 6)
+FROM (
+    SELECT "id", row_number() OVER (PARTITION BY "slug" ORDER BY "createdAt", "id") AS rn
+    FROM "Event"
+) AS dup
+WHERE dup."id" = e."id" AND dup.rn > 1;
+
+ALTER TABLE "Event" ALTER COLUMN "slug" SET NOT NULL;
+
+CREATE UNIQUE INDEX "Event_slug_key" ON "Event"("slug");

--- a/apps/web/prisma/migrations/20260826000004_add_ticket_event_stellar_unique/migration.sql
+++ b/apps/web/prisma/migrations/20260826000004_add_ticket_event_stellar_unique/migration.sql
@@ -1,0 +1,25 @@
+-- Prevent duplicate on-chain tickets for the same event (Issue #1287)
+-- Rows with a null "stellarId" are excluded and stay unaffected.
+DO $$
+DECLARE
+    duplicates TEXT;
+BEGIN
+    SELECT string_agg(format('(%s, %s) x%s', "eventId", "stellarId", n), ', ')
+    INTO duplicates
+    FROM (
+        SELECT "eventId", "stellarId", count(*) AS n
+        FROM "Ticket"
+        WHERE "stellarId" IS NOT NULL
+        GROUP BY "eventId", "stellarId"
+        HAVING count(*) > 1
+    ) AS d;
+
+    IF duplicates IS NOT NULL THEN
+        RAISE EXCEPTION 'Cannot create Ticket_eventId_stellarId_key: duplicate (eventId, stellarId) pairs exist: %', duplicates;
+    END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX "Ticket_eventId_stellarId_key"
+ON "Ticket"("eventId", "stellarId")
+WHERE "stellarId" IS NOT NULL;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -18,10 +18,10 @@ enum EventStatus {
 }
 
 model Event {
-  id              String   @id @default(uuid())
+  id              String           @id @default(uuid())
   title           String
-  slug            String   @unique
-  description     String   @default("")
+  slug            String           @unique
+  description     String           @default("")
   startsAt        DateTime
   endsAt          DateTime?
   location        String
@@ -32,15 +32,15 @@ model Event {
   category        String
   organizerName   String
   organizerWallet String
-  imageUrl        String   @default("/images/event1.png")
-  ticketPrice     Float    @default(0)
-  totalTickets    Int      @default(100)
-  mintedTickets   Int      @default(0)
-  followersOnly   Boolean  @default(false)
+  imageUrl        String           @default("/images/event1.png")
+  ticketPrice     Float            @default(0)
+  totalTickets    Int              @default(100)
+  mintedTickets   Int              @default(0)
+  followersOnly   Boolean          @default(false)
   hostEmail       String
-  status          EventStatus @default(PUBLISHED)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  status          EventStatus      @default(PUBLISHED)
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
   tickets         Ticket[]
   analyticsEvents AnalyticsEvent[]
 
@@ -59,6 +59,10 @@ model Ticket {
   utmMedium   String?  @db.VarChar(255)
   utmCampaign String?  @db.VarChar(255)
   createdAt   DateTime @default(now())
+
+  /// Guards against a retried mint or a duplicated indexer event inserting the
+  /// same on-chain ticket twice. Rows with a null stellarId are unaffected.
+  @@unique([eventId, stellarId])
 }
 
 /// Organizer brand profile keyed by Stellar wallet address.

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -16,6 +16,7 @@ model Event {
   title           String
   description     String   @default("")
   startsAt        DateTime
+  endsAt          DateTime?
   location        String
   /// Optional WGS84 latitude for map discovery (-90 to 90).
   latitude        Float?

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -20,6 +20,7 @@ enum EventStatus {
 model Event {
   id              String   @id @default(uuid())
   title           String
+  slug            String   @unique
   description     String   @default("")
   startsAt        DateTime
   endsAt          DateTime?

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -11,6 +11,12 @@ datasource db {
   provider = "postgresql"
 }
 
+enum EventStatus {
+  DRAFT
+  PUBLISHED
+  CANCELLED
+}
+
 model Event {
   id              String   @id @default(uuid())
   title           String
@@ -31,10 +37,13 @@ model Event {
   mintedTickets   Int      @default(0)
   followersOnly   Boolean  @default(false)
   hostEmail       String
+  status          EventStatus @default(PUBLISHED)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
   tickets         Ticket[]
   analyticsEvents AnalyticsEvent[]
+
+  @@index([status, startsAt])
 }
 
 model Ticket {

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -157,6 +157,12 @@ Individual tickets purchased by users.
 | `created_at` | TIMESTAMPTZ | NOT NULL, default `NOW()` | Record creation time |
 | `updated_at` | TIMESTAMPTZ | NOT NULL, default `NOW()` | Last update time (auto-managed by trigger) |
 
+**Constraints**
+
+| Name | Definition | Purpose |
+|---|---|---|
+| `tickets_event_id_stellar_id_key` | `UNIQUE (event_id, stellar_id) WHERE stellar_id IS NOT NULL` | Rejects a second row for an on-chain ticket already synced for the same event, so a retried mint or a duplicated indexer event cannot inflate `minted_tickets`. Rows with a null `stellar_id` are unaffected. |
+
 ---
 
 ### `transactions`

--- a/server/migrations/20260826000001_add_events_end_time_check.sql
+++ b/server/migrations/20260826000001_add_events_end_time_check.sql
@@ -1,0 +1,5 @@
+-- Enforce that an event's end time, when set, comes after its start time (Issue #1283).
+-- `events.end_time` already exists and stays nullable, so existing rows are unaffected.
+ALTER TABLE events
+    ADD CONSTRAINT events_end_time_after_start_time_check
+    CHECK (end_time IS NULL OR end_time > start_time);

--- a/server/migrations/20260826000002_add_events_status.sql
+++ b/server/migrations/20260826000002_add_events_status.sql
@@ -1,0 +1,14 @@
+-- Add a lifecycle status to events (Issue #1284).
+-- Existing rows backfill to 'PUBLISHED' via the column default.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'event_status') THEN
+        CREATE TYPE event_status AS ENUM ('DRAFT', 'PUBLISHED', 'CANCELLED');
+    END IF;
+END
+$$;
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS status event_status NOT NULL DEFAULT 'PUBLISHED';
+
+CREATE INDEX IF NOT EXISTS events_status_start_time_idx ON events (status, start_time);

--- a/server/migrations/20260826000003_add_events_slug.sql
+++ b/server/migrations/20260826000003_add_events_slug.sql
@@ -1,0 +1,24 @@
+-- Add a unique, human-readable slug to events (Issue #1286).
+ALTER TABLE events ADD COLUMN IF NOT EXISTS slug TEXT;
+
+UPDATE events
+SET slug = NULLIF(
+    trim(both '-' from left(regexp_replace(lower(title), '[^a-z0-9]+', '-', 'g'), 80)),
+    ''
+)
+WHERE slug IS NULL;
+
+UPDATE events SET slug = 'event' WHERE slug IS NULL;
+
+-- Disambiguate titles that collapse to the same slug.
+UPDATE events AS e
+SET slug = trim(both '-' from left(e.slug, 73)) || '-' || substr(md5(e.id::text), 1, 6)
+FROM (
+    SELECT id, row_number() OVER (PARTITION BY slug ORDER BY created_at, id) AS rn
+    FROM events
+) AS dup
+WHERE dup.id = e.id AND dup.rn > 1;
+
+ALTER TABLE events ALTER COLUMN slug SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS events_slug_key ON events (slug);

--- a/server/migrations/20260826000004_add_tickets_event_stellar_unique.sql
+++ b/server/migrations/20260826000004_add_tickets_event_stellar_unique.sql
@@ -1,0 +1,29 @@
+-- no-transaction
+-- Prevent duplicate on-chain tickets for the same event (Issue #1287).
+-- `tickets_stellar_id_idx` (20260728000002) only covers stellar_id on its own,
+-- so this partial index on (event_id, stellar_id) is not a duplicate of it.
+-- Rows with a null stellar_id are excluded and stay unaffected.
+DO $$
+DECLARE
+    duplicates TEXT;
+BEGIN
+    SELECT string_agg(format('(%s, %s) x%s', event_id, stellar_id, n), ', ')
+    INTO duplicates
+    FROM (
+        SELECT event_id, stellar_id, count(*) AS n
+        FROM tickets
+        WHERE stellar_id IS NOT NULL
+        GROUP BY event_id, stellar_id
+        HAVING count(*) > 1
+    ) AS d;
+
+    IF duplicates IS NOT NULL THEN
+        RAISE EXCEPTION 'Cannot create tickets_event_id_stellar_id_key: duplicate (event_id, stellar_id) pairs exist: %', duplicates;
+    END IF;
+END
+$$;
+
+-- CONCURRENTLY so the index build does not lock tickets on a live database.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS tickets_event_id_stellar_id_key
+    ON tickets (event_id, stellar_id)
+    WHERE stellar_id IS NOT NULL;


### PR DESCRIPTION
What changed per issue

- #1283 — endsAt DateTime? on Event; Prisma migration adds the column plus a endsAt IS NULL OR endsAt > startsAt check; server migration adds the equivalent check on the existing events.end_time; EventRecord/CreateEventInput mirror the field. server/src/models/event.rs already had end_time: Option<DateTime<Utc>>, so no Rust change was needed.
- #1284 — EventStatus enum, status @default(PUBLISHED), composite [status, startsAt] index, matching SQL migration on the Rust side, and the public listing in app/api/events/route.ts:41 now filters to PUBLISHED (the type=my host view still shows drafts/cancelled).
- #1286 — slug String @unique, new apps/web/lib/slugify.ts (slugify + withRandomSuffix), backfill migrations for both schemas that slugify titles and disambiguate collisions with an id-derived suffix, and the create route generates a slug with retry-on-P2002 so an insert never fails on collision.
- #1287 — partial unique index on (eventId, stellarId) WHERE stellarId IS NOT NULL; the server migration is -- no-transaction + CONCURRENTLY and raises a listing of pre-existing duplicate pairs before building the index; documented in docs/DATABASE_SCHEMA.md. tickets_stellar_id_idx from 20260728000002 covers stellar_id alone, so this isn't a duplicate.

Two things to flag: prisma format/generate could not run (no network to the npm registry), so the schema is hand-aligned and the client isn't regenerated — status/slug typings will only resolve after a prisma generate. And the Prisma @@unique([eventId, stellarId]) is non-partial in the schema while the actual index is rate diff may notice that divergence.

PR description

## Summary

Four self-contained schema changes to `Event` and `Ticket`, one commit each.

- **`endsAt` on `Event`** — nullable end time with a `ends_at > starts_at` check constraint, mirrs` table and in `EventRecord`.
- **`status` on `Event`** — a `DRAFT`/`PUBLISHED`/`CANCELLED` enum defaulting to `PUBLISHED` so existing rows keep working, with a composite `[status, startsAt]` index. Public event listings now exclude drafts and cancelled events; the host's own `?type=my` listing still shows them.
- **`slug` on `Event`** — unique, human-readable slugs for `/events/stellar-developer-meetup-lagoify.ts` helper, migrations that backfill every existing row and disambiguate collisions, andcollision-safe slug generation on create.
- **Unique `(eventId, stellarId)` on `Ticket`** — partial unique index (nulls unaffected) so a retried mint or duplicated indexer event can't create phantom tickets that inflate `mintedTickets`.

## Notes

- Every migration is written for both `apps/web/prisma/migrations/` and `server/migrations/`.
- The ticket index is created `CONCURRENTLY` in a `-- no-transaction` migration so it doesn't lock `tickets` on a live database, and the migration raises a listing of any pre-existing duplicate pairs rather than failing opaquely.
- `server/src/models/event.rs` already carried `end_time: Option<DateTime<Utc>>`, so no Rust modee end-time work.
- `prisma generate` has not been run here; `status` and `slug` typings resolve after the client is regenerated.

Closes #1283
Closes #1284
Closes #1286
Closes #1287