### PR TITLE
feat(frontend): add live character counter to event description (Closes #1236)

### DIFF
--- a/apps/web/__tests__/create-event-form.test.tsx
+++ b/apps/web/__tests__/create-event-form.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { expect, afterEach, describe, it, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import CreateEventForm from "@/components/events/create-event-form";
+import { MAX_DESCRIPTION_LENGTH } from "@/lib/validation";
+
+// Mock next/image
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    width,
+    height,
+  }: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+  }) => <img src={src} alt={alt} width={width} height={height} />,
+}));
+
+describe("CreateEventForm character counter", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the character counter and links it to the textarea", () => {
+    render(<CreateEventForm />);
+
+    const textarea = screen.getByLabelText(/Add Description/i);
+    expect(textarea).toHaveAttribute(
+      "aria-describedby",
+      "description-character-count",
+    );
+    expect(textarea).toHaveAttribute(
+      "maxlength",
+      String(MAX_DESCRIPTION_LENGTH),
+    );
+
+    const counter = screen.getByText(
+      new RegExp(`0 / ${MAX_DESCRIPTION_LENGTH.toLocaleString()}`),
+    );
+    expect(counter).toBeInTheDocument();
+  });
+
+  it("updates the counter as the user types", () => {
+    render(<CreateEventForm />);
+
+    const textarea = screen.getByLabelText(/Add Description/i);
+    fireEvent.change(textarea, { target: { value: "hello" } });
+
+    const counter = screen.getByText(
+      new RegExp(`5 / ${MAX_DESCRIPTION_LENGTH.toLocaleString()}`),
+    );
+    expect(counter).toBeInTheDocument();
+  });
+
+  it("switches to amber styling at 90% of the limit", () => {
+    render(<CreateEventForm />);
+
+    const ninetyPercent = Math.floor(MAX_DESCRIPTION_LENGTH * 0.9);
+    const textarea = screen.getByLabelText(/Add Description/i);
+    fireEvent.change(textarea, {
+      target: { value: "x".repeat(ninetyPercent) },
+    });
+
+    const counter = screen.getByText(
+      new RegExp(`${ninetyPercent.toLocaleString()} /`),
+    );
+    expect(counter).toHaveClass("text-amber-500");
+  });
+
+  it("switches to red styling at 100% of the limit", () => {
+    render(<CreateEventForm />);
+
+    const textarea = screen.getByLabelText(/Add Description/i);
+    fireEvent.change(textarea, {
+      target: { value: "x".repeat(MAX_DESCRIPTION_LENGTH) },
+    });
+
+    const counter = screen.getByText(
+      new RegExp(`${MAX_DESCRIPTION_LENGTH.toLocaleString()} /`),
+    );
+    expect(counter).toHaveClass("text-red-500");
+  });
+});

