### PR TITLE
fix(backend): bound search input, validate CORS origins, configurable…

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -48,6 +48,10 @@ Required variables:
 | | `BASE_URL` | No | `https://agora.events` | The base URL of the API. | `http://localhost:8080` |
 | **Database** | `DATABASE_URL` **[SECRET]** | Yes | - | PostgreSQL connection string. | `postgres://user:pass@localhost/db` |
 | | `SLOW_QUERY_THRESHOLD_MS` | Yes | - | Execution time threshold for logging slow DB queries. | `500` |
+| | `DB_MAX_CONNECTIONS` | No | `10` | Maximum connections in the PostgreSQL pool. | `25` |
+| | `DB_MIN_CONNECTIONS` | No | `1` | Minimum idle connections kept in the pool. | `2` |
+| | `DB_ACQUIRE_TIMEOUT_SECS` | No | `10` | Seconds to wait for an available connection before failing. | `30` |
+| | `DB_IDLE_TIMEOUT_SECS` | No | `600` | Seconds before an idle connection is closed. | `300` |
 | **Redis** | `REDIS_URL` | No | `redis://127.0.0.1:6379` | Redis connection string. | `redis://127.0.0.1:6379` |
 | **CORS** | `CORS_ALLOWED_ORIGINS` | No | (Code default) | Comma-separated list of allowed CORS origins. | `https://agora.events` |
 | **Security & Auth** | `JWT_SECRET` **[SECRET]** | No | `""` | Secret key used for signing JWTs. | `super_secret_string` |

--- a/server/src/config/cors.rs
+++ b/server/src/config/cors.rs
@@ -5,8 +5,121 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 const DEFAULT_ALLOWED_ORIGINS: &str = "http://localhost:3000,http://localhost:5173";
 
 const PREFLIGHT_MAX_AGE_SECS: u64 = 86400;
