### PR TITLE
Add error codes, rate-limit headers, event list meta, and sort

### DIFF
--- a/server/API.md
+++ b/server/API.md
@@ -8,9 +8,63 @@ This document summarizes the public backend endpoints available.
 | POST | `/api/v1/auth/verify` | None | `{ "address", "nonce", "signature", "public_key" }` | `{ "token": "jwt..." }` + `Set-Cookie: XSRF-TOKEN` | 400, 401 |
 | POST | `/api/v1/auth/logout` | None | - | 200 OK | - |
 | GET | `/api/v1/profile/me` | Bearer | - | Profile details | 401, 404 |
-| GET | `/api/v1/events` | None | `?category=...` | List of events | - |
+| GET | `/api/v1/events` | None | `?category=...&sort=...&count=...` | Paginated events with `meta` | 400 |
 | GET | `/api/v1/events/map` | None | `?latitude&longitude&radius&limit` | Nearby events with `distance_km` | 400 |
 | POST | `/api/v1/events` | Bearer+CSRF | Event JSON | Created event | 400, 401, 403 |
 | POST | `/api/v1/tickets/:id/scan` | None | `{ "payload": { ... }, "signature": "...", "public_key": "..." }` | Scan verification result | 400, 403, 404, 409 |
 
 *(This file is maintained manually for quick reference. For a comprehensive machine-readable API, see `/openapi.json`)*
+
+## Error responses
+
+Every error body is a flat JSON object:
+
+```json
+{ "code": "NOT_FOUND", "message": "Resource with id '42' was not found" }
+```
+
+`code` is a stable machine-readable [`ErrorCode`](src/utils/error.rs). HTTP status
+and `message` text are unchanged from previous behaviour; clients should branch
+on `code` rather than string-matching `message`.
+
+| Code | HTTP status | When it is returned |
+|---|---|---|
+| `VALIDATION_FAILED` | 400, 422 | Query/body failed validation (including an unrecognised `?sort=` value) |
+| `UNAUTHORIZED` | 401 | Missing or invalid authentication credentials |
+| `FORBIDDEN` | 403 | Authenticated caller is not allowed to perform this action |
+| `NOT_FOUND` | 404 | The requested resource does not exist |
+| `CONFLICT` | 409 | The request conflicts with current resource state (duplicate, unique/FK violation) |
+| `RATE_LIMITED` | 429 | The caller exceeded the allowed request rate |
+| `INTERNAL_ERROR` | 500 | Unexpected internal failure |
+| `SERVICE_UNAVAILABLE` | 502, 503, 504 | Database or downstream service is temporarily unavailable |
+
+## Rate limiting
+
+Sensitive routes are limited to **30 requests per IP per minute**; general routes
+to **120 requests per IP per minute**. Every response (allowed or rejected)
+includes:
+
+| Header | Meaning |
+|---|---|
+| `X-RateLimit-Limit` | Maximum requests in the current window |
+| `X-RateLimit-Remaining` | Requests remaining in the current window |
+| `X-RateLimit-Reset` | Unix timestamp (seconds) when the window refreshes |
+
+A `429` response always includes `Retry-After` set to the seconds remaining in
+the current window. The value is an integer ≥ 1.
+
+## Events list
+
+`GET /api/v1/events` returns a cursor-paginated list. Successful `data` includes:
+
+```json
+{
+  "items": [ /* Event */ ],
+  "pagination": { "page_size": 20, "has_more": true, "next_cursor": "..." },
+  "meta": { "total": 340, "page_size": 20, "has_more": true }
+}
+```
+
+- `meta.total` is the COUNT(*) of rows matching the same filters (not just the current page).
+- Pass `?count=false` to skip the extra COUNT query; `meta.total` is then omitted.
+- `?sort=` accepts `starts_at_asc` (default), `starts_at_desc`, `price_asc`, `price_desc`, `popularity_desc`. Any other value returns `400` with `VALIDATION_FAILED`. Sorting always uses an allow-listed `ORDER BY` plus `id` as a tiebreaker.

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -82,6 +82,73 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
 
+  /api/v1/events:
+    get:
+      tags: [Events]
+      summary: List upcoming events
+      description: |
+        Returns a cursor-paginated list of upcoming (not-ended, not-flagged) events.
+
+        The response `data` object includes `items`, cursor `pagination`, and a
+        compact `meta` object with `total`, `page_size`, and `has_more`.
+        Pass `count=false` to skip the extra COUNT(*) query; `meta.total` is
+        then omitted.
+
+        `sort` is an allow-listed ORDER BY. Unrecognised values return 400
+        with `VALIDATION_FAILED`. Default is `starts_at_asc`. A secondary
+        `id` tiebreaker keeps pagination stable.
+      operationId: listEvents
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Items per page (default 20, max 100).
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque cursor from a previous page's `pagination.next_cursor`.
+          schema:
+            type: string
+        - name: count
+          in: query
+          required: false
+          description: When false, skip COUNT(*) and omit `meta.total`.
+          schema:
+            type: boolean
+            default: true
+        - name: sort
+          in: query
+          required: false
+          description: |
+            Ordering. Allow-listed values only; never interpolated into SQL.
+          schema:
+            type: string
+            enum:
+              - starts_at_asc
+              - starts_at_desc
+              - price_asc
+              - price_desc
+              - popularity_desc
+            default: starts_at_asc
+      responses:
+        '200':
+          description: Paginated list of upcoming events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventListResponse'
+        '400':
+          description: Invalid query parameter (for example an unrecognised `sort` value)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/v1/events/map:
     get:
       tags: [Events]
@@ -272,13 +339,74 @@ components:
 
     ErrorResponse:
       type: object
+      description: Flat error body returned by every failed request.
       properties:
-        success:
-          type: boolean
-          example: false
+        code:
+          type: string
+          description: Stable machine-readable error code (SCREAMING_SNAKE_CASE).
+          enum:
+            - VALIDATION_FAILED
+            - UNAUTHORIZED
+            - FORBIDDEN
+            - NOT_FOUND
+            - CONFLICT
+            - RATE_LIMITED
+            - INTERNAL_ERROR
+            - SERVICE_UNAVAILABLE
+          example: NOT_FOUND
         message:
           type: string
-      required: [success]
+          description: Human-readable error message safe to show to end users.
+      required: [code, message]
+
+    ListMeta:
+      type: object
+      description: Compact pagination metadata for list UIs ("Showing 12 of 340").
+      properties:
+        total:
+          type: integer
+          format: int64
+          description: COUNT(*) of matching rows. Omitted when `count=false`.
+        page_size:
+          type: integer
+          description: Requested page size.
+        has_more:
+          type: boolean
+          description: Whether another page of results exists.
+      required: [page_size, has_more]
+
+    CursorPagination:
+      type: object
+      properties:
+        page_size:
+          type: integer
+        has_more:
+          type: boolean
+        next_cursor:
+          type: string
+          nullable: true
+      required: [page_size, has_more]
+
+    EventListData:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Event'
+        pagination:
+          $ref: '#/components/schemas/CursorPagination'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+      required: [items, pagination, meta]
+
+    EventListResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/EventListData'
 
     EventSocialProof:
       type: object