--- a/apps/web/__tests__/create-event-schema.test.ts
+++ b/apps/web/__tests__/create-event-schema.test.ts
@@ -14,7 +14,10 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { createEventSchema } from "@/lib/validation";
+import {
+  createEventSchema,
+  MAX_DESCRIPTION_LENGTH,
+} from "@/lib/validation";
 
 /** A minimal payload that satisfies every required field in the schema. */
 function validPayload(overrides: Record<string, unknown> = {}) {
@@ -106,5 +109,35 @@ describe("createEventSchema", () => {
       expect(visibilityIssue?.message).toMatch(/Public/);
       expect(visibilityIssue?.message).toMatch(/Private/);
     }
+  });
+
+  it("accepts a description at the max length", () => {
+    const result = createEventSchema.safeParse(
+      validPayload({ description: "x".repeat(MAX_DESCRIPTION_LENGTH) })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a description longer than the max length", () => {
+    const result = createEventSchema.safeParse(
+      validPayload({ description: "x".repeat(MAX_DESCRIPTION_LENGTH + 1) })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const descriptionIssue = result.error.issues.find((issue) =>
+        issue.path.includes("description")
+      );
+      expect(descriptionIssue).toBeDefined();
+      expect(descriptionIssue?.message).toMatch(
+        new RegExp(String(MAX_DESCRIPTION_LENGTH))
+      );
+    }
+  });
+
+  it("treats a missing description as optional", () => {
+    const result = createEventSchema.safeParse(
+      validPayload({ description: undefined })
+    );
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/web/components/events/create-event-form.tsx
+++ b/apps/web/components/events/create-event-form.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import { useState } from "react";
+import { MAX_DESCRIPTION_LENGTH } from "@/lib/validation";
 
 /**
  * Form data structure for creating a new event
@@ -235,11 +236,15 @@ export default function CreateEventForm() {
       <div
         className={`p-4 shadow-sm min-h-[140px] flex flex-col ${neubrutalistInputClass}`}
       >
-        <label className="block text-sm font-semibold mb-3">
+        <label
+          htmlFor="event-description"
+          className="block text-sm font-semibold mb-3"
+        >
           Add Description
         </label>
         <div className="flex items-start gap-4 flex-1">
           <textarea
+            id="event-description"
             name="description"
             value={formData.description}
             onChange={handleChange}
@@ -249,6 +254,8 @@ export default function CreateEventForm() {
               target.style.height = `${target.scrollHeight}px`;
             }}
             placeholder="Add Description about this Event..."
+            maxLength={MAX_DESCRIPTION_LENGTH}
+            aria-describedby="description-character-count"
             className="flex-1 text-base font-medium bg-transparent outline-none placeholder:text-gray-300 resize-none overflow-hidden min-h-[80px]"
           />
           <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center shrink-0 mt-1">
@@ -260,6 +267,23 @@ export default function CreateEventForm() {
               className="opacity-60"
             />
           </div>
+        </div>
+        <div className="flex justify-end mt-2">
+          <span
+            id="description-character-count"
+            aria-live="polite"
+            className={`text-xs font-medium tabular-nums ${
+              formData.description.length >= MAX_DESCRIPTION_LENGTH
+                ? "text-red-500"
+                : formData.description.length >=
+                    MAX_DESCRIPTION_LENGTH * 0.9
+                  ? "text-amber-500"
+                  : "text-gray-400"
+            }`}
+          >
+            {formData.description.length.toLocaleString()} /{" "}
+            {MAX_DESCRIPTION_LENGTH.toLocaleString()}
+          </span>
         </div>
       </div>
 

--- a/apps/web/lib/validation.ts
+++ b/apps/web/lib/validation.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+/**
+ * Maximum length for an event description.
+ *
+ * Mirrors the `events_description_length_check` CHECK constraint added in
+ * `server/migrations/20260728000001_add_description_check_constraint.sql`
+ * (`LENGTH(description) <= 10000`). Shared so the schema and the form UI can
+ * never drift apart from the database rule.
+ */
+export const MAX_DESCRIPTION_LENGTH = 10000;
+
 export const authSchema = z.object({
   email: z
     .string()
@@ -14,7 +24,13 @@ export const createEventSchema = z.object({
   endDate: z.string().optional(),
   endTime: z.string().optional(),
   location: z.string().trim().min(1, "Location is required"),
-  description: z.string().optional(),
+  description: z
+    .string()
+    .max(
+      MAX_DESCRIPTION_LENGTH,
+      `Description must be at most ${MAX_DESCRIPTION_LENGTH} characters`,
+    )
+    .optional(),
   capacity: z
     .string()
     .optional()


### PR DESCRIPTION
## Summary

Implements the live character counter for the event description field, closing #1236.

The DB enforces a 10,000-char CHECK constraint on event descriptions
(`server/migrations/20260728000001_add_description_check_constraint.sql`), but the create-event
form gave users no length feedback — they only discovered the limit by failing a submit.

### Changes

**`apps/web/lib/validation.ts`**
- Added `MAX_DESCRIPTION_LENGTH = 10000`, mirroring the DB CHECK constraint so schema and UI
  can never drift apart from the database rule.
- Enforced the limit in `createEventSchema.description` via `z.string().max(...)`.

**`apps/web/components/events/create-event-form.tsx`**
- Added `maxLength={MAX_DESCRIPTION_LENGTH}` to the description `<textarea>` so overflow is
  prevented, not just reported.
- Rendered a live "N / 10,000" counter under the textarea that updates as the user types.
- Counter turns amber at ≥90% of the limit and red at 100%.
- Wired `aria-describedby` from the textarea to the counter and added `aria-live="polite"` for
  screen readers. Linked the label via `htmlFor`/`id`.

**Tests**
- `__tests__/create-event-schema.test.ts`: added cases for max-length acceptance, over-limit
  rejection, and description-optional.
- `__tests__/create-event-form.test.tsx` (new): renders the counter, verifies `maxLength` and
  `aria-describedby`, updates the count on input, and checks amber/red styling thresholds.

### Verification
- `create-event-schema.test.ts`: 9/9 pass.
- `create-event-form.test.tsx`: 4/4 pass.
- `typecheck` on the touched files introduces no new errors (repo has pre-existing unrelated
  svg/prisma module-resolution errors).

Closes #1236