+
+/// Error returned when the CORS origin list is invalid or insecure.
+#[derive(Debug, PartialEq)]
+pub struct CorsConfigError(pub String);
+
+impl std::fmt::Display for CorsConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CORS configuration error: {}", self.0)
+    }
+}
+
+impl std::error::Error for CorsConfigError {}
+
+/// Validate a comma-separated list of CORS origins and return an [`AllowOrigin`].
+///
+/// Rules enforced (Issue #1264):
+/// 1. Every entry must be a well-formed absolute URL (scheme + host, no trailing path).
+/// 2. The wildcard `*` is forbidden when `allow_credentials` is `true`
+///    (the combination is rejected by all browsers and is a misconfiguration).
+/// 3. An empty list is treated the same as no configuration and falls back to defaults.
+///
+/// The resolved origin list is logged at `INFO` level so it appears in startup logs.
+pub fn validate_and_build_origins(
+    origins_str: &str,
+    allow_credentials: bool,
+) -> Result<AllowOrigin, CorsConfigError> {
+    // Check for wildcard + credentials conflict before anything else.
+    let has_wildcard = origins_str
+        .split(',')
+        .any(|o| o.trim() == "*");
+
+    if has_wildcard && allow_credentials {
+        return Err(CorsConfigError(
+            "ALLOWED_ORIGINS contains '*' but credentials are enabled. \
+             This combination is forbidden by the CORS specification. \
+             Either list explicit origins or disable allow_credentials."
+                .to_string(),
+        ));
+    }
+
+    if has_wildcard {
+        tracing::info!("CORS: Using wildcard origin '*'");
+        return Ok(AllowOrigin::any());
+    }
+
+    let mut valid_origins: Vec<HeaderValue> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for raw in origins_str.split(',') {
+        let origin = raw.trim();
+        if origin.is_empty() {
+            continue;
+        }
+
+        // Must be an absolute URL: scheme must be http or https.
+        if !origin.starts_with("http://") && !origin.starts_with("https://") {
+            errors.push(format!(
+                "'{}' is not a well-formed absolute URL (must start with http:// or https://)",
+                origin
+            ));
+            continue;
+        }
+
+        // Parse as a HeaderValue to ensure it is valid in HTTP headers.
+        match origin.parse::<HeaderValue>() {
+            Ok(value) => valid_origins.push(value),
+            Err(e) => {
+                errors.push(format!("'{}' is not a valid HTTP header value: {}", origin, e));
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(CorsConfigError(format!(
+            "malformed origin(s) in ALLOWED_ORIGINS:\n  - {}",
+            errors.join("\n  - ")
+        )));
+    }
+
+    if valid_origins.is_empty() {
+        // No origins configured — fall back to defaults (development only).
+        tracing::warn!(
+            "CORS: No valid origins configured, using permissive settings for development"
+        );
+        return Ok(AllowOrigin::any());
+    }
+
+    tracing::info!(
+        "CORS: Resolved {} allowed origin(s): {}",
+        valid_origins.len(),
+        origins_str
+            .split(',')
+            .map(|o| o.trim())
+            .filter(|o| !o.is_empty())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    Ok(AllowOrigin::list(valid_origins))
+}
+
 pub fn create_cors_layer() -> CorsLayer {
-    let allowed_origins = get_allowed_origins();
+    let origins_str = env::var("CORS_ALLOWED_ORIGINS")
+        .unwrap_or_else(|_| DEFAULT_ALLOWED_ORIGINS.to_string());
+
+    // allow_credentials is always true in this layer.
+    let allowed_origins = match validate_and_build_origins(&origins_str, true) {
+        Ok(origins) => origins,
+        Err(e) => {
+            // Fatal: abort startup with a clear message (Issue #1264).
+            eprintln!("ERROR: {e}");
+            tracing::error!("{e}");
+            std::process::exit(1);
+        }
+    };
 
     CorsLayer::new()
         .allow_origin(allowed_origins)
@@ -34,62 +147,109 @@ pub fn create_cors_layer() -> CorsLayer {
         .max_age(std::time::Duration::from_secs(PREFLIGHT_MAX_AGE_SECS))
 }
 
-fn get_allowed_origins() -> AllowOrigin {
-    let origins_str =
-        env::var("CORS_ALLOWED_ORIGINS").unwrap_or_else(|_| DEFAULT_ALLOWED_ORIGINS.to_string());
-
-    let origins: Vec<HeaderValue> = origins_str
-        .split(',')
-        .filter_map(|origin| {
-            let trimmed = origin.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                match trimmed.parse::<HeaderValue>() {
-                    Ok(value) => {
-                        tracing::debug!("CORS: Allowing origin: {}", trimmed);
-                        Some(value)
-                    }
-                    Err(e) => {
-                        tracing::warn!("CORS: Invalid origin '{}': {}", trimmed, e);
-                        None
-                    }
-                }
-            }
-        })
-        .collect();
-
-    if origins.is_empty() {
-        tracing::warn!(
-            "CORS: No valid origins configured, using permissive settings for development"
-        );
-        AllowOrigin::any()
-    } else {
-        tracing::info!("CORS: Configured with {} allowed origin(s)", origins.len());
-        AllowOrigin::list(origins)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_create_cors_layer() {
-        // Should not panic when creating the CORS layer
-        let _layer = create_cors_layer();
+        // Should not panic when creating the CORS layer with defaults.
+        // We set the env var to a safe value so the validation path is exercised.
+        std::env::set_var("CORS_ALLOWED_ORIGINS", "http://localhost:3000");
+        // create_cors_layer calls process::exit on error, so call the validator directly.
+        let result = validate_and_build_origins("http://localhost:3000", true);
+        assert!(result.is_ok());
+        std::env::remove_var("CORS_ALLOWED_ORIGINS");
     }
 
     #[test]
     fn test_default_origins_are_valid() {
-        // Verify default origins can be parsed as HeaderValues
-        for origin in DEFAULT_ALLOWED_ORIGINS.split(',') {
-            let trimmed = origin.trim();
-            assert!(
-                trimmed.parse::<HeaderValue>().is_ok(),
-                "Default origin '{}' should be a valid HeaderValue",
-                trimmed
-            );
-        }
+        // Verify default origins pass validation.
+        let result = validate_and_build_origins(DEFAULT_ALLOWED_ORIGINS, true);
+        assert!(
+            result.is_ok(),
+            "Default origins should be valid, got: {:?}",
+            result.unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_valid_origin_list_accepted() {
+        let result = validate_and_build_origins(
+            "https://app.example.com,https://admin.example.com",
+            true,
+        );
+        assert!(result.is_ok(), "Valid origin list should be accepted");
+    }
+
+    #[test]
+    fn test_malformed_entry_rejected() {
+        // A bare hostname without scheme is not a well-formed absolute URL.
+        let result = validate_and_build_origins("not-a-url", true);
+        assert!(
+            result.is_err(),
+            "Malformed origin should cause an error"
+        );
+        let msg = result.unwrap_err().0;
+        assert!(
+            msg.contains("not-a-url"),
+            "Error message should mention the bad entry, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_wildcard_with_credentials_rejected() {
+        // '*' + allow_credentials is a CORS spec violation and must be rejected.
+        let result = validate_and_build_origins("*", true);
+        assert!(
+            result.is_err(),
+            "Wildcard + credentials should be rejected"
+        );
+        let msg = result.unwrap_err().0;
+        assert!(
+            msg.contains("credentials"),
+            "Error message should mention credentials, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_wildcard_without_credentials_accepted() {
+        // '*' is fine when credentials are not required.
+        let result = validate_and_build_origins("*", false);
+        assert!(result.is_ok(), "Wildcard without credentials should be accepted");
+    }
+
+    #[test]
+    fn test_empty_origins_string_falls_back_gracefully() {
+        // Empty string should not error out — it falls back to any origin (dev mode).
+        let result = validate_and_build_origins("", true);
+        assert!(result.is_ok(), "Empty origins should fall back without error");
+    }
+
+    #[test]
+    fn test_http_origin_accepted() {
+        let result = validate_and_build_origins("http://localhost:3000", true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_ftp_scheme_rejected() {
+        let result = validate_and_build_origins("ftp://files.example.com", true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mixed_valid_and_invalid_entries_all_rejected() {
+        // Even one bad entry must cause the whole list to fail.
+        let result = validate_and_build_origins(
+            "https://good.example.com,bad-entry,https://also-good.example.com",
+            true,
+        );
+        assert!(
+            result.is_err(),
+            "A list with any malformed entry should be rejected"
+        );
     }
 }

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -100,6 +100,21 @@ pub struct Config {
 
     /// Allowed MIME types for uploaded files.
     pub allowed_upload_mime_types: Vec<String>,
+
+    // -----------------------------------------------------------------------
+    // Database connection pool settings (Issue #1265)
+    // -----------------------------------------------------------------------
+    /// Maximum number of connections in the pool (DB_MAX_CONNECTIONS, default: 10).
+    pub db_max_connections: u32,
+
+    /// Minimum number of idle connections kept in the pool (DB_MIN_CONNECTIONS, default: 1).
+    pub db_min_connections: u32,
+
+    /// Maximum time in seconds to wait for an available connection (DB_ACQUIRE_TIMEOUT_SECS, default: 10).
+    pub db_acquire_timeout_secs: u64,
+
+    /// Time in seconds after which an idle connection is closed (DB_IDLE_TIMEOUT_SECS, default: 600).
+    pub db_idle_timeout_secs: u64,
 }
 
 /// A collection of configuration errors found during [`Config::validate`].
@@ -179,6 +194,29 @@ impl Config {
                 ]
             });
 
+        // -----------------------------------------------------------------------
+        // Database pool settings (Issue #1265)
+        // -----------------------------------------------------------------------
+        let db_max_connections = env::var("DB_MAX_CONNECTIONS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10u32);
+
+        let db_min_connections = env::var("DB_MIN_CONNECTIONS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1u32);
+
+        let db_acquire_timeout_secs = env::var("DB_ACQUIRE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10u64);
+
+        let db_idle_timeout_secs = env::var("DB_IDLE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(600u64);
+
         Ok(Self {
             database_url,
             port,
@@ -199,6 +237,10 @@ impl Config {
             admin_token,
             auth_rate_limit_per_minute,
             allowed_upload_mime_types,
+            db_max_connections,
+            db_min_connections,
+            db_acquire_timeout_secs,
+            db_idle_timeout_secs,
         })
     }
 
@@ -300,6 +342,17 @@ impl Config {
             ));
         }
 
+        // --- DB pool settings (Issue #1265) ------------------------------
+        if self.db_min_connections > self.db_max_connections {
+            errors.push(format!(
+                "DB_MIN_CONNECTIONS ({}) must not exceed DB_MAX_CONNECTIONS ({})",
+                self.db_min_connections, self.db_max_connections
+            ));
+        }
+        if self.db_max_connections == 0 {
+            errors.push("DB_MAX_CONNECTIONS must be at least 1".to_string());
+        }
+
         if errors.is_empty() {
             Ok(())
         } else {
@@ -360,6 +413,10 @@ mod tests {
                 "image/webp".to_string(),
                 "image/gif".to_string(),
             ],
+            db_max_connections: 10,
+            db_min_connections: 1,
+            db_acquire_timeout_secs: 10,
+            db_idle_timeout_secs: 600,
         }
     }
 
@@ -899,6 +956,10 @@ mod tests {
                 "image/webp".to_string(),
                 "image/gif".to_string(),
             ],
+            db_max_connections: 10,
+            db_min_connections: 1,
+            db_acquire_timeout_secs: 10,
+            db_idle_timeout_secs: 600,
         };
 
         let err = cfg.validate().unwrap_err();
@@ -944,5 +1005,92 @@ mod tests {
         let result = truncate_url(&url);
         assert!(result.ends_with('…'));
         assert!(result.len() < url.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #1265 — DB pool configuration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_db_pool_defaults_are_valid() {
+        // Default values (min=1, max=10) must pass validation.
+        let cfg = valid_config();
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_db_min_greater_than_max_rejected() {
+        let mut cfg = valid_config();
+        cfg.db_min_connections = 20;
+        cfg.db_max_connections = 10;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("DB_MIN_CONNECTIONS") && e.contains("DB_MAX_CONNECTIONS")),
+            "got: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_validate_db_max_zero_rejected() {
+        let mut cfg = valid_config();
+        cfg.db_max_connections = 0;
+        cfg.db_min_connections = 0;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.errors.iter().any(|e| e.contains("DB_MAX_CONNECTIONS")),
+            "got: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_validate_db_min_equals_max_is_valid() {
+        let mut cfg = valid_config();
+        cfg.db_min_connections = 5;
+        cfg.db_max_connections = 5;
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_db_pool_defaults_from_env() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        env::set_var("DATABASE_URL", "postgres://test:pass@localhost/db");
+        env::remove_var("DB_MAX_CONNECTIONS");
+        env::remove_var("DB_MIN_CONNECTIONS");
+        env::remove_var("DB_ACQUIRE_TIMEOUT_SECS");
+        env::remove_var("DB_IDLE_TIMEOUT_SECS");
+
+        let cfg = Config::from_env().unwrap();
+        assert_eq!(cfg.db_max_connections, 10);
+        assert_eq!(cfg.db_min_connections, 1);
+        assert_eq!(cfg.db_acquire_timeout_secs, 10);
+        assert_eq!(cfg.db_idle_timeout_secs, 600);
+
+        env::remove_var("DATABASE_URL");
+    }
+
+    #[test]
+    fn test_db_pool_custom_values_from_env() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        env::set_var("DATABASE_URL", "postgres://test:pass@localhost/db");
+        env::set_var("DB_MAX_CONNECTIONS", "25");
+        env::set_var("DB_MIN_CONNECTIONS", "5");
+        env::set_var("DB_ACQUIRE_TIMEOUT_SECS", "30");
+        env::set_var("DB_IDLE_TIMEOUT_SECS", "120");
+
+        let cfg = Config::from_env().unwrap();
+        assert_eq!(cfg.db_max_connections, 25);
+        assert_eq!(cfg.db_min_connections, 5);
+        assert_eq!(cfg.db_acquire_timeout_secs, 30);
+        assert_eq!(cfg.db_idle_timeout_secs, 120);
+
+        env::remove_var("DATABASE_URL");
+        env::remove_var("DB_MAX_CONNECTIONS");
+        env::remove_var("DB_MIN_CONNECTIONS");
+        env::remove_var("DB_ACQUIRE_TIMEOUT_SECS");
+        env::remove_var("DB_IDLE_TIMEOUT_SECS");
     }
 }

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -1312,6 +1312,103 @@ mod tests {
             clause
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Issue #1263 — search query validation / sanitisation
+    // -----------------------------------------------------------------------
+
+    /// Helper that applies the same normalisation logic used in `search_events`.
+    fn normalise_search_q(raw: &str) -> Result<Option<String>, String> {
+        if raw.len() > MAX_SEARCH_QUERY_LENGTH {
+            return Err(format!(
+                "Search query must not exceed {} characters",
+                MAX_SEARCH_QUERY_LENGTH
+            ));
+        }
+        let trimmed = raw.trim().to_string();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        let sanitised = trimmed
+            .to_lowercase()
+            .replace('%', "")
+            .replace('_', " ");
+        let sanitised = sanitised.trim().to_string();
+        Ok(if sanitised.is_empty() { None } else { Some(sanitised) })
+    }
+
+    #[test]
+    fn test_search_q_over_128_chars_is_rejected() {
+        let long_q = "a".repeat(MAX_SEARCH_QUERY_LENGTH + 1);
+        assert!(
+            normalise_search_q(&long_q).is_err(),
+            "query longer than {} characters should be rejected",
+            MAX_SEARCH_QUERY_LENGTH
+        );
+    }
+
+    #[test]
+    fn test_search_q_exactly_128_chars_is_accepted() {
+        let q = "a".repeat(MAX_SEARCH_QUERY_LENGTH);
+        assert!(
+            normalise_search_q(&q).is_ok(),
+            "query of exactly {} characters should be accepted",
+            MAX_SEARCH_QUERY_LENGTH
+        );
+    }
+
+    #[test]
+    fn test_search_q_empty_string_treated_as_absent() {
+        let result = normalise_search_q("").unwrap();
+        assert_eq!(result, None, "empty query should normalise to None");
+    }
+
+    #[test]
+    fn test_search_q_whitespace_only_treated_as_absent() {
+        let result = normalise_search_q("   ").unwrap();
+        assert_eq!(
+            result, None,
+            "whitespace-only query should normalise to None"
+        );
+    }
+
+    #[test]
+    fn test_search_q_percent_wildcard_stripped() {
+        // A bare `%` must not produce a full-scan LIKE pattern.
+        let result = normalise_search_q("%").unwrap();
+        assert_eq!(
+            result, None,
+            "a bare '%' should be stripped and treated as absent"
+        );
+    }
+
+    #[test]
+    fn test_search_q_percent_mixed_stripped() {
+        // `%music%` should become `music`.
+        let result = normalise_search_q("%music%").unwrap();
+        assert_eq!(result, Some("music".to_string()));
+    }
+
+    #[test]
+    fn test_search_q_underscore_wildcard_replaced_with_space() {
+        let result = normalise_search_q("hello_world").unwrap();
+        // `_` is replaced with a space, then the result is trimmed.
+        assert!(result.is_some());
+        let inner = result.unwrap();
+        assert!(!inner.contains('_'), "underscore should be removed from query");
+    }
+
+    #[test]
+    fn test_search_q_normalised_to_lowercase() {
+        let result = normalise_search_q("CONCERT").unwrap();
+        assert_eq!(result, Some("concert".to_string()));
+    }
+
+    #[test]
+    fn test_search_q_trimmed_before_use() {
+        let result = normalise_search_q("  jazz  ").unwrap();
+        assert_eq!(result, Some("jazz".to_string()));
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -2437,13 +2534,17 @@ pub async fn submit_event_rating(
     success(response, "Rating recorded successfully").into_response()
 }
 
+/// Maximum length for the free-text search query parameter `q`.
+/// Queries longer than this are rejected with a 400 to prevent expensive full-table scans.
+const MAX_SEARCH_QUERY_LENGTH: usize = 128;
+
 /// Search events with advanced filters
 ///
 /// # Endpoint
 /// GET `/api/v1/events/search`
 ///
 /// # Query Parameters
-/// - `q` (optional): Keyword search in title and description
+/// - `q` (optional): Keyword search in title and description (max 128 chars)
 /// - `category_id` (optional): Filter by category UUID
 /// - `min_price` (optional): Minimum ticket price in cents
 /// - `max_price` (optional): Maximum ticket price in cents
@@ -2459,11 +2560,38 @@ const SEARCH_CACHE_TTL: Duration = Duration::from_secs(120);
 
 pub async fn search_events(
     State(mut state): State<EventState>,
-    Query(params): Query<SearchParams>,
+    Query(mut params): Query<SearchParams>,
 ) -> Response {
     if let Err(msg) = params.validate_page_size() {
         return AppError::ValidationError(msg).into_response();
     }
+
+    // --- Issue #1263: sanitise and validate the free-text search parameter ---
+    if let Some(raw_q) = params.q.take() {
+        // Reject queries that exceed the maximum allowed length.
+        if raw_q.len() > MAX_SEARCH_QUERY_LENGTH {
+            return AppError::ValidationError(format!(
+                "Search query must not exceed {} characters",
+                MAX_SEARCH_QUERY_LENGTH
+            ))
+            .into_response();
+        }
+
+        // Trim whitespace; treat empty/whitespace-only queries as absent.
+        let trimmed = raw_q.trim().to_string();
+        if trimmed.is_empty() {
+            params.q = None;
+        } else {
+            // Normalise to lowercase and strip SQL LIKE wildcards.
+            let sanitised = trimmed
+                .to_lowercase()
+                .replace('%', "")
+                .replace('_', " ");
+            let sanitised = sanitised.trim().to_string();
+            params.q = if sanitised.is_empty() { None } else { Some(sanitised) };
+        }
+    }
+
     let pagination = PaginationParams {
         page: params.page,
         page_size: params.page_size,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -57,11 +57,21 @@ async fn main() {
     // Note: DATABASE_URL is strictly excluded from logging for security reasons.
 
     let pool = PgPoolOptions::new()
-        .max_connections(5)
+        .max_connections(config.db_max_connections)
+        .min_connections(config.db_min_connections)
+        .acquire_timeout(std::time::Duration::from_secs(config.db_acquire_timeout_secs))
+        .idle_timeout(std::time::Duration::from_secs(config.db_idle_timeout_secs))
         .connect(&config.database_url)
         .await
         .expect("Failed to connect to database");
 
+    tracing::info!(
+        "Database pool: max_connections={} min_connections={} acquire_timeout={}s idle_timeout={}s",
+        config.db_max_connections,
+        config.db_min_connections,
+        config.db_acquire_timeout_secs,
+        config.db_idle_timeout_secs,
+    );
     tracing::info!("Successfully connected to database");
 
     sqlx::migrate!()

--- a/server/src/utils/cursor_pagination.rs
+++ b/server/src/utils/cursor_pagination.rs
@@ -285,4 +285,109 @@ mod tests {
         assert!(!response.pagination.has_more);
         assert!(response.pagination.next_cursor.is_none());
     }
+
+    // -----------------------------------------------------------------------
+    // Issue #1266 — additional coverage
+    // -----------------------------------------------------------------------
+
+    /// An empty result set must return `has_more = false` and no next cursor.
+    #[test]
+    fn test_cursor_response_empty_result() {
+        let params = ValidatedCursorParams {
+            limit: 20,
+            cursor: None,
+        };
+        let response: CursorResponse<i32> = CursorResponse::new(vec![], &params, None);
+        assert!(!response.pagination.has_more);
+        assert!(response.pagination.next_cursor.is_none());
+        assert!(response.items.is_empty());
+    }
+
+    /// A single-item result must behave correctly (no overflow, has_more = false).
+    #[test]
+    fn test_cursor_response_single_result() {
+        let params = ValidatedCursorParams {
+            limit: 20,
+            cursor: None,
+        };
+        let response: CursorResponse<i32> = CursorResponse::new(vec![42], &params, None);
+        assert!(!response.pagination.has_more);
+        assert_eq!(response.items.len(), 1);
+    }
+
+    /// When the result count equals the page size exactly, `has_more` must be
+    /// determined by whether a `next_cursor` was passed, not by item count.
+    #[test]
+    fn test_cursor_response_exact_page_boundary_no_more() {
+        let params = ValidatedCursorParams {
+            limit: 3,
+            cursor: None,
+        };
+        // Exactly page_size items returned — caller did NOT pass a next cursor,
+        // meaning the DB had no additional rows.
+        let response: CursorResponse<i32> = CursorResponse::new(vec![1, 2, 3], &params, None);
+        assert!(!response.pagination.has_more);
+        assert!(response.pagination.next_cursor.is_none());
+        assert_eq!(response.items.len(), 3);
+    }
+
+    #[test]
+    fn test_cursor_response_exact_page_boundary_has_more() {
+        let params = ValidatedCursorParams {
+            limit: 3,
+            cursor: None,
+        };
+        // Caller stripped the extra item and encoded a cursor.
+        let response: CursorResponse<i32> =
+            CursorResponse::new(vec![1, 2, 3], &params, Some("next-token".to_string()));
+        assert!(response.pagination.has_more);
+        assert_eq!(
+            response.pagination.next_cursor.as_deref(),
+            Some("next-token")
+        );
+    }
+
+    /// A tampered (invalid characters) base64 cursor must return an error.
+    #[test]
+    fn test_decode_tampered_cursor_is_rejected() {
+        // Valid base64 chars but content that cannot deserialise into EventCursor.
+        let tampered = URL_SAFE_NO_PAD.encode(b"this is not valid json");
+        let result: Result<EventCursor, _> = decode_cursor(&tampered);
+        assert!(
+            matches!(result, Err(CursorError::Deserialize(_))),
+            "tampered cursor should fail with Deserialize error"
+        );
+    }
+
+    /// Round-trip encode/decode of an AttendeeCursor.
+    #[test]
+    fn test_encode_decode_attendee_cursor_roundtrip() {
+        let cursor = AttendeeCursor {
+            created_at: Utc::now(),
+            id: Uuid::new_v4(),
+        };
+        let encoded = encode_cursor(&cursor).unwrap();
+        let decoded: AttendeeCursor = decode_cursor(&encoded).unwrap();
+        assert_eq!(cursor.created_at, decoded.created_at);
+        assert_eq!(cursor.id, decoded.id);
+    }
+
+    /// Cursor with all optional fields set to None still round-trips correctly.
+    #[test]
+    fn test_encode_decode_event_cursor_minimal() {
+        let cursor = EventCursor {
+            start_time: Utc::now(),
+            id: Uuid::new_v4(),
+            created_at: None,
+            minted_tickets: None,
+            count_of_ratings: None,
+        };
+        let encoded = encode_cursor(&cursor).unwrap();
+        let decoded: EventCursor = decode_cursor(&encoded).unwrap();
+        assert_eq!(cursor.start_time, decoded.start_time);
+        assert_eq!(cursor.id, decoded.id);
+        assert!(decoded.created_at.is_none());
+        assert!(decoded.minted_tickets.is_none());
+        assert!(decoded.count_of_ratings.is_none());
+    }
 }


### PR DESCRIPTION
… DB pool, cursor pagination tests

Closes #1263 
Closes #1264 
Closes #1265 
Closes #1266 

## #1263 — Bound the length of free-text search input
- Added MAX_SEARCH_QUERY_LENGTH = 128 constant in handlers/events.rs
- Reject queries longer than 128 chars with a 400 ValidationError
- Trim whitespace and treat empty/whitespace-only queries as absent (no LIKE match)
- Normalise input to lowercase before passing to ILIKE clauses
- Strip SQL LIKE wildcards (% → removed, _ → space) to prevent forced full scans
- Added unit tests: over-long query rejected, empty/whitespace treated as absent, % stripped, _ replaced, lowercase normalisation, trim, 128-char boundary accepted

## #1264 — Validate CORS allowed origins at startup
- Rewrote config/cors.rs: extracted validate_and_build_origins() that runs at boot
- Validates each origin is a well-formed absolute URL (http:// or https:// scheme)
- Fails with a clear message and process::exit(1) on any malformed entry
- Refuses to start if '*' is combined with allow_credentials (CORS spec violation)
- Logs the resolved origin list at INFO level during startup
- Added unit tests: valid list, malformed entry, wildcard+credentials rejected, wildcard without credentials accepted, ftp scheme rejected, empty fallback

## #1265 — Make database pool settings configurable via environment
- Added DB_MAX_CONNECTIONS (default 10), DB_MIN_CONNECTIONS (default 1), DB_ACQUIRE_TIMEOUT_SECS (default 10), DB_IDLE_TIMEOUT_SECS (default 600) to Config struct and Config::from_env() in config/mod.rs
- Applied all four settings via PgPoolOptions in main.rs (replaces hardcoded max=5)
- Validate that db_min_connections <= db_max_connections at startup; fail fast otherwise
- Log the effective pool configuration at startup (INFO level)
- Documented the four new variables in server/README.md

## #1266 — Add unit tests for cursor pagination utilities
- Extended #[cfg(test)] mod tests in utils/cursor_pagination.rs
- New tests: empty-result page (has_more=false), single-result page, exact page boundary without cursor (has_more=false), exact page boundary with cursor (has_more=true), tampered/non-JSON base64 cursor rejected with Deserialize error, AttendeeCursor round-trip, EventCursor minimal (all-None optional fields)

## Description

<!--
Briefly describe the changes in this PR. What problem does it solve or what
feature does it add? Link to the related issue(s) if applicable.
-->