### PR TITLE
feat(frontend): highlight matched query in help center search results

### DIFF
--- a/apps/web/app/help/page.tsx
+++ b/apps/web/app/help/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
+import { HighlightText } from "@/components/ui/highlight-text";
 
 // Icon imports — all sourced from /public/icons/
 import SearchIcon from "@/public/icons/search.svg";

--- a/apps/web/app/help/page.tsx
+++ b/apps/web/app/help/page.tsx
@@ -233,11 +233,11 @@ export default function HelpCenterPage() {
 
                   {/* Text */}
                   <h3 className="font-bold text-base text-black leading-snug mb-1">
-                    {category.title}
-                  </h3>
+                    <HighlightText text={category.title} query={query} />
+                </h3>
                   <p className="text-sm text-gray-500 flex-1 leading-relaxed">
-                    {category.description}
-                  </p>
+                    <HighlightText text={category.description} query={query} />
+                </p>
 
                   {/* Footer row */}
                   <div className="mt-4 pt-4 border-t border-gray-100 flex items-center justify-between">

--- a/apps/web/components/ui/highlight-text.tsx
+++ b/apps/web/components/ui/highlight-text.tsx
@@ -1,0 +1,51 @@
+export interface HighlightTextProps {
+  text: string;
+  query: string;
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * HighlightText — highlights all occurrences of `query` within `text`
+ * using `<mark>` with the design-system accent background.
+ *
+ * When `query` is empty or whitespace-only, the original text is returned
+ * without any highlighting.
+ */
+export function HighlightText({ text, query }: HighlightTextProps) {
+  const q = query.trim();
+  if (!q) return <>{text}</>;
+
+  const escaped = escapeRegExp(q);
+  const matcher = new RegExp(escaped, "gi");
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = matcher.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+    nodes.push(
+      <mark
+        key={key++}
+        className="bg-accent text-ink px-0.5 rounded-[2px]"
+      >
+        {match[0]}
+      </mark>
+    );
+    lastIndex = match.index + match[0].length;
+    if (match[0].length === 0) {
+      matcher.lastIndex++;
+    }
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return <>{nodes}</>;
+}


### PR DESCRIPTION
## Summary

Help center search results in `apps/web/app/help/page.tsx` show plain titles — it's not obvious why an article matched. This PR adds a reusable `HighlightText` component that highlights matching substrings with `<mark>`.

## Changes

- **New** `apps/web/components/ui/highlight-text.tsx` — takes `text` and `query` props, escapes regex metacharacters, matches case-insensitively, and highlights every occurrence with the design-system accent background
- **Modified** `apps/web/app/help/page.tsx` — wraps result titles and descriptions with `HighlightText`

## Verification

- Searching "ticket" highlights every occurrence of "ticket"/"Ticket" in results
- Searching a string containing regex characters (`c++`, `(`) does not throw
- When query is empty, no highlighting is applied
- Uses `bg-accent text-ink` — readable in both light and dark mode

Closes #1222