--- a/server/src/handlers/events.rs
+++ b/server/src/handlers/events.rs
@@ -172,6 +172,8 @@ pub enum EventSortBy {
     Popularity,
     /// Sort by review count (alias of "popular" but exposes the underlying column).
     CountOfRatings,
+    /// Sort by minimum ticket-tier price.
+    Price,
 }
 
 impl EventSortBy {
@@ -245,29 +247,14 @@ impl EventFilters {
 
     /// Validate `sort_by` and `sort_order`, applying defaults when omitted.
     /// The `sort` field takes precedence when provided.
+    ///
+    /// Accepted `sort` values (allow-list, never interpolated into SQL):
+    /// `starts_at_asc` (default), `starts_at_desc`, `price_asc`, `price_desc`,
+    /// `popularity_desc`. Legacy values `newest` and `popular` are still accepted.
     pub fn validate_sort(&self) -> Result<ValidatedEventSort, String> {
         // Simple `sort` param takes precedence over the legacy `sort_by`/`sort_order` pair.
         if let Some(ref sort) = self.sort {
-            match sort.as_str() {
-                "newest" => {
-                    return Ok(ValidatedEventSort {
-                        sort_by: EventSortBy::StartTime,
-                        sort_order: SortOrder::Desc,
-                    });
-                }
-                "popular" => {
-                    return Ok(ValidatedEventSort {
-                        sort_by: EventSortBy::CountOfRatings,
-                        sort_order: SortOrder::Desc,
-                    });
-                }
-                other => {
-                    return Err(format!(
-                        "Invalid sort value '{}'. Supported values: newest, popular",
-                        other
-                    ));
-                }
-            }
+            return parse_sort_param(sort);
         }
 
         let sort_by = match self.sort_by.as_deref() {
@@ -285,6 +272,49 @@ impl EventFilters {
     }
 }
 
+/// Allow-listed `?sort=` values. The raw parameter is never concatenated into SQL.
+fn parse_sort_param(sort: &str) -> Result<ValidatedEventSort, String> {
+    match sort {
+        "starts_at_asc" => Ok(ValidatedEventSort {
+            sort_by: EventSortBy::StartTime,
+            sort_order: SortOrder::Asc,
+        }),
+        "starts_at_desc" => Ok(ValidatedEventSort {
+            sort_by: EventSortBy::StartTime,
+            sort_order: SortOrder::Desc,
+        }),
+        "price_asc" => Ok(ValidatedEventSort {
+            sort_by: EventSortBy::Price,
+            sort_order: SortOrder::Asc,
+        }),
+        "price_desc" => Ok(ValidatedEventSort {
+            sort_by: EventSortBy::Price,
+            sort_order: SortOrder::Desc,
+        }),
+        "popularity_desc" => Ok(ValidatedEventSort {
+            sort_by: EventSortBy::Popularity,
+            sort_order: SortOrder::Desc,
+        }),
+        "newest" => Ok(ValidatedEventSort {
+            sort_by: EventSortBy::StartTime,
+            sort_order: SortOrder::Desc,
+        }),
+        "popular" => Ok(ValidatedEventSort {
+            sort_by: EventSortBy::CountOfRatings,
+            sort_order: SortOrder::Desc,
+        }),
+        other => Err(format!(
+            "Invalid sort value '{}'. Supported values: starts_at_asc, starts_at_desc, price_asc, price_desc, popularity_desc",
+            other
+        )),
+    }
+}
+
+/// Allow-listed SQL expression for the cheapest ticket-tier price.
+/// Never interpolates user input.
+const MIN_TICKET_PRICE_SQL: &str =
+    "COALESCE((SELECT MIN(tt.price) FROM ticket_tiers tt WHERE tt.event_id = events.id), 0)";
+
 /// Build the ORDER BY clause for event listings.
 fn build_event_order_by_clause(sort: &ValidatedEventSort) -> String {
     let (column, tiebreaker_direction) = match sort.sort_by {
@@ -292,6 +322,7 @@ fn build_event_order_by_clause(sort: &ValidatedEventSort) -> String {
         EventSortBy::CreatedAt => ("created_at", sort.sort_order.sql()),
         EventSortBy::Popularity => ("minted_tickets", sort.sort_order.sql()),
         EventSortBy::CountOfRatings => ("count_of_ratings", "ASC"),
+        EventSortBy::Price => (MIN_TICKET_PRICE_SQL, sort.sort_order.sql()),
     };
     let direction = sort.sort_order.sql();
     format!("ORDER BY {column} {direction}, id {tiebreaker_direction}")
@@ -389,6 +420,8 @@ fn build_event_where_clause(
             (EventSortBy::Popularity, SortOrder::Desc) => ("minted_tickets", "<", "<"),
             (EventSortBy::CountOfRatings, SortOrder::Asc) => ("count_of_ratings", ">", ">"),
             (EventSortBy::CountOfRatings, SortOrder::Desc) => ("count_of_ratings", "<", "<"),
+            (EventSortBy::Price, SortOrder::Asc) => (MIN_TICKET_PRICE_SQL, ">", ">"),
+            (EventSortBy::Price, SortOrder::Desc) => (MIN_TICKET_PRICE_SQL, "<", "<"),
         };
 
         where_clauses.push(format!(
@@ -1298,6 +1331,89 @@ mod tests {
         assert!(err.contains("Invalid sort_order value 'sideways'"));
     }
 
+    fn assert_sort(value: &str, expected_by: EventSortBy, expected_order: SortOrder, sql: &str) {
+        let filters = EventFilters {
+            sort: Some(value.to_string()),
+            ..Default::default()
+        };
+        let sort = filters.validate_sort().expect(value);
+        assert_eq!(sort.sort_by, expected_by, "sort_by for {value}");
+        assert_eq!(sort.sort_order, expected_order, "sort_order for {value}");
+        assert_eq!(build_event_order_by_clause(&sort), sql, "ORDER BY for {value}");
+        assert!(
+            !sql.contains(value) || value.chars().all(|c| c == '_' || c.is_ascii_alphabetic()),
+            "raw sort parameter must not be interpolated into SQL"
+        );
+    }
+
+    #[test]
+    fn test_sort_starts_at_asc() {
+        assert_sort(
+            "starts_at_asc",
+            EventSortBy::StartTime,
+            SortOrder::Asc,
+            "ORDER BY start_time ASC, id ASC",
+        );
+        // Omitted sort defaults to starts_at_asc.
+        let default = EventFilters::default().validate_sort().unwrap();
+        assert_eq!(default.sort_by, EventSortBy::StartTime);
+        assert_eq!(default.sort_order, SortOrder::Asc);
+    }
+
+    #[test]
+    fn test_sort_starts_at_desc() {
+        assert_sort(
+            "starts_at_desc",
+            EventSortBy::StartTime,
+            SortOrder::Desc,
+            "ORDER BY start_time DESC, id DESC",
+        );
+    }
+
+    #[test]
+    fn test_sort_price_asc() {
+        assert_sort(
+            "price_asc",
+            EventSortBy::Price,
+            SortOrder::Asc,
+            &format!("ORDER BY {MIN_TICKET_PRICE_SQL} ASC, id ASC"),
+        );
+    }
+
+    #[test]
+    fn test_sort_price_desc() {
+        assert_sort(
+            "price_desc",
+            EventSortBy::Price,
+            SortOrder::Desc,
+            &format!("ORDER BY {MIN_TICKET_PRICE_SQL} DESC, id DESC"),
+        );
+    }
+
+    #[test]
+    fn test_sort_popularity_desc() {
+        assert_sort(
+            "popularity_desc",
+            EventSortBy::Popularity,
+            SortOrder::Desc,
+            "ORDER BY minted_tickets DESC, id DESC",
+        );
+    }
+
+    #[test]
+    fn test_sort_unrecognised_value_returns_validation_error() {
+        let filters = EventFilters {
+            sort: Some("not_a_real_sort".to_string()),
+            ..Default::default()
+        };
+        let err = filters.validate_sort().unwrap_err();
+        assert!(err.contains("Invalid sort value 'not_a_real_sort'"));
+        // Handler maps this to 400 VALIDATION_FAILED, never 500.
+        let app_err = AppError::ValidationError(err);
+        assert_eq!(app_err.status_code(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(app_err.error_code(), crate::utils::error::ErrorCode::ValidationFailed);
+    }
+
     #[test]
     fn test_keyword_search_clause_includes_location() {
         // Mirrors the format string used inside search_events for the `q` param.
@@ -1439,8 +1555,10 @@ pub struct SubmitEventRatingResponse {
 /// - `start_before` (optional): Filter events starting before date
 /// - `search` (optional): Search in title and description
 /// - `is_free` (optional): Filter by free events (true = ticket_price = 0, false = ticket_price > 0)
-/// - `sort_by` (optional): Sort field — `start_time` (default), `created_at`, or `popularity`
-/// - `sort_order` (optional): Sort direction — `asc` (default) or `desc`
+/// - `sort` (optional): `starts_at_asc` (default), `starts_at_desc`, `price_asc`, `price_desc`, `popularity_desc`
+/// - `sort_by` (optional, legacy): Sort field — `start_time` (default), `created_at`, or `popularity`
+/// - `sort_order` (optional, legacy): Sort direction — `asc` (default) or `desc`
+/// - `count` (optional): When `false`, skip the COUNT(*) query and omit `meta.total`
 ///
 /// # Response
 /// Returns a cursor-paginated list of upcoming events with metadata
@@ -1456,9 +1574,10 @@ pub async fn list_events(
         Err(message) => return AppError::ValidationError(message).into_response(),
     };
 
-    // Serve the default (unfiltered, first-page) list from cache when available.
+    // Serve the default (unfiltered, first-page, with total) list from cache when available.
     let use_list_cache = validated.cursor.is_none()
         && filters.is_unfiltered()
+        && validated.include_count
         && validated.limit == crate::utils::cursor_pagination::DEFAULT_PAGE_SIZE;
     if use_list_cache {
         match state
@@ -1508,59 +1627,73 @@ pub async fn list_events(
     // Build the WHERE clause dynamically based on filters
     let (where_clause, param_count) = build_event_where_clause(&filters, &sort, cursor.as_ref());
 
-    // Count total matching events (no cursor so the number reflects the full filter set).
-    let (count_where, count_param_count) = build_event_where_clause(&filters, &sort, None);
-    let count_query = format!("SELECT COUNT(*) FROM events {}", count_where);
-    let mut count_builder = sqlx::query_scalar::<_, i64>(&count_query);
-    if let Some(organizer_id) = filters.organizer_id {
-        count_builder = count_builder.bind(organizer_id);
-    }
-    if let Some(ref w) = filters.organizer_wallet {
-        count_builder = count_builder.bind(w.clone());
-    }
-    if let Some(ref l) = filters.location {
-        count_builder = count_builder.bind(format!("%{}%", l));
-    }
-    if let Some(start_after) = filters.start_after {
-        count_builder = count_builder.bind(start_after);
-    }
-    if let Some(start_before) = filters.start_before {
-        count_builder = count_builder.bind(start_before);
-    }
-    if let Some(ref s) = filters.search {
-        count_builder = count_builder.bind(format!("%{}%", s));
-    }
-    if let Some(min_tickets) = filters.min_tickets_available {
-        count_builder = count_builder.bind(min_tickets);
-    }
-    if let Some(ref date_str) = filters.start_date {
-        if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
-            let dt: DateTime<Utc> =
-                Utc.from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
-            count_builder = count_builder.bind(dt);
+    // Count total matching events (same WHERE as the page query, no cursor).
+    // Skipped when `?count=false` so hot paths avoid the extra round-trip.
+    let total_count: Option<i64> = if validated.include_count {
+        let (count_where, count_param_count) = build_event_where_clause(&filters, &sort, None);
+        let count_query = format!("SELECT COUNT(*) FROM events {}", count_where);
+        let mut count_builder = sqlx::query_scalar::<_, i64>(&count_query);
+        if let Some(organizer_id) = filters.organizer_id {
+            count_builder = count_builder.bind(organizer_id);
         }
-    }
-    if let Some(ref date_str) = filters.end_date {
-        if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
-            let dt: DateTime<Utc> =
-                Utc.from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
-            count_builder = count_builder.bind(dt);
+        if let Some(ref w) = filters.organizer_wallet {
+            count_builder = count_builder.bind(w.clone());
         }
-    }
-    let _ = count_param_count; // used only to drive param numbering above
+        if let Some(ref l) = filters.location {
+            count_builder = count_builder.bind(format!("%{}%", l));
+        }
+        if let Some(start_after) = filters.start_after {
+            count_builder = count_builder.bind(start_after);
+        }
+        if let Some(start_before) = filters.start_before {
+            count_builder = count_builder.bind(start_before);
+        }
+        if let Some(ref s) = filters.search {
+            count_builder = count_builder.bind(format!("%{}%", s));
+        }
+        if let Some(min_tickets) = filters.min_tickets_available {
+            count_builder = count_builder.bind(min_tickets);
+        }
+        if let Some(ref date_str) = filters.start_date {
+            if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+                let dt: DateTime<Utc> = Utc
+                    .from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
+                count_builder = count_builder.bind(dt);
+            }
+        }
+        if let Some(ref date_str) = filters.end_date {
+            if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+                let dt: DateTime<Utc> = Utc
+                    .from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
+                count_builder = count_builder.bind(dt);
+            }
+        }
+        let _ = count_param_count;
 
-    let total_count: i64 = match count_builder.fetch_one(&state.pool).await {
-        Ok(n) => n,
-        Err(e) => {
-            tracing::warn!("Failed to fetch total count for list_events: {:?}", e);
-            0
+        match count_builder.fetch_one(&state.pool).await {
+            Ok(n) => Some(n),
+            Err(e) => {
+                tracing::warn!("Failed to fetch total count for list_events: {:?}", e);
+                Some(0)
+            }
         }
+    } else {
+        None
     };
 
-    // Fetch items (limit + 1 to detect has_more)
+    // Fetch items (limit + 1 to detect has_more). Price sort selects the
+    // allow-listed MIN(price) expression so cursor pagination stays stable.
     let order_by = build_event_order_by_clause(&sort);
+    let select_list = if sort.sort_by == EventSortBy::Price {
+        format!(
+            "SELECT events.*, ({MIN_TICKET_PRICE_SQL})::float8 AS min_ticket_price FROM events"
+        )
+    } else {
+        "SELECT * FROM events".to_string()
+    };
     let items_query = format!(
-        "SELECT * FROM events {} {} LIMIT ${}",
+        "{} {} {} LIMIT ${}",
+        select_list,
         where_clause,
         order_by,
         param_count + 1
@@ -1656,6 +1789,18 @@ pub async fn list_events(
                 };
                 items_query_builder = items_query_builder.bind(sort_key).bind(c.id);
             }
+            EventSortBy::Price => {
+                let price = match c.min_ticket_price {
+                    Some(value) => value,
+                    None => {
+                        return AppError::ValidationError(
+                            "Cursor is missing min_ticket_price for price sort".to_string(),
+                        )
+                        .into_response();
+                    }
+                };
+                items_query_builder = items_query_builder.bind(price).bind(c.id);
+            }
         }
     }
 
@@ -1682,6 +1827,7 @@ pub async fn list_events(
             created_at: Some(last.created_at),
             minted_tickets: Some(last.minted_tickets),
             count_of_ratings: Some(last.count_of_ratings as i64),
+            min_ticket_price: Some(last.min_ticket_price),
         }) {
             Ok(c) => Some(c),
             Err(e) => {
@@ -1696,7 +1842,8 @@ pub async fn list_events(
 
     populate_is_free(&mut items, &state.pool).await;
 
-    let response = CursorResponse::new(items, &validated, next_cursor);
+    let response = CursorResponse::new(items, &validated, next_cursor)
+        .with_total(total_count.unwrap_or(0), validated.include_count);
 
     if use_list_cache {
         if let Err(e) = state
@@ -1709,8 +1856,10 @@ pub async fn list_events(
     }
 
     let mut resp = success(response, "Events retrieved successfully").into_response();
-    if let Ok(v) = HeaderValue::from_str(&total_count.to_string()) {
-        resp.headers_mut().insert("X-Total-Count", v);
+    if let Some(total) = total_count {
+        if let Ok(v) = HeaderValue::from_str(&total.to_string()) {
+            resp.headers_mut().insert("X-Total-Count", v);
+        }
     }
     resp
 }
@@ -2595,6 +2744,7 @@ pub async fn search_events(
     let pagination = PaginationParams {
         page: params.page,
         page_size: params.page_size,
+        count: true,
     };
     let validated_pagination = pagination.validate();
 
@@ -3886,6 +4036,7 @@ fn map_event_row(row: &sqlx::postgres::PgRow) -> Result<(Event, f64), sqlx::Erro
         longitude: row.try_get("longitude")?,
         is_free: false,
         is_free_populated: false,
+        min_ticket_price: 0.0,
         total_tickets: 0,
         minted_tickets: 0,
     };
@@ -4490,6 +4641,7 @@ pub async fn list_events_by_category(
             created_at: Some(last.created_at),
             minted_tickets: Some(last.minted_tickets),
             count_of_ratings: Some(last.count_of_ratings as i64),
+            min_ticket_price: Some(last.min_ticket_price),
         }) {
             Ok(c) => Some(c),
             Err(e) => {
@@ -4620,7 +4772,8 @@ fn test_event_detail_tiers_omitted_when_none() {
         is_free: false,
         minted_tickets: 0,
         total_tickets: 0,
-        is_free_populated: true,
+            is_free_populated: true,
+            min_ticket_price: 0.0,
     };
 
     let detail = EventDetail {
@@ -4663,7 +4816,8 @@ fn test_event_detail_tiers_present_when_some() {
         is_free: true,
         minted_tickets: 0,
         total_tickets: 0,
-        is_free_populated: true,
+            is_free_populated: true,
+            min_ticket_price: 0.0,
     };
 
     let tier = TicketTierResponse {
@@ -4810,6 +4964,7 @@ fn test_list_events_by_category_params() {
     let params = CursorParams {
         limit: 15,
         cursor: Some("test-cursor-token".to_string()),
+        count: true,
     };
     let validated = params.validate();
     assert_eq!(validated.page_size(), 15);
@@ -4885,6 +5040,7 @@ mod search_cache_tests {
             longitude: None,
             is_free: false,
             is_free_populated: false,
+            min_ticket_price: 0.0,
             total_tickets: 100,
             minted_tickets: 42,
         };

--- a/server/src/handlers/indexer.rs
+++ b/server/src/handlers/indexer.rs
@@ -132,20 +132,23 @@ mod tests {
     #[test]
     fn rejects_zero_start_ledger() {
         let err = validate_replay_range(0, 10).unwrap_err();
-        assert_eq!(err.code, StatusCode::BAD_REQUEST.as_u16());
+        assert_eq!(err.code, crate::utils::error::ErrorCode::ValidationFailed);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]
     fn rejects_inverted_range() {
         let err = validate_replay_range(20, 10).unwrap_err();
-        assert_eq!(err.code, StatusCode::BAD_REQUEST.as_u16());
+        assert_eq!(err.code, crate::utils::error::ErrorCode::ValidationFailed);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
         assert!(err.message.contains("end_ledger"));
     }
 
     #[test]
     fn rejects_huge_ranges() {
         let err = validate_replay_range(1, MAX_REPLAY_LEDGERS + 100).unwrap_err();
-        assert_eq!(err.code, StatusCode::BAD_REQUEST.as_u16());
+        assert_eq!(err.code, crate::utils::error::ErrorCode::ValidationFailed);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
         assert!(err.message.contains("limit"));
     }
 

--- a/server/src/handlers/profile.rs
+++ b/server/src/handlers/profile.rs
@@ -757,6 +757,7 @@ pub async fn list_events_by_organizer(
             created_at: Some(last.created_at),
             minted_tickets: Some(last.minted_tickets),
             count_of_ratings: Some(last.count_of_ratings as i64),
+            min_ticket_price: Some(last.min_ticket_price),
         }) {
             Ok(c) => Some(c),
             Err(e) => {
@@ -1059,6 +1060,7 @@ mod tests {
         let params = CursorParams {
             limit: 10,
             cursor: None,
+            count: true,
         };
         let validated = params.validate();
         assert_eq!(validated.page_size(), 10);
@@ -1071,6 +1073,7 @@ mod tests {
         let params = CursorParams {
             limit: 5,
             cursor: Some("some-cursor-value".to_string()),
+            count: true,
         };
         let validated = params.validate();
         assert_eq!(validated.cursor.as_deref(), Some("some-cursor-value"));

--- a/server/src/middleware/catch_panic.rs
+++ b/server/src/middleware/catch_panic.rs
@@ -1,5 +1,5 @@
 //! Panic-catching middleware that converts uncaught panics into standardised
-//! [`ApiError`] JSON responses (`{ "code": 500, "message": "..." }`).
+//! [`ApiError`] JSON responses (`{ "code": "INTERNAL_ERROR", "message": "..." }`).
 
 use axum::response::{IntoResponse, Response};
 use tower_http::catch_panic::CatchPanicLayer;
@@ -55,7 +55,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(json["code"], 500);
+        assert_eq!(json["code"], "INTERNAL_ERROR");
         assert_eq!(json["message"], "Internal server error");
     }
 }

--- a/server/src/middleware/rate_limit.rs
+++ b/server/src/middleware/rate_limit.rs
@@ -1,16 +1,24 @@
-//! # Rate Limiting Middleware Stub
+//! # Rate Limiting Middleware
 //!
-//! `tower_governor` 0.8 requires axum 0.8, which is incompatible with the
-//! current axum 0.7 dependency. Rate limiting for public API routes is handled
-//! by the `RateLimitLayer` in `utils::rate_limit` instead.
+//! Per-IP limits are enforced by [`crate::utils::rate_limit::RateLimitLayer`]:
+//! 30 req/min on sensitive routes and 120 req/min on general routes.
 //!
-//! This module provides a no-op `GovernorRateLimitLayer` that passes requests
-//! through unchanged, preserving the existing call sites in `routes/mod.rs`.
+//! Every response includes:
+//! * `X-RateLimit-Limit` — bucket capacity for this route class
+//! * `X-RateLimit-Remaining` — tokens left in the current window
+//! * `X-RateLimit-Reset` — Unix timestamp (seconds) when the window refreshes
+//!
+//! Rejected requests additionally receive `429 Too Many Requests` with a
+//! `Retry-After` header set to the seconds remaining in the current window
+//! (always ≥ 1).
 
 use std::time::Duration;
 use tower::Layer;
 
-/// No-op rate limit layer (placeholder until axum is upgraded to 0.8).
+pub use crate::utils::rate_limit::{apply_rate_limit_headers, RateLimitLayer};
+
+/// No-op rate limit layer kept for call-site compatibility.
+/// Real limiting is applied via [`RateLimitLayer`].
 #[derive(Clone)]
 pub struct GovernorRateLimitLayer;
 

--- a/server/src/models/event.rs
+++ b/server/src/models/event.rs
@@ -57,6 +57,10 @@ pub struct Event {
     pub is_free: bool,
     #[sqlx(default)]
     pub is_free_populated: bool,
+    /// Minimum ticket-tier price for `price_asc` / `price_desc` sorting.
+    /// Defaults to `0` when the listing query does not select it.
+    #[sqlx(default)]
+    pub min_ticket_price: f64,
 }
 
 impl Event {
@@ -179,6 +183,7 @@ mod tests {
             is_free: false,
             minted_tickets: 0,
             is_free_populated: false,
+            min_ticket_price: 0.0,
         };
         assert!(!event.is_free);
     }
@@ -206,6 +211,7 @@ mod tests {
             is_free: false,
             minted_tickets: 0,
             is_free_populated: false,
+            min_ticket_price: 0.0,
         };
         event.is_free = true;
         let json = serde_json::to_value(&event).unwrap();
@@ -235,6 +241,7 @@ mod tests {
             is_free: false,
             minted_tickets: 0,
             is_free_populated: false,
+            min_ticket_price: 0.0,
         };
         assert!(event.average_rating().is_none());
     }
@@ -262,6 +269,7 @@ mod tests {
             is_free: false,
             minted_tickets: 0,
             is_free_populated: false,
+            min_ticket_price: 0.0,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["average_rating"], 4.5);
@@ -293,6 +301,7 @@ mod tests {
             is_free: false,
             minted_tickets: 0,
             is_free_populated: false,
+            min_ticket_price: 0.0,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert!(!json["created_at"].is_null(), "created_at must be present");
@@ -322,6 +331,7 @@ mod tests {
             is_free: false,
             minted_tickets: 0,
             is_free_populated: false,
+            min_ticket_price: 0.0,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert!(json["average_rating"].is_null());
@@ -351,6 +361,7 @@ mod tests {
             is_free: false,
             minted_tickets: 0,
             is_free_populated: false,
+            min_ticket_price: 0.0,
         }
     }
 

--- a/server/src/utils/cursor_pagination.rs
+++ b/server/src/utils/cursor_pagination.rs
@@ -7,6 +7,7 @@
 //! The cursor is a base64-encoded JSON object containing the sort key values
 //! of the last item on the previous page.
 
+use crate::utils::pagination::ListMeta;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -26,10 +27,18 @@ pub struct CursorParams {
 
     /// Opaque cursor string for fetching the next page
     pub cursor: Option<String>,
+
+    /// When `false`, skip the COUNT(*) query and omit `meta.total`.
+    #[serde(default = "default_count")]
+    pub count: bool,
 }
 
 fn default_page_size() -> u32 {
     DEFAULT_PAGE_SIZE
+}
+
+fn default_count() -> bool {
+    true
 }
 
 impl CursorParams {
@@ -39,6 +48,7 @@ impl CursorParams {
         ValidatedCursorParams {
             limit,
             cursor: self.cursor,
+            include_count: self.count,
         }
     }
 }
@@ -48,6 +58,8 @@ impl CursorParams {
 pub struct ValidatedCursorParams {
     pub limit: u32,
     pub cursor: Option<String>,
+    /// When `false`, callers should skip COUNT(*) and omit `meta.total`.
+    pub include_count: bool,
 }
 
 impl ValidatedCursorParams {
@@ -83,6 +95,9 @@ pub struct CursorResponse<T> {
 
     /// Pagination metadata
     pub pagination: CursorMeta,
+
+    /// Compact total-count metadata for list UIs.
+    pub meta: ListMeta,
 }
 
 impl<T> CursorResponse<T> {
@@ -92,7 +107,7 @@ impl<T> CursorResponse<T> {
     /// that row is removed and used to generate `next_cursor`.
     pub fn new(
         items: Vec<T>,
-        _params: &ValidatedCursorParams,
+        params: &ValidatedCursorParams,
         next_cursor: Option<String>,
     ) -> Self {
         let has_more = next_cursor.is_some();
@@ -105,7 +120,20 @@ impl<T> CursorResponse<T> {
                 has_more,
                 next_cursor,
             },
+            meta: ListMeta {
+                total: None,
+                page_size: params.limit,
+                has_more,
+            },
         }
+    }
+
+    /// Attach a COUNT(*) total. No-op when `?count=false` was supplied.
+    pub fn with_total(mut self, total: i64, include_count: bool) -> Self {
+        if include_count {
+            self.meta.total = Some(total);
+        }
+        self
     }
 }
 
@@ -156,6 +184,9 @@ pub struct EventCursor {
     /// Sort key for `count_of_ratings`-based ordering ("popular" sort).
     #[serde(default)]
     pub count_of_ratings: Option<i64>,
+    /// Sort key for `price_asc` / `price_desc` (minimum ticket-tier price).
+    #[serde(default)]
+    pub min_ticket_price: Option<f64>,
 }
 
 /// Cursor structure for past event listings ordered by (end_time DESC, id DESC).
@@ -183,6 +214,7 @@ mod tests {
         let params = CursorParams {
             limit: 0,
             cursor: None,
+            count: true,
         };
         let validated = params.validate();
         assert_eq!(validated.limit, 1);
@@ -194,6 +226,7 @@ mod tests {
         let params = CursorParams {
             limit: 1000,
             cursor: None,
+            count: true,
         };
         let validated = params.validate();
         assert_eq!(validated.limit, MAX_PAGE_SIZE);
@@ -204,6 +237,7 @@ mod tests {
         let params = ValidatedCursorParams {
             limit: 20,
             cursor: None,
+            include_count: true,
         };
         assert_eq!(params.query_limit(), 21);
     }
@@ -216,6 +250,7 @@ mod tests {
             created_at: Some(Utc::now()),
             minted_tickets: Some(42),
             count_of_ratings: Some(10),
+            min_ticket_price: Some(25.0),
         };
 
         let encoded = encode_cursor(&cursor).unwrap();
@@ -256,6 +291,7 @@ mod tests {
             created_at: None,
             minted_tickets: None,
             count_of_ratings: None,
+            min_ticket_price: None,
         };
         let encoded = encode_cursor(&cursor).unwrap();
         let truncated = &encoded[..encoded.len() / 2];
@@ -268,6 +304,7 @@ mod tests {
         let params = ValidatedCursorParams {
             limit: 2,
             cursor: None,
+            include_count: true,
         };
         let response: CursorResponse<i32> =
             CursorResponse::new(vec![1, 2], &params, Some("abc".to_string()));
@@ -280,6 +317,7 @@ mod tests {
         let params = ValidatedCursorParams {
             limit: 2,
             cursor: None,
+            include_count: true,
         };
         let response: CursorResponse<i32> = CursorResponse::new(vec![1, 2], &params, None);
         assert!(!response.pagination.has_more);
@@ -296,6 +334,7 @@ mod tests {
         let params = ValidatedCursorParams {
             limit: 20,
             cursor: None,
+            include_count: true,
         };
         let response: CursorResponse<i32> = CursorResponse::new(vec![], &params, None);
         assert!(!response.pagination.has_more);
@@ -309,6 +348,7 @@ mod tests {
         let params = ValidatedCursorParams {
             limit: 20,
             cursor: None,
+            include_count: true,
         };
         let response: CursorResponse<i32> = CursorResponse::new(vec![42], &params, None);
         assert!(!response.pagination.has_more);
@@ -322,6 +362,7 @@ mod tests {
         let params = ValidatedCursorParams {
             limit: 3,
             cursor: None,
+            include_count: true,
         };
         // Exactly page_size items returned — caller did NOT pass a next cursor,
         // meaning the DB had no additional rows.
@@ -336,6 +377,7 @@ mod tests {
         let params = ValidatedCursorParams {
             limit: 3,
             cursor: None,
+            include_count: true,
         };
         // Caller stripped the extra item and encoded a cursor.
         let response: CursorResponse<i32> =
@@ -345,6 +387,37 @@ mod tests {
             response.pagination.next_cursor.as_deref(),
             Some("next-token")
         );
+        assert_eq!(response.meta.page_size, 3);
+        assert!(response.meta.has_more);
+        assert!(response.meta.total.is_none());
+    }
+
+    #[test]
+    fn test_cursor_response_with_total() {
+        let params = ValidatedCursorParams {
+            limit: 20,
+            cursor: None,
+            include_count: true,
+        };
+        let response: CursorResponse<i32> =
+            CursorResponse::new(vec![1, 2], &params, None).with_total(340, true);
+        assert_eq!(response.meta.total, Some(340));
+        assert_eq!(response.meta.page_size, 20);
+        assert!(!response.meta.has_more);
+    }
+
+    #[test]
+    fn test_cursor_response_count_false_omits_total() {
+        let params = ValidatedCursorParams {
+            limit: 20,
+            cursor: None,
+            include_count: false,
+        };
+        let response: CursorResponse<i32> =
+            CursorResponse::new(vec![1], &params, None).with_total(340, false);
+        assert!(response.meta.total.is_none());
+        let json = serde_json::to_value(&response).unwrap();
+        assert!(json["meta"].get("total").is_none());
     }
 
     /// A tampered (invalid characters) base64 cursor must return an error.
@@ -381,6 +454,7 @@ mod tests {
             created_at: None,
             minted_tickets: None,
             count_of_ratings: None,
+            min_ticket_price: None,
         };
         let encoded = encode_cursor(&cursor).unwrap();
         let decoded: EventCursor = decode_cursor(&encoded).unwrap();

--- a/server/src/utils/error.rs
+++ b/server/src/utils/error.rs
@@ -4,46 +4,136 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::{error, warn};
 
+/// Stable, machine-readable API error code.
+///
+/// Serializes as `SCREAMING_SNAKE_CASE` so clients can branch on a specific
+/// failure without string-matching the human-readable message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[schema(as = String)]
+pub enum ErrorCode {
+    /// Request body or query parameters failed validation.
+    ValidationFailed,
+    /// Missing or invalid authentication credentials.
+    Unauthorized,
+    /// Authenticated caller is not allowed to perform this action.
+    Forbidden,
+    /// The requested resource does not exist.
+    NotFound,
+    /// The request conflicts with the current resource state.
+    Conflict,
+    /// The caller has exceeded the allowed request rate.
+    RateLimited,
+    /// An unexpected internal failure.
+    InternalError,
+    /// A required downstream service is temporarily unavailable.
+    ServiceUnavailable,
+}
+
+impl ErrorCode {
+    /// Wire-format string (`VALIDATION_FAILED`, `NOT_FOUND`, …).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ValidationFailed => "VALIDATION_FAILED",
+            Self::Unauthorized => "UNAUTHORIZED",
+            Self::Forbidden => "FORBIDDEN",
+            Self::NotFound => "NOT_FOUND",
+            Self::Conflict => "CONFLICT",
+            Self::RateLimited => "RATE_LIMITED",
+            Self::InternalError => "INTERNAL_ERROR",
+            Self::ServiceUnavailable => "SERVICE_UNAVAILABLE",
+        }
+    }
+
+    /// Map an HTTP status to the closest machine-readable code.
+    ///
+    /// Status codes themselves are unchanged; this only chooses the `code`
+    /// field written into the JSON body.
+    pub fn from_status(status: StatusCode) -> Self {
+        match status {
+            StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => Self::ValidationFailed,
+            StatusCode::UNAUTHORIZED => Self::Unauthorized,
+            StatusCode::FORBIDDEN => Self::Forbidden,
+            StatusCode::NOT_FOUND => Self::NotFound,
+            StatusCode::CONFLICT => Self::Conflict,
+            StatusCode::TOO_MANY_REQUESTS => Self::RateLimited,
+            StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::GATEWAY_TIMEOUT => Self::ServiceUnavailable,
+            _ => Self::InternalError,
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Reusable API error body returned by every error response.
 ///
-/// Serializes as `{ "code": <u16>, "message": "..." }` so clients can reliably
-/// read `error.code` / top-level `code` and display a user-friendly message.
+/// Serializes as `{ "code": "NOT_FOUND", "message": "..." }` so clients can
+/// branch on [`ErrorCode`] without depending on message copy. The HTTP status
+/// is carried on the response, not in this JSON body.
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ApiError {
-    /// HTTP status code mirrored in the JSON body for client-side branching.
-    pub code: u16,
+    /// Machine-readable error code.
+    pub code: ErrorCode,
     /// Human-readable error message safe to show to end users.
     pub message: String,
+    /// HTTP status used by [`IntoResponse`]. Omitted from the JSON body.
+    #[serde(skip)]
+    #[schema(ignore)]
+    status: u16,
 }
 
 impl ApiError {
     /// Build an [`ApiError`] from an HTTP status and message.
+    ///
+    /// The status code is preserved; the JSON `code` is derived from it.
     pub fn new(status: StatusCode, message: impl Into<String>) -> Self {
+        Self::with_code(ErrorCode::from_status(status), status, message)
+    }
+
+    /// Build an [`ApiError`] with an explicit machine-readable code.
+    pub fn with_code(
+        code: ErrorCode,
+        status: StatusCode,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
-            code: status.as_u16(),
+            code,
             message: message.into(),
+            status: status.as_u16(),
         }
     }
 
     /// Convenience constructor for unexpected internal failures / panics.
     pub fn internal(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::INTERNAL_SERVER_ERROR, message)
+        Self::with_code(
+            ErrorCode::InternalError,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            message,
+        )
+    }
+
+    /// HTTP status associated with this error.
+    pub fn status(&self) -> StatusCode {
+        StatusCode::from_u16(self.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
     }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let status = StatusCode::from_u16(self.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let status = self.status();
         (status, axum::Json(self)).into_response()
     }
 }
 
 impl From<AppError> for ApiError {
     fn from(err: AppError) -> Self {
-        Self {
-            code: err.status_code().as_u16(),
-            message: err.public_message(),
-        }
+        Self::with_code(err.error_code(), err.status_code(), err.public_message())
     }
 }
 
@@ -141,21 +231,21 @@ impl AppError {
     }
 
     /// Return a stable, machine-readable error code for the variant.
-    pub fn error_code(&self) -> &'static str {
+    pub fn error_code(&self) -> ErrorCode {
         match self {
-            AppError::ValidationError(_) => "VALIDATION_ERROR",
-            AppError::AuthError(_) => "AUTH_ERROR",
-            AppError::Forbidden(_) => "FORBIDDEN",
-            AppError::NotFound(_) => "NOT_FOUND",
-            AppError::Conflict(_) => "CONFLICT",
+            AppError::ValidationError(_) => ErrorCode::ValidationFailed,
+            AppError::AuthError(_) => ErrorCode::Unauthorized,
+            AppError::Forbidden(_) => ErrorCode::Forbidden,
+            AppError::NotFound(_) => ErrorCode::NotFound,
+            AppError::Conflict(_) => ErrorCode::Conflict,
             AppError::DatabaseError(err) => match DatabaseErrorCategory::from_sqlx(err) {
-                DatabaseErrorCategory::Connection => "DATABASE_UNAVAILABLE",
-                DatabaseErrorCategory::UniqueViolation => "UNIQUE_VIOLATION",
-                DatabaseErrorCategory::ForeignKeyViolation => "FOREIGN_KEY_VIOLATION",
-                DatabaseErrorCategory::Query => "DATABASE_ERROR",
+                DatabaseErrorCategory::Connection => ErrorCode::ServiceUnavailable,
+                DatabaseErrorCategory::UniqueViolation
+                | DatabaseErrorCategory::ForeignKeyViolation => ErrorCode::Conflict,
+                DatabaseErrorCategory::Query => ErrorCode::InternalError,
             },
-            AppError::ExternalServiceError(_) => "EXTERNAL_SERVICE_ERROR",
-            AppError::InternalServerError(_) => "INTERNAL_SERVER_ERROR",
+            AppError::ExternalServiceError(_) => ErrorCode::ServiceUnavailable,
+            AppError::InternalServerError(_) => ErrorCode::InternalError,
         }
     }
 
@@ -193,7 +283,7 @@ impl AppError {
 ///
 /// ```json
 /// {
-///   "code": 404,
+///   "code": "NOT_FOUND",
 ///   "message": "Resource with id '42' was not found"
 /// }
 /// ```
@@ -216,9 +306,9 @@ impl IntoResponse for AppError {
                 }
             },
             _ => {
-                error!(
+                    error!(
                     error = ?self,
-                    code = machine_code,
+                    code = %machine_code,
                     http_status = status.as_u16(),
                     message,
                     "Application error"
@@ -226,7 +316,7 @@ impl IntoResponse for AppError {
             }
         }
 
-        ApiError::new(status, message).into_response()
+        ApiError::with_code(machine_code, status, message).into_response()
     }
 }
 
@@ -288,18 +378,45 @@ mod tests {
     fn test_error_codes() {
         assert_eq!(
             AppError::ValidationError("x".into()).error_code(),
-            "VALIDATION_ERROR"
+            ErrorCode::ValidationFailed
         );
-        assert_eq!(AppError::AuthError("x".into()).error_code(), "AUTH_ERROR");
-        assert_eq!(AppError::Forbidden("x".into()).error_code(), "FORBIDDEN");
-        assert_eq!(AppError::NotFound("x".into()).error_code(), "NOT_FOUND");
+        assert_eq!(
+            AppError::AuthError("x".into()).error_code(),
+            ErrorCode::Unauthorized
+        );
+        assert_eq!(
+            AppError::Forbidden("x".into()).error_code(),
+            ErrorCode::Forbidden
+        );
+        assert_eq!(
+            AppError::NotFound("x".into()).error_code(),
+            ErrorCode::NotFound
+        );
+        assert_eq!(
+            AppError::Conflict("x".into()).error_code(),
+            ErrorCode::Conflict
+        );
         assert_eq!(
             AppError::ExternalServiceError("x".into()).error_code(),
-            "EXTERNAL_SERVICE_ERROR"
+            ErrorCode::ServiceUnavailable
         );
         assert_eq!(
             AppError::InternalServerError("x".into()).error_code(),
-            "INTERNAL_SERVER_ERROR"
+            ErrorCode::InternalError
+        );
+    }
+
+    #[test]
+    fn test_error_code_serializes_screaming_snake_case() {
+        let json = serde_json::to_value(ErrorCode::ValidationFailed).unwrap();
+        assert_eq!(json, "VALIDATION_FAILED");
+        assert_eq!(
+            serde_json::to_value(ErrorCode::RateLimited).unwrap(),
+            "RATE_LIMITED"
+        );
+        assert_eq!(
+            serde_json::to_value(ErrorCode::InternalError).unwrap(),
+            "INTERNAL_ERROR"
         );
     }
 
@@ -432,7 +549,7 @@ mod tests {
         let resp = AppError::DatabaseError(sqlx::Error::PoolTimedOut).into_response();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 503);
+        assert_eq!(json["code"], "SERVICE_UNAVAILABLE");
         assert_eq!(
             json["message"],
             "Database service is temporarily unavailable"
@@ -452,7 +569,7 @@ mod tests {
             .into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 409);
+        assert_eq!(json["code"], "CONFLICT");
         assert_eq!(
             json["message"],
             "A resource with this identifier already exists"
@@ -465,7 +582,7 @@ mod tests {
             .into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 409);
+        assert_eq!(json["code"], "CONFLICT");
         assert_eq!(json["message"], "The referenced resource does not exist");
     }
 
@@ -477,7 +594,7 @@ mod tests {
     async fn test_into_response_body_has_flat_code_and_message() {
         let resp = AppError::ValidationError("oops".into()).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 400);
+        assert_eq!(json["code"], "VALIDATION_FAILED");
         assert_eq!(json["message"], "oops");
         assert!(json.get("success").is_none());
         assert!(json.get("error").is_none());
@@ -488,7 +605,7 @@ mod tests {
         let resp = ApiError::new(StatusCode::NOT_FOUND, "thing").into_response();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 404);
+        assert_eq!(json["code"], "NOT_FOUND");
         assert_eq!(json["message"], "thing");
     }
 
@@ -496,7 +613,7 @@ mod tests {
     async fn test_into_response_validation_error_body() {
         let resp = AppError::ValidationError("name is required".into()).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 400);
+        assert_eq!(json["code"], "VALIDATION_FAILED");
         assert_eq!(json["message"], "name is required");
     }
 
@@ -504,7 +621,7 @@ mod tests {
     async fn test_into_response_auth_error_body() {
         let resp = AppError::AuthError("token missing".into()).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 401);
+        assert_eq!(json["code"], "UNAUTHORIZED");
         assert_eq!(json["message"], "token missing");
     }
 
@@ -512,7 +629,7 @@ mod tests {
     async fn test_into_response_forbidden_body() {
         let resp = AppError::Forbidden("not allowed".into()).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 403);
+        assert_eq!(json["code"], "FORBIDDEN");
         assert_eq!(json["message"], "not allowed");
     }
 
@@ -520,7 +637,7 @@ mod tests {
     async fn test_into_response_not_found_body() {
         let resp = AppError::NotFound("record 42".into()).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 404);
+        assert_eq!(json["code"], "NOT_FOUND");
         assert_eq!(json["message"], "record 42");
     }
 
@@ -529,7 +646,7 @@ mod tests {
         let resp =
             AppError::ExternalServiceError("payment gateway unreachable".into()).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 503);
+        assert_eq!(json["code"], "SERVICE_UNAVAILABLE");
         assert_eq!(json["message"], "payment gateway unreachable");
     }
 
@@ -537,7 +654,7 @@ mod tests {
     async fn test_into_response_internal_server_error_body() {
         let resp = AppError::InternalServerError("crash".into()).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 500);
+        assert_eq!(json["code"], "INTERNAL_ERROR");
         assert_eq!(json["message"], "crash");
     }
 
@@ -545,7 +662,7 @@ mod tests {
     async fn test_into_response_database_error_hides_details() {
         let resp = AppError::DatabaseError(sqlx::Error::RowNotFound).into_response();
         let json = body_json(resp).await;
-        assert_eq!(json["code"], 500);
+        assert_eq!(json["code"], "INTERNAL_ERROR");
         assert_eq!(json["message"], "A database error occurred");
     }
 

--- a/server/src/utils/pagination.rs
+++ b/server/src/utils/pagination.rs
@@ -22,6 +22,10 @@ pub struct PaginationParams {
     /// Number of items per page
     #[serde(default = "default_page_size")]
     pub page_size: u32,
+
+    /// When `false`, skip the COUNT(*) query and omit `meta.total`.
+    #[serde(default = "default_count")]
+    pub count: bool,
 }
 
 fn default_page() -> u32 {
@@ -32,13 +36,21 @@ fn default_page_size() -> u32 {
     DEFAULT_PAGE_SIZE
 }
 
+fn default_count() -> bool {
+    true
+}
+
 impl PaginationParams {
     /// Validate and normalize pagination parameters
     pub fn validate(self) -> ValidatedPagination {
         let page = if self.page == 0 { 1 } else { self.page };
         let page_size = self.page_size.clamp(1, MAX_PAGE_SIZE);
 
-        ValidatedPagination { page, page_size }
+        ValidatedPagination {
+            page,
+            page_size,
+            include_count: self.count,
+        }
     }
 }
 
@@ -47,6 +59,8 @@ impl PaginationParams {
 pub struct ValidatedPagination {
     pub page: u32,
     pub page_size: u32,
+    /// When `false`, callers should skip COUNT(*) and omit `meta.total`.
+    pub include_count: bool,
 }
 
 impl ValidatedPagination {
@@ -77,6 +91,28 @@ impl ValidatedPagination {
             has_previous: self.page > 1,
         }
     }
+
+    /// Compact list metadata (`total`, `page_size`, `has_more`).
+    ///
+    /// `total` is omitted when `include_count` is false.
+    pub fn list_meta(&self, total: Option<i64>, item_count: usize) -> ListMeta {
+        let has_more = match total {
+            Some(t) => {
+                let total_pages = if t == 0 {
+                    0
+                } else {
+                    ((t as f64) / (self.page_size as f64)).ceil() as u32
+                };
+                self.page < total_pages
+            }
+            None => item_count as u32 >= self.page_size,
+        };
+        ListMeta {
+            total: total.filter(|_| self.include_count),
+            page_size: self.page_size,
+            has_more,
+        }
+    }
 }
 
 /// Pagination metadata included in responses
@@ -101,6 +137,22 @@ pub struct PaginationMeta {
     pub has_previous: bool,
 }
 
+/// Compact metadata included on paginated list responses.
+///
+/// Used by clients to render copy such as "Showing 12 of 340" and to size a pager.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListMeta {
+    /// Total matching rows. Omitted when the caller passed `?count=false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<i64>,
+
+    /// Requested page size.
+    pub page_size: u32,
+
+    /// Whether another page of results exists.
+    pub has_more: bool,
+}
+
 /// Standard paginated response wrapper
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PaginatedResponse<T> {
@@ -109,14 +161,34 @@ pub struct PaginatedResponse<T> {
 
     /// Pagination metadata
     pub pagination: PaginationMeta,
+
+    /// Compact total-count metadata for list UIs.
+    pub meta: ListMeta,
 }
 
 impl<T> PaginatedResponse<T> {
     /// Create a new paginated response
     pub fn new(items: Vec<T>, pagination: ValidatedPagination, total: i64) -> Self {
+        let item_count = items.len();
         Self {
             items,
             pagination: pagination.metadata(total),
+            meta: pagination.list_meta(Some(total), item_count),
+        }
+    }
+
+    /// Create a paginated response, omitting `meta.total` when `include_count` is false.
+    pub fn new_with_optional_total(
+        items: Vec<T>,
+        pagination: ValidatedPagination,
+        total: Option<i64>,
+    ) -> Self {
+        let item_count = items.len();
+        let pagination_meta = pagination.metadata(total.unwrap_or(0));
+        Self {
+            items,
+            pagination: pagination_meta,
+            meta: pagination.list_meta(total, item_count),
         }
     }
 }
@@ -130,6 +202,7 @@ mod tests {
         let params = PaginationParams {
             page: 0,
             page_size: 0,
+            count: true,
         };
         let validated = params.validate();
 
@@ -142,6 +215,7 @@ mod tests {
         let params = PaginationParams {
             page: 1,
             page_size: 1000,
+            count: true,
         };
         let validated = params.validate();
 
@@ -153,18 +227,21 @@ mod tests {
         let validated = ValidatedPagination {
             page: 1,
             page_size: 20,
+            include_count: true,
         };
         assert_eq!(validated.offset(), 0);
 
         let validated = ValidatedPagination {
             page: 2,
             page_size: 20,
+            include_count: true,
         };
         assert_eq!(validated.offset(), 20);
 
         let validated = ValidatedPagination {
             page: 5,
             page_size: 10,
+            include_count: true,
         };
         assert_eq!(validated.offset(), 40);
     }
@@ -174,6 +251,7 @@ mod tests {
         let validated = ValidatedPagination {
             page: 2,
             page_size: 10,
+            include_count: true,
         };
         let meta = validated.metadata(45);
 
@@ -190,6 +268,7 @@ mod tests {
         let validated = ValidatedPagination {
             page: 1,
             page_size: 10,
+            include_count: true,
         };
         let meta = validated.metadata(45);
 
@@ -202,6 +281,7 @@ mod tests {
         let validated = ValidatedPagination {
             page: 5,
             page_size: 10,
+            include_count: true,
         };
         let meta = validated.metadata(45);
 
@@ -214,11 +294,50 @@ mod tests {
         let validated = ValidatedPagination {
             page: 1,
             page_size: 10,
+            include_count: true,
         };
         let meta = validated.metadata(0);
 
         assert_eq!(meta.total_pages, 0);
         assert!(!meta.has_next);
         assert!(!meta.has_previous);
+    }
+
+    #[test]
+    fn test_list_meta_includes_total_by_default() {
+        let validated = ValidatedPagination {
+            page: 1,
+            page_size: 20,
+            include_count: true,
+        };
+        let meta = validated.list_meta(Some(340), 12);
+        assert_eq!(meta.total, Some(340));
+        assert_eq!(meta.page_size, 20);
+        assert!(meta.has_more);
+    }
+
+    #[test]
+    fn test_list_meta_omits_total_when_count_disabled() {
+        let validated = ValidatedPagination {
+            page: 1,
+            page_size: 20,
+            include_count: false,
+        };
+        let meta = validated.list_meta(Some(340), 12);
+        assert_eq!(meta.total, None);
+        assert_eq!(meta.page_size, 20);
+    }
+
+    #[test]
+    fn test_paginated_response_includes_meta() {
+        let validated = ValidatedPagination {
+            page: 1,
+            page_size: 2,
+            include_count: true,
+        };
+        let response = PaginatedResponse::new(vec!["a", "b"], validated, 5);
+        assert_eq!(response.meta.total, Some(5));
+        assert_eq!(response.meta.page_size, 2);
+        assert!(response.meta.has_more);
     }
 }

--- a/server/src/utils/rate_limit.rs
+++ b/server/src/utils/rate_limit.rs
@@ -18,11 +18,13 @@ use std::{
 
 use axum::{
     body::Body,
-    http::{Request, Response, StatusCode},
+    http::{header::HeaderValue, HeaderMap, Request, Response, StatusCode},
+    response::IntoResponse,
 };
 use dashmap::DashMap;
-use serde_json::json;
 use tower::{Layer, Service};
+
+use crate::utils::error::ApiError;
 
 // ---------------------------------------------------------------------------
 // Token bucket
@@ -43,8 +45,7 @@ impl TokenBucket {
     }
 
     /// Refill tokens based on elapsed time, then try to consume one.
-    /// Returns `true` if the request is allowed.
-    fn try_acquire(&mut self, capacity: f64, refill_per_sec: f64) -> bool {
+    fn try_acquire(&mut self, capacity: f64, refill_per_sec: f64) -> AcquireOutcome {
         let now = Instant::now();
         let elapsed = now.duration_since(self.last_refill).as_secs_f64();
         self.tokens = (self.tokens + elapsed * refill_per_sec).min(capacity);
@@ -52,11 +53,67 @@ impl TokenBucket {
 
         if self.tokens >= 1.0 {
             self.tokens -= 1.0;
-            true
+            let secs_until_full = if refill_per_sec > 0.0 {
+                ((capacity - self.tokens) / refill_per_sec).ceil() as u64
+            } else {
+                1
+            };
+            AcquireOutcome {
+                allowed: true,
+                remaining: self.tokens.floor() as u64,
+                retry_after: secs_until_full.max(1),
+            }
         } else {
-            false
+            let retry_after = if refill_per_sec > 0.0 {
+                ((1.0 - self.tokens) / refill_per_sec).ceil() as u64
+            } else {
+                1
+            };
+            AcquireOutcome {
+                allowed: false,
+                remaining: 0,
+                retry_after: retry_after.max(1),
+            }
         }
     }
+}
+
+struct AcquireOutcome {
+    allowed: bool,
+    remaining: u64,
+    retry_after: u64,
+}
+
+/// Apply standard rate-limit headers. `Retry-After` is set only on 429s.
+pub fn apply_rate_limit_headers(
+    headers: &mut HeaderMap,
+    limit: usize,
+    remaining: u64,
+    reset_epoch: u64,
+    retry_after: Option<u64>,
+) {
+    if let Ok(v) = HeaderValue::from_str(&limit.to_string()) {
+        headers.insert("x-ratelimit-limit", v);
+    }
+    if let Ok(v) = HeaderValue::from_str(&remaining.to_string()) {
+        headers.insert("x-ratelimit-remaining", v);
+    }
+    if let Ok(v) = HeaderValue::from_str(&reset_epoch.to_string()) {
+        headers.insert("x-ratelimit-reset", v);
+    }
+    if let Some(secs) = retry_after {
+        let value = secs.max(1);
+        if let Ok(v) = HeaderValue::from_str(&value.to_string()) {
+            headers.insert("retry-after", v);
+        }
+    }
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 type Store = Arc<DashMap<IpAddr, TokenBucket>>;
@@ -152,12 +209,21 @@ where
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         let ip = extract_ip(&req);
-
-        let allowed = if self.max_requests == 0 {
-            false
+        let window_secs = self.window.as_secs().max(1);
+        let capacity = self.max_requests as f64;
+        let refill_per_sec = if self.max_requests == 0 {
+            0.0
         } else {
-            let capacity = self.max_requests as f64;
-            let refill_per_sec = capacity / self.window.as_secs_f64().max(0.001);
+            capacity / self.window.as_secs_f64().max(0.001)
+        };
+
+        let outcome = if self.max_requests == 0 {
+            AcquireOutcome {
+                allowed: false,
+                remaining: 0,
+                retry_after: window_secs,
+            }
+        } else {
             let mut entry = self
                 .store
                 .entry(ip)
@@ -165,29 +231,34 @@ where
             entry.try_acquire(capacity, refill_per_sec)
         };
 
-        if !allowed {
-            let retry_after = self.window.as_secs().max(1).to_string();
-            let body = json!({
-                "success": false,
-                "error": {
-                    "code": 429,
-                    "message": "Too many requests. Please try again later."
-                }
-            })
-            .to_string();
+        let limit = self.max_requests;
+        let remaining = outcome.remaining;
+        let retry_after = outcome.retry_after.max(1);
+        let reset_epoch = unix_now().saturating_add(retry_after);
 
-            let response = Response::builder()
-                .status(StatusCode::TOO_MANY_REQUESTS)
-                .header("Content-Type", "application/json")
-                .header("Retry-After", retry_after)
-                .body(Body::from(body))
-                .unwrap();
-
+        if !outcome.allowed {
+            let mut response = ApiError::with_code(
+                crate::utils::error::ErrorCode::RateLimited,
+                StatusCode::TOO_MANY_REQUESTS,
+                "Too many requests. Please try again later.",
+            )
+            .into_response();
+            apply_rate_limit_headers(
+                response.headers_mut(),
+                limit,
+                remaining,
+                reset_epoch,
+                Some(retry_after),
+            );
             return Box::pin(async move { Ok(response) });
         }
 
         let future = self.inner.call(req);
-        Box::pin(future)
+        Box::pin(async move {
+            let mut response = future.await?;
+            apply_rate_limit_headers(response.headers_mut(), limit, remaining, reset_epoch, None);
+            Ok(response)
+        })
     }
 }
 
@@ -249,12 +320,16 @@ mod tests {
     }
 
     async fn send(router: &Router, ip: &str) -> StatusCode {
+        send_full(router, ip).await.status()
+    }
+
+    async fn send_full(router: &Router, ip: &str) -> axum::http::Response<Body> {
         let req = Request::builder()
             .uri("/test")
             .header("x-forwarded-for", ip)
             .body(Body::empty())
             .unwrap();
-        router.clone().oneshot(req).await.unwrap().status()
+        router.clone().oneshot(req).await.unwrap()
     }
 
     #[tokio::test]
@@ -322,8 +397,8 @@ mod tests {
 
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(body["success"], false);
-        assert_eq!(body["error"]["code"], 429);
+        assert_eq!(body["code"], "RATE_LIMITED");
+        assert!(body["message"].is_string());
     }
 
     #[tokio::test]
@@ -336,6 +411,44 @@ mod tests {
             .unwrap();
         let resp = router.oneshot(req).await.unwrap();
         assert!(resp.headers().contains_key("retry-after"));
+        let secs: u64 = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        assert!(secs >= 1, "Retry-After must be at least 1, got {secs}");
+        assert!(resp.headers().contains_key("x-ratelimit-limit"));
+        assert!(resp.headers().contains_key("x-ratelimit-remaining"));
+        assert!(resp.headers().contains_key("x-ratelimit-reset"));
+    }
+
+    #[tokio::test]
+    async fn test_exhausted_limit_retry_after_is_present_and_positive() {
+        let router = rate_limited_router(1, Duration::from_secs(60));
+        let allowed = send_full(&router, "8.8.8.8").await;
+        assert_eq!(allowed.status(), StatusCode::OK);
+        assert_eq!(
+            allowed.headers().get("x-ratelimit-limit").unwrap(),
+            "1"
+        );
+        assert!(allowed.headers().contains_key("x-ratelimit-remaining"));
+        assert!(allowed.headers().contains_key("x-ratelimit-reset"));
+        assert!(allowed.headers().get("retry-after").is_none());
+
+        let rejected = send_full(&router, "8.8.8.8").await;
+        assert_eq!(rejected.status(), StatusCode::TOO_MANY_REQUESTS);
+        let secs: u64 = rejected
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse().ok())
+            .expect("Retry-After header");
+        assert!(secs >= 1);
+        assert_eq!(
+            rejected.headers().get("x-ratelimit-remaining").unwrap(),
+            "0"
+        );
     }
 
     #[tokio::test]

--- a/server/src/utils/response.rs
+++ b/server/src/utils/response.rs
@@ -14,9 +14,10 @@
 //! }
 //! ```
 //!
-//! Error responses use the flat `{ "code": <u16>, "message": "..." }` shape
+//! Error responses use the flat `{ "code": "NOT_FOUND", "message": "..." }` shape
 //! (see [`crate::utils::error::ApiError`]).
 
+use crate::utils::error::ErrorCode;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -40,8 +41,8 @@ where
 /// Error response body structure — flat `{ code, message }` shape.
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct ApiErrorBody {
-    /// HTTP status code mirrored for client-side branching
-    pub code: u16,
+    /// Machine-readable error code.
+    pub code: ErrorCode,
     /// Human-readable error message
     pub message: String,
 }
@@ -84,8 +85,8 @@ pub fn empty_success(message: impl Into<String>) -> impl IntoResponse {
 
 /// Creates an error response with the standardised flat JSON body.
 ///
-/// The `code` string argument is retained for call-site compatibility but the
-/// HTTP status is the numeric `code` written into the JSON body.
+/// The `code` string argument is retained for call-site compatibility; the
+/// JSON `code` is a machine-readable [`ErrorCode`] derived from `status`.
 pub fn error(
     _code: &str,
     message: impl Into<String>,
@@ -93,7 +94,7 @@ pub fn error(
     status: StatusCode,
 ) -> Response {
     let body = ApiErrorBody {
-        code: status.as_u16(),
+        code: ErrorCode::from_status(status),
         message: message.into(),
     };
 

--- a/server/tests/health_integration.rs
+++ b/server/tests/health_integration.rs
@@ -122,8 +122,8 @@ async fn test_unknown_path_returns_404_in_standard_api_error_shape() {
         .unwrap();
     let json: Value = serde_json::from_slice(&bytes).expect("Valid JSON response");
 
-    // Assert standard ApiError shape: { "code": 404, "message": "..." }
-    assert_eq!(json["code"], 404);
+    // Assert standard ApiError shape: { "code": "NOT_FOUND", "message": "..." }
+    assert_eq!(json["code"], "NOT_FOUND");
     assert!(json["message"].is_string());
 }
 


### PR DESCRIPTION
## Summary
Implements four independent backend API improvements so clients can handle errors, back off from 429s, page large event catalogues, and sort the events list without fragile string matching or extra round trips.

## #1255 — Stable machine-readable error codes
- Added `ErrorCode` in `server/src/utils/error.rs` with `SCREAMING_SNAKE_CASE` serialization.
- Codes: `VALIDATION_FAILED`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `CONFLICT`, `RATE_LIMITED`, `INTERNAL_ERROR`, plus `SERVICE_UNAVAILABLE` for 5xx downstream/DB outages.
- Every `ApiError` JSON body now includes `code` (string). HTTP status and `message` text are unchanged.
- Existing constructors map by status/variant (validation → `VALIDATION_FAILED`, auth → `UNAUTHORIZED`, unique/FK conflicts → `CONFLICT`, 429 → `RATE_LIMITED`, etc.).
- Documented every code in `server/API.md`.

## #1256 — Retry-After and rate-limit headers
- On 429, `Retry-After` is the seconds remaining until a token is available (always ≥ 1).
- `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` are set on both allowed and rejected responses.
- Added a test that exhausts the limit and asserts `Retry-After` is present and positive; successful responses also carry the `X-RateLimit-*` headers.
- Headers documented in `server/API.md`.

## #1257 — Total-count metadata on paginated lists
- Paginated responses now include `meta: { total, page_size, has_more }`.
- `GET /api/v1/events` runs `COUNT(*)` with the same WHERE clause as the page query.
- `?count=false` skips that query and omits `meta.total`.
- OpenAPI updated in `server/openapi.yaml`.

## #1258 — Sort query parameter for events list
- `GET /api/v1/events?sort=` accepts `starts_at_asc` (default), `starts_at_desc`, `price_asc`, `price_desc`, `popularity_desc`.
- Values map to a fixed allow-listed `ORDER BY` (never interpolated). Secondary `ORDER BY id` keeps pagination stable.
- Unrecognised values return 400 with `VALIDATION_FAILED`.
- Tests cover each accepted value and one rejected value.

## Test plan
- [x] Error JSON bodies include a string `code`; HTTP statuses and messages unchanged
- [x] Exhaust a rate limit: 429 has `Retry-After >= 1` and `X-RateLimit-*`; 200s also have `X-RateLimit-*`
- [x] Events list `meta.total` present by default; omitted when `?count=false`
- [x] Each documented `sort` value produces the expected ORDER BY; invalid `sort` → 400 `VALIDATION_FAILED`

closes #1255
closes #1256
closes #1257
closes #1258