### PR TITLE
test(server): add performance benchmarks and chaos testing suite

### DIFF
--- a/scripts/generate_perf_report.mjs
+++ b/scripts/generate_perf_report.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+// ==============================================================================
+// Agora Performance Regression Report Generator (Issue #1178)
+// ==============================================================================
+// Reads criterion's per-benchmark `estimates.json` files and a k6
+// `--summary-export` JSON file, and produces a single Markdown regression
+// report with p50/p95/p99 latency and throughput (RPS) for CI runs — the
+// "structured performance regression report" the issue asks for.
+//
+// Zero npm dependencies (fs/path/process only) so it never needs an install
+// step in CI — it just needs a `node` binary, already required by the rest
+// of this monorepo's frontend tooling.
+//
+// Usage:
+//   node scripts/generate_perf_report.mjs \
+//     --k6-summary=scripts/.stress-results/summary.json \
+//     --criterion-dir=server/target/criterion \
+//     --baseline=scripts/perf_baseline.json \
+//     [--fail-on-regression] [--update-baseline] [--threshold=20]
+//
+// Any input that's missing is skipped gracefully — the report still renders
+// with whatever data is available (e.g. a run with only criterion results
+// and no k6 summary still produces a useful report).
+// ==============================================================================
+
+import { readFileSync, writeFileSync, existsSync, appendFileSync, readdirSync } from 'node:fs';
+import { resolve, relative, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {
+    k6Summary: 'scripts/.stress-results/summary.json',
+    criterionDir: 'server/target/criterion',
+    baseline: 'scripts/perf_baseline.json',
+    failOnRegression: false,
+    updateBaseline: false,
+    thresholdPercent: 20,
+  };
+  for (const raw of argv) {
+    const [flag, value] = raw.split('=');
+    switch (flag) {
+      case '--k6-summary':
+        args.k6Summary = value;
+        break;
+      case '--criterion-dir':
+        args.criterionDir = value;
+        break;
+      case '--baseline':
+        args.baseline = value;
+        break;
+      case '--fail-on-regression':
+        args.failOnRegression = true;
+        break;
+      case '--update-baseline':
+        args.updateBaseline = true;
+        break;
+      case '--threshold':
+        args.thresholdPercent = Number(value);
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// criterion: walk target/criterion/**/new/estimates.json
+// ---------------------------------------------------------------------------
+
+function findEstimatesFiles(dir) {
+  const results = [];
+  if (!existsSync(dir)) return results;
+
+  const walk = (current) => {
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name === 'estimates.json' && current.endsWith('new')) {
+        results.push(full);
+      }
+    }
+  };
+  walk(dir);
+  return results;
+}
+
+function nsToMs(ns) {
+  return ns / 1_000_000;
+}
+
+function loadCriterionResults(criterionDir) {
+  const absDir = resolve(REPO_ROOT, criterionDir);
+  const files = findEstimatesFiles(absDir);
+  const results = [];
+
+  for (const file of files) {
+    // .../target/criterion/<benchmark path...>/new/estimates.json
+    const rel = relative(absDir, file);
+    const parts = rel.split(/[\\/]/).filter((p) => p !== 'new' && p !== 'estimates.json');
+    const name = parts.join(' / ') || rel;
+
+    try {
+      const data = JSON.parse(readFileSync(file, 'utf8'));
+      results.push({
+        name,
+        meanMs: nsToMs(data.mean.point_estimate),
+        stdDevMs: nsToMs(data.std_dev.point_estimate),
+        medianMs: nsToMs(data.median?.point_estimate ?? data.mean.point_estimate),
+      });
+    } catch (e) {
+      console.error(`warning: failed to parse ${file}: ${e.message}`);
+    }
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// k6: --summary-export JSON
+// ---------------------------------------------------------------------------
+
+function loadK6Summary(k6SummaryPath) {
+  const absPath = resolve(REPO_ROOT, k6SummaryPath);
+  if (!existsSync(absPath)) return null;
+
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(absPath, 'utf8'));
+  } catch (e) {
+    console.error(`warning: failed to parse k6 summary at ${absPath}: ${e.message}`);
+    return null;
+  }
+
+  const metrics = raw.metrics || {};
+  const pick = (metricName, field, fallback = null) => {
+    const m = metrics[metricName];
+    if (!m) return fallback;
+    // k6 nests percentile/rate values under `values` in newer summary
+    // formats and directly on the metric object in older ones.
+    const values = m.values || m;
+    return values[field] ?? fallback;
+  };
+
+  const httpReqs = metrics.http_reqs;
+  const testDurationSeconds = raw.state?.testRunDurationMs
+    ? raw.state.testRunDurationMs / 1000
+    : null;
+  const totalRequests = httpReqs ? (httpReqs.values || httpReqs).count : null;
+  const rps =
+    totalRequests && testDurationSeconds ? totalRequests / testDurationSeconds : pick('http_reqs', 'rate');
+
+  return {
+    httpReqDuration: {
+      p50: pick('http_req_duration', 'med'),
+      p95: pick('http_req_duration', 'p(95)'),
+      p99: pick('http_req_duration', 'p(99)'),
+      avg: pick('http_req_duration', 'avg'),
+    },
+    httpReqFailedRate: pick('http_req_failed', 'rate'),
+    rps,
+    totalRequests,
+    perPhase: {
+      browse: extractTrend(metrics, 'agora_browse_duration'),
+      queue: extractTrend(metrics, 'agora_queue_duration'),
+      checkout: extractTrend(metrics, 'agora_checkout_duration'),
+      scan: extractTrend(metrics, 'agora_scan_duration'),
+      powSolve: extractTrend(metrics, 'agora_pow_solve_duration'),
+    },
+    funnelErrorRate: pick('agora_funnel_error_rate', 'rate'),
+  };
+}
+
+function extractTrend(metrics, name) {
+  const m = metrics[name];
+  if (!m) return null;
+  const values = m.values || m;
+  return { p50: values.med, p95: values['p(95)'], p99: values['p(99)'], avg: values.avg };
+}
+
+// ---------------------------------------------------------------------------
+// Baseline comparison
+// ---------------------------------------------------------------------------
+
+function loadBaseline(baselinePath) {
+  const absPath = resolve(REPO_ROOT, baselinePath);
+  if (!existsSync(absPath)) return null;
+  try {
+    return JSON.parse(readFileSync(absPath, 'utf8'));
+  } catch (e) {
+    console.error(`warning: failed to parse baseline at ${absPath}: ${e.message}`);
+    return null;
+  }
+}
+
+function pctChange(current, baseline) {
+  if (baseline === null || baseline === undefined || baseline === 0) return null;
+  return ((current - baseline) / baseline) * 100;
+}
+
+function compareCriterion(current, baseline, thresholdPercent) {
+  const baselineByName = new Map((baseline?.criterion || []).map((b) => [b.name, b]));
+  const regressions = [];
+  const rows = current.map((bench) => {
+    const base = baselineByName.get(bench.name);
+    const change = base ? pctChange(bench.meanMs, base.meanMs) : null;
+    const regressed = change !== null && change > thresholdPercent;
+    if (regressed) regressions.push({ name: bench.name, change, kind: 'criterion' });
+    return { ...bench, change, regressed };
+  });
+  return { rows, regressions };
+}
+
+function compareK6(current, baseline, thresholdPercent) {
+  if (!current || !baseline?.k6) return { regressions: [] };
+  const regressions = [];
+  for (const key of ['p50', 'p95', 'p99']) {
+    const cur = current.httpReqDuration[key];
+    const base = baseline.k6.httpReqDuration?.[key];
+    const change = pctChange(cur, base);
+    if (change !== null && change > thresholdPercent) {
+      regressions.push({ name: `k6 http_req_duration ${key}`, change, kind: 'k6' });
+    }
+  }
+  return { regressions };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+function fmtMs(v) {
+  if (v === null || v === undefined || Number.isNaN(v)) return '—';
+  return `${v.toFixed(2)}ms`;
+}
+
+function fmtPct(v) {
+  if (v === null || v === undefined) return '—';
+  return `${(v * 100).toFixed(2)}%`;
+}
+
+function fmtChange(v) {
+  if (v === null || v === undefined) return '—';
+  const sign = v > 0 ? '+' : '';
+  const flag = v > 0 ? ' ⚠️' : '';
+  return `${sign}${v.toFixed(1)}%${flag}`;
+}
+
+function renderReport({ criterionComparison, k6Summary, k6Comparison, generatedAt }) {
+  const lines = [];
+  lines.push('## Performance Regression Report');
+  lines.push('');
+  lines.push(`_Generated ${generatedAt}_`);
+  lines.push('');
+
+  lines.push('### k6 Load Test — browse → queue → checkout → scan');
+  lines.push('');
+  if (k6Summary) {
+    lines.push('| Metric | p50 | p95 | p99 |');
+    lines.push('|---|---|---|---|');
+    lines.push(
+      `| Overall \`http_req_duration\` | ${fmtMs(k6Summary.httpReqDuration.p50)} | ${fmtMs(
+        k6Summary.httpReqDuration.p95,
+      )} | ${fmtMs(k6Summary.httpReqDuration.p99)} |`,
+    );
+    for (const [phase, trend] of Object.entries(k6Summary.perPhase)) {
+      if (!trend) continue;
+      lines.push(`| ${phase} | ${fmtMs(trend.p50)} | ${fmtMs(trend.p95)} | ${fmtMs(trend.p99)} |`);
+    }
+    lines.push('');
+    lines.push(`**Throughput:** ${k6Summary.rps ? k6Summary.rps.toFixed(1) : '—'} req/s`);
+    lines.push(`**Total requests:** ${k6Summary.totalRequests ?? '—'}`);
+    lines.push(`**HTTP failure rate:** ${fmtPct(k6Summary.httpReqFailedRate)}`);
+    lines.push(`**Funnel error rate:** ${fmtPct(k6Summary.funnelErrorRate)}`);
+
+    if (k6Comparison.regressions.length > 0) {
+      lines.push('');
+      lines.push('**⚠️ Regressions vs. baseline:**');
+      for (const r of k6Comparison.regressions) {
+        lines.push(`- ${r.name}: ${fmtChange(r.change)}`);
+      }
+    }
+  } else {
+    lines.push('_No k6 summary found — run `scripts/run_stress_test.sh` first._');
+  }
+  lines.push('');
+
+  lines.push('### Criterion Benchmarks');
+  lines.push('');
+  if (criterionComparison.rows.length > 0) {
+    lines.push('| Benchmark | Mean | Std Dev | vs. Baseline |');
+    lines.push('|---|---|---|---|');
+    for (const row of criterionComparison.rows) {
+      const flag = row.regressed ? ' ⚠️' : '';
+      lines.push(
+        `| ${row.name} | ${fmtMs(row.meanMs)} | ${fmtMs(row.stdDevMs)} | ${fmtChange(row.change)}${flag} |`,
+      );
+    }
+  } else {
+    lines.push(
+      '_No criterion results found — run `cargo bench` in `server/` first (some benches ' +
+        'require `DATABASE_URL` to register more than zero benchmarks; see `server/benches/`)._',
+    );
+  }
+
+  if (criterionComparison.regressions.length > 0) {
+    lines.push('');
+    lines.push(
+      `**⚠️ ${criterionComparison.regressions.length} benchmark(s) regressed beyond threshold.**`,
+    );
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const criterionResults = loadCriterionResults(args.criterionDir);
+  const k6Summary = loadK6Summary(args.k6Summary);
+  const baseline = loadBaseline(args.baseline);
+
+  const criterionComparison = compareCriterion(criterionResults, baseline, args.thresholdPercent);
+  const k6Comparison = compareK6(k6Summary, baseline, args.thresholdPercent);
+
+  const report = renderReport({
+    criterionComparison,
+    k6Summary,
+    k6Comparison,
+    generatedAt: new Date().toISOString(),
+  });
+
+  console.log(report);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
+  }
+
+  if (args.updateBaseline) {
+    const newBaseline = {
+      generatedAt: new Date().toISOString(),
+      criterion: criterionResults.map(({ name, meanMs, stdDevMs }) => ({ name, meanMs, stdDevMs })),
+      k6: k6Summary ? { httpReqDuration: k6Summary.httpReqDuration, rps: k6Summary.rps } : undefined,
+    };
+    writeFileSync(resolve(REPO_ROOT, args.baseline), JSON.stringify(newBaseline, null, 2) + '\n');
+    console.log(`Baseline updated at ${args.baseline}`);
+  }
+
+  const totalRegressions = criterionComparison.regressions.length + k6Comparison.regressions.length;
+  if (args.failOnRegression && totalRegressions > 0) {
+    console.error(`\n${totalRegressions} performance regression(s) exceeded the ${args.thresholdPercent}% threshold.`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/perf_baseline.json
+++ b/scripts/perf_baseline.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Performance baseline for scripts/generate_perf_report.mjs (Issue #1178). Empty until a maintainer runs `node scripts/generate_perf_report.mjs --update-baseline` against a known-good build. With no entries, regression comparisons have nothing to compare against and report zero regressions rather than failing spuriously.",
+  "generatedAt": null,
+  "criterion": [],
+  "k6": null
+}

--- a/scripts/run_stress_test.sh
+++ b/scripts/run_stress_test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# ==============================================================================
+# Agora k6 Stress Test Runner (Issue #1178)
+# ==============================================================================
+# Thin wrapper around `k6 run scripts/stress_test.js` that:
+#   - verifies k6 is installed (with an install hint if not)
+#   - waits for the target server's /health endpoint before generating load,
+#     so a slow-starting server doesn't get counted as a wall of failures
+#   - exports a machine-readable summary for
+#     scripts/generate_perf_report.mjs / CI regression reporting
+#
+# Usage:
+#   ./scripts/run_stress_test.sh
+#   BASE_URL=http://localhost:3001 VUS=50 DURATION=5m ./scripts/run_stress_test.sh
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+BASE_URL="${BASE_URL:-http://localhost:3001}"
+VUS="${VUS:-20}"
+DURATION="${DURATION:-2m}"
+RAMP_TIME="${RAMP_TIME:-30s}"
+OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/scripts/.stress-results}"
+WAIT_FOR_SERVER_SECONDS="${WAIT_FOR_SERVER_SECONDS:-60}"
+
+mkdir -p "$OUT_DIR"
+
+if ! command -v k6 >/dev/null 2>&1; then
+  echo "ERROR: k6 is not installed." >&2
+  echo "  macOS:   brew install k6" >&2
+  echo "  Linux:   see https://grafana.com/docs/k6/latest/set-up/install-k6/" >&2
+  echo "  CI:      this repo's chaos-bench workflow installs it via grafana/setup-k6-action" >&2
+  exit 1
+fi
+
+echo "==> Waiting for $BASE_URL/api/v1/health (up to ${WAIT_FOR_SERVER_SECONDS}s)..."
+elapsed=0
+until curl -fsS "$BASE_URL/api/v1/health" >/dev/null 2>&1; do
+  if [ "$elapsed" -ge "$WAIT_FOR_SERVER_SECONDS" ]; then
+    echo "ERROR: $BASE_URL did not become healthy within ${WAIT_FOR_SERVER_SECONDS}s" >&2
+    exit 1
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+echo "==> Server is healthy. Starting stress test (VUS=$VUS DURATION=$DURATION RAMP_TIME=$RAMP_TIME)..."
+
+SUMMARY_JSON="$OUT_DIR/summary.json"
+SUMMARY_TEXT="$OUT_DIR/summary.txt"
+
+BASE_URL="$BASE_URL" VUS="$VUS" DURATION="$DURATION" RAMP_TIME="$RAMP_TIME" \
+  k6 run \
+    --summary-export="$SUMMARY_JSON" \
+    "$SCRIPT_DIR/stress_test.js" | tee "$SUMMARY_TEXT"
+
+echo ""
+echo "==> Stress test complete. Summary written to:"
+echo "      $SUMMARY_JSON"
+echo "      $SUMMARY_TEXT"
+echo "==> Generate a p50/p95/p99 + RPS regression report with:"
+echo "      node $SCRIPT_DIR/generate_perf_report.mjs --k6-summary=$SUMMARY_JSON"

--- a/scripts/stress_test.js
+++ b/scripts/stress_test.js
@@ -1,0 +1,345 @@
+// ==============================================================================
+// Agora k6 Stress / Load Test — browse -> queue -> checkout -> scan (Issue #1178)
+// ==============================================================================
+// Note on file extension: the issue's target location names this
+// `scripts/stress_test.rs`, but k6 scripts run on k6's embedded Goja
+// JavaScript runtime — it cannot execute Rust. This is the equivalent
+// modular k6 script at `scripts/stress_test.js`; the Rust side of the
+// suite (criterion benchmarks, the chaos harness, and the re-org runner)
+// lives under `server/benches/` and `server/tests/` per the rest of the
+// issue's target locations.
+//
+// Simulates the realistic funnel a real Agora attendee walks through:
+//   1. browse   — list/search events, view an event, view its ticket tiers
+//   2. queue    — solve the SHA-256 proof-of-work gate and join the virtual
+//                 waiting room (agora_server::handlers::waiting_room)
+//   3. checkout — generate a signed QR payload for a ticket
+//                 (agora_server::handlers::qr_payload). Actual on-chain
+//                 payment happens client-side via the Soroban SDK against
+//                 the `ticket_payment` contract, outside this REST surface,
+//                 so it is out of scope for an HTTP load generator.
+//   4. scan     — present the QR payload at the gate
+//                 (POST /api/v1/tickets/:id/scan)
+//
+// Usage:
+//   k6 run scripts/stress_test.js
+//   BASE_URL=https://staging.agora.example VUS=50 DURATION=5m k6 run scripts/stress_test.js
+//   k6 run --summary-export=summary.json scripts/stress_test.js
+//
+// Env vars:
+//   BASE_URL   Agora API base URL          (default: http://localhost:3001)
+//   VUS        peak virtual users          (default: 20)
+//   DURATION   sustained load duration     (default: 2m)
+//   RAMP_TIME  ramp up/down duration       (default: 30s)
+// ==============================================================================
+
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { sha256 } from 'k6/crypto';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3001';
+const API = `${BASE_URL}/api/v1`;
+const PEAK_VUS = Number(__ENV.VUS || 20);
+const DURATION = __ENV.DURATION || '2m';
+const RAMP_TIME = __ENV.RAMP_TIME || '30s';
+// Safety valve for the proof-of-work solver — a wildly high difficulty
+// (server misconfiguration) must not spin a VU forever.
+const MAX_POW_ATTEMPTS = Number(__ENV.MAX_POW_ATTEMPTS || 2_000_000);
+
+// ---------------------------------------------------------------------------
+// Custom metrics — one Trend per funnel phase so CI can report p50/p95/p99
+// per stage, not just an aggregate. `scripts/generate_perf_report.mjs`
+// reads these back out of the k6 summary JSON.
+// ---------------------------------------------------------------------------
+
+const browseDuration = new Trend('agora_browse_duration', true);
+const queueDuration = new Trend('agora_queue_duration', true);
+const checkoutDuration = new Trend('agora_checkout_duration', true);
+const scanDuration = new Trend('agora_scan_duration', true);
+const powSolveDuration = new Trend('agora_pow_solve_duration', true);
+const powAttempts = new Trend('agora_pow_attempts');
+const funnelCompleted = new Counter('agora_funnel_completed_total');
+const funnelErrors = new Rate('agora_funnel_error_rate');
+
+// ---------------------------------------------------------------------------
+// k6 scenario / threshold configuration
+// ---------------------------------------------------------------------------
+
+export const options = {
+  scenarios: {
+    browse_to_scan_funnel: {
+      executor: 'ramping-vus',
+      exec: 'fullFunnel',
+      startVUs: 0,
+      stages: [
+        { duration: RAMP_TIME, target: PEAK_VUS },
+        { duration: DURATION, target: PEAK_VUS },
+        { duration: RAMP_TIME, target: 0 },
+      ],
+      gracefulRampDown: '10s',
+    },
+    // A lighter, browse-only scenario running the whole time to model
+    // casual traffic (users who never queue) alongside the funnel above.
+    browse_only: {
+      executor: 'constant-vus',
+      exec: 'browseOnly',
+      vus: Math.max(2, Math.floor(PEAK_VUS / 4)),
+      duration: DURATION,
+      startTime: RAMP_TIME,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<1500', 'p(99)<3000'],
+    agora_browse_duration: ['p(95)<800'],
+    agora_funnel_error_rate: ['rate<0.10'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Proof-of-work solver — mirrors agora_server::services::pow::verify_pow
+// exactly: SHA-256(challenge || nonce) must have `difficulty` leading hex
+// zeros, where nonce is the decimal string form of an increasing counter
+// (see server/src/services/pow.rs::solve_pow).
+// ---------------------------------------------------------------------------
+
+function solvePow(challenge, difficulty) {
+  const target = '0'.repeat(difficulty);
+  const start = Date.now();
+  for (let nonce = 0; nonce < MAX_POW_ATTEMPTS; nonce++) {
+    const digestHex = sha256(challenge + String(nonce), 'hex');
+    if (digestHex.substring(0, difficulty) === target) {
+      powSolveDuration.add(Date.now() - start);
+      powAttempts.add(nonce + 1);
+      return String(nonce);
+    }
+  }
+  throw new Error(`pow: exhausted ${MAX_POW_ATTEMPTS} attempts at difficulty ${difficulty}`);
+}
+
+function uuidv4() {
+  // RFC 4122 v4 via Math.random — fine for load-test payload uniqueness,
+  // not for anything security-sensitive.
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Browse
+// ---------------------------------------------------------------------------
+
+/// Returns the id of an event to carry into the queue/checkout phases, or
+/// `null` when the environment has no events seeded (browse still ran and
+/// still contributes latency data either way).
+function browse() {
+  const start = Date.now();
+  let chosenEventId = null;
+
+  group('browse', () => {
+    const list = http.get(`${API}/events?limit=20`, { tags: { phase: 'browse' } });
+    check(list, { 'browse: list events succeeds': (r) => r.status === 200 });
+
+    const upcoming = http.get(`${API}/events/upcoming?limit=10`, { tags: { phase: 'browse' } });
+    check(upcoming, { 'browse: upcoming events succeeds': (r) => r.status === 200 });
+
+    const searchTerm = ['music', 'tech', 'art', 'sports'][randomIntBetween(0, 3)];
+    const search = http.get(`${API}/events/search?q=${searchTerm}`, { tags: { phase: 'browse' } });
+    check(search, { 'browse: search succeeds': (r) => r.status === 200 || r.status === 400 });
+
+    chosenEventId = extractFirstEventId(list) || extractFirstEventId(upcoming);
+
+    if (chosenEventId) {
+      const detail = http.get(`${API}/events/${chosenEventId}`, { tags: { phase: 'browse' } });
+      check(detail, { 'browse: event detail succeeds': (r) => r.status === 200 || r.status === 404 });
+
+      const tiers = http.get(`${API}/events/${chosenEventId}/ticket-tiers`, {
+        tags: { phase: 'browse' },
+      });
+      check(tiers, {
+        'browse: ticket tiers succeeds': (r) => r.status === 200 || r.status === 404,
+      });
+    }
+  });
+
+  browseDuration.add(Date.now() - start);
+  return chosenEventId;
+}
+
+function extractFirstEventId(res) {
+  if (!res || res.status !== 200) return null;
+  try {
+    const body = res.json();
+    const items = (body && body.data && (body.data.items || body.data.events || body.data)) || [];
+    if (Array.isArray(items) && items.length > 0 && items[0] && items[0].id) {
+      return items[0].id;
+    }
+  } catch (_e) {
+    // Non-JSON or unexpected shape — treat as "no event available" rather
+    // than failing the whole iteration.
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Queue (proof-of-work gate + virtual waiting room)
+// ---------------------------------------------------------------------------
+
+/// Returns true once the client is admitted (or the event has no queue
+/// configured, i.e. the join call itself fails gracefully), false on a hard
+/// failure worth counting against the error rate.
+function queue(eventId, clientId) {
+  if (!eventId) return true; // nothing to queue for in this environment
+
+  const start = Date.now();
+  let ok = true;
+
+  group('queue', () => {
+    const challengeRes = http.post(
+      `${API}/waiting-room/challenge`,
+      JSON.stringify({ event_id: eventId }),
+      { headers: { 'Content-Type': 'application/json' }, tags: { phase: 'queue' } },
+    );
+    if (challengeRes.status !== 200) {
+      // Waiting room may not be configured for this event/environment —
+      // that's a valid non-error outcome for a load test, not a bug.
+      return;
+    }
+
+    let challenge, difficulty;
+    try {
+      const body = challengeRes.json();
+      challenge = body.data.challenge;
+      difficulty = body.data.difficulty;
+    } catch (_e) {
+      ok = false;
+      return;
+    }
+
+    const nonce = solvePow(challenge, difficulty);
+
+    const joinRes = http.post(
+      `${API}/waiting-room/join`,
+      JSON.stringify({ event_id: eventId, client_id: clientId, challenge, nonce }),
+      { headers: { 'Content-Type': 'application/json' }, tags: { phase: 'queue' } },
+    );
+    ok = check(joinRes, {
+      'queue: join succeeds or reports sold out': (r) =>
+        r.status === 200 || r.status === 409 || r.status === 422,
+    });
+
+    if (joinRes.status === 200) {
+      const statusRes = http.get(
+        `${API}/waiting-room/status?event_id=${eventId}&client_id=${clientId}`,
+        { tags: { phase: 'queue' } },
+      );
+      check(statusRes, { 'queue: status check succeeds': (r) => r.status === 200 || r.status === 404 });
+    }
+  });
+
+  queueDuration.add(Date.now() - start);
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Checkout (signed QR issuance — the platform-side half of a
+// purchase; the on-chain leg runs through the Soroban `ticket_payment`
+// contract via the client's wallet, not this REST API).
+// ---------------------------------------------------------------------------
+
+function checkout(eventId) {
+  const start = Date.now();
+  const ticketId = uuidv4();
+
+  const res = http.post(
+    `${API}/qr/generate`,
+    JSON.stringify({
+      qr_type: 'ticket',
+      data: { event_id: eventId, ticket_id: ticketId },
+      ticket_id: ticketId,
+      expires_in_seconds: 3600,
+    }),
+    { headers: { 'Content-Type': 'application/json' }, tags: { phase: 'checkout' } },
+  );
+
+  checkoutDuration.add(Date.now() - start);
+
+  const ok = check(res, { 'checkout: qr generation succeeds': (r) => r.status === 200 });
+  if (!ok) return null;
+
+  try {
+    const body = res.json();
+    return { ticketId, qr: body.data };
+  } catch (_e) {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Scan (gate check-in)
+// ---------------------------------------------------------------------------
+
+function scan(ticketId, qr) {
+  if (!qr) return;
+
+  const start = Date.now();
+  const res = http.post(
+    `${API}/tickets/${ticketId}/scan`,
+    JSON.stringify({
+      payload: qr.payload,
+      signature: qr.signature,
+      public_key: qr.public_key,
+    }),
+    { headers: { 'Content-Type': 'application/json' }, tags: { phase: 'scan' } },
+  );
+  scanDuration.add(Date.now() - start);
+
+  // A synthetic ticket_id was never actually minted on-chain, so a 404/422
+  // here is expected under load-test conditions — only a 5xx indicates the
+  // scan endpoint itself is unhealthy under load.
+  check(res, {
+    'scan: endpoint does not 5xx under load': (r) => r.status < 500,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scenario entry points
+// ---------------------------------------------------------------------------
+
+export function fullFunnel() {
+  const clientId = `k6-vu-${__VU}-iter-${__ITER}`;
+  let succeeded = true;
+
+  const eventId = browse();
+  sleep(randomIntBetween(1, 3));
+
+  succeeded = queue(eventId, clientId) && succeeded;
+  sleep(randomIntBetween(1, 2));
+
+  if (eventId) {
+    const checkoutResult = checkout(eventId);
+    sleep(randomIntBetween(1, 2));
+    if (checkoutResult) {
+      scan(checkoutResult.ticketId, checkoutResult.qr);
+      funnelCompleted.add(1);
+    } else {
+      succeeded = false;
+    }
+  }
+
+  funnelErrors.add(!succeeded);
+  sleep(randomIntBetween(1, 4));
+}
+
+export function browseOnly() {
+  browse();
+  sleep(randomIntBetween(2, 6));
+}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "chrono",
+ "criterion",
  "curve25519-dalek",
  "dashmap",
  "dotenvy",
@@ -104,6 +105,18 @@ checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "arbitrary"
@@ -941,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1018,58 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -1143,6 +1214,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1284,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1747,6 +1862,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1955,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2206,6 +2338,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,6 +2694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2841,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -4151,6 +4337,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -95,3 +95,22 @@ dashmap = "6.2.1"
 temp-env = { version = "0.3", features = ["async_closure"] }
 tower = { version = "0.4", features = ["full"] }
 serde_yaml = "0.9"
+
+# Criterion benchmark harness (Issue #1178)
+criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
+
+[[bench]]
+name = "serialization_bench"
+harness = false
+
+[[bench]]
+name = "handler_bench"
+harness = false
+
+[[bench]]
+name = "db_query_bench"
+harness = false
+
+[[bench]]
+name = "reorg_indexer_bench"
+harness = false

--- a/server/benches/db_query_bench.rs
+++ b/server/benches/db_query_bench.rs
@@ -1,0 +1,216 @@
+//! # Database Query Benchmarks (Issue #1178)
+//!
+//! Benchmarks real PostgreSQL round trips: the ledger-checkpoint upsert that
+//! sits on the Soroban indexer's hot path (`CheckpointStore`), and a
+//! cursor-paginated ticket listing query against seeded data.
+//!
+//! Requires a reachable `DATABASE_URL` with migrations applied (same
+//! requirement as `server/tests/auth_integration.rs`). When `DATABASE_URL`
+//! is unset this binary registers zero benchmarks and exits cleanly instead
+//! of failing the build, so `cargo bench` still works in environments
+//! without Postgres.
+//!
+//! ```bash
+//! DATABASE_URL=postgres://user:password@localhost:5432/agora cargo bench --bench db_query_bench
+//! ```
+//!
+//! All rows this benchmark writes live under a synthetic organizer created
+//! at startup and are removed via `ON DELETE CASCADE` in a teardown step, so
+//! it is safe to run repeatedly against a shared dev database. The
+//! checkpoint row uses a `bench:` prefixed `chain_key` that can never
+//! collide with a real `soroban:*` chain.
+
+use agora_server::models::blockchain_checkpoint::CheckpointStore;
+use criterion::{black_box, Criterion};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+const SEEDED_TICKET_COUNT: i64 = 500;
+
+struct BenchFixture {
+    pool: PgPool,
+    chain_key: String,
+    organizer_id: Uuid,
+    event_id: Uuid,
+}
+
+impl BenchFixture {
+    async fn setup(pool: PgPool) -> Self {
+        let organizer_id = Uuid::new_v4();
+        let event_id = Uuid::new_v4();
+        let chain_key = format!("bench:checkpoint:{organizer_id}");
+
+        sqlx::query(
+            "INSERT INTO organizers (id, name, contact_email) VALUES ($1, 'Bench Organizer', 'bench@agora.test')",
+        )
+        .bind(organizer_id)
+        .execute(&pool)
+        .await
+        .expect("seed organizer");
+
+        sqlx::query(
+            "INSERT INTO events (id, organizer_id, title, location, start_time)
+             VALUES ($1, $2, 'Bench Event', 'Bench Venue', NOW())",
+        )
+        .bind(event_id)
+        .bind(organizer_id)
+        .execute(&pool)
+        .await
+        .expect("seed event");
+
+        for i in 0..SEEDED_TICKET_COUNT {
+            sqlx::query(
+                "INSERT INTO tickets (stellar_id, event_id, buyer_wallet, owner_wallet, status)
+                 VALUES ($1, $2, $3, $3, 'Unused')",
+            )
+            .bind(format!("bench-stellar-id-{organizer_id}-{i}"))
+            .bind(event_id)
+            .bind(format!("GBENCHWALLET{i:06}"))
+            .execute(&pool)
+            .await
+            .expect("seed ticket");
+        }
+
+        Self {
+            pool,
+            chain_key,
+            organizer_id,
+            event_id,
+        }
+    }
+
+    /// Deleting the organizer cascades to its event and every seeded ticket
+    /// (`events.organizer_id` and `tickets.event_id` are both
+    /// `ON DELETE CASCADE`); the checkpoint row is cleaned separately since
+    /// it has no FK relationship to organizers.
+    async fn teardown(&self) {
+        let _ = sqlx::query("DELETE FROM organizers WHERE id = $1")
+            .bind(self.organizer_id)
+            .execute(&self.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM blockchain_checkpoints WHERE chain_key = $1")
+            .bind(&self.chain_key)
+            .execute(&self.pool)
+            .await;
+    }
+}
+
+fn bench_checkpoint_save_load_roundtrip(c: &mut Criterion, rt: &tokio::runtime::Runtime, fx: &BenchFixture) {
+    let mut ledger = 1_000_000i64;
+    c.bench_function("checkpoint_save_upsert", |b| {
+        b.to_async(rt).iter(|| {
+            ledger += 1;
+            let pool = fx.pool.clone();
+            let chain_key = fx.chain_key.clone();
+            async move {
+                CheckpointStore::save(&pool, &chain_key, black_box(ledger), None)
+                    .await
+                    .unwrap();
+            }
+        })
+    });
+
+    c.bench_function("checkpoint_load", |b| {
+        b.to_async(rt).iter(|| {
+            let pool = fx.pool.clone();
+            let chain_key = fx.chain_key.clone();
+            async move {
+                black_box(CheckpointStore::load(&pool, &chain_key).await.unwrap());
+            }
+        })
+    });
+}
+
+fn bench_checkpoint_rollback(c: &mut Criterion, rt: &tokio::runtime::Runtime, fx: &BenchFixture) {
+    // Rollback is only meaningfully benchmarked with buffered rows present —
+    // seed a small window so the DELETE inside the transaction does real work.
+    rt.block_on(async {
+        for ledger in 999_900i64..1_000_000 {
+            sqlx::query(
+                "INSERT INTO indexer_ledger_events (id, ledger, contract_id, topic, value, finalized)
+                 VALUES ($1, $2, 'bench-contract', '\"Bench\"'::jsonb, '{}'::jsonb, FALSE)
+                 ON CONFLICT (id) DO NOTHING",
+            )
+            .bind(format!("bench-evt-{}-{ledger}", fx.organizer_id))
+            .bind(ledger)
+            .execute(&fx.pool)
+            .await
+            .unwrap();
+        }
+    });
+
+    c.bench_function("checkpoint_rollback_to_100_ledger_window", |b| {
+        b.to_async(rt).iter(|| {
+            let pool = fx.pool.clone();
+            let chain_key = fx.chain_key.clone();
+            async move {
+                black_box(
+                    CheckpointStore::rollback_to(&pool, &chain_key, 999_900)
+                        .await
+                        .unwrap(),
+                );
+            }
+        })
+    });
+
+    rt.block_on(async {
+        let _ = sqlx::query("DELETE FROM indexer_ledger_events WHERE contract_id = 'bench-contract'")
+            .execute(&fx.pool)
+            .await;
+    });
+}
+
+fn bench_ticket_pagination_query(c: &mut Criterion, rt: &tokio::runtime::Runtime, fx: &BenchFixture) {
+    let mut group = c.benchmark_group("ticket_list_pagination_by_page_size");
+    for limit in [10i64, 20, 50, 100] {
+        group.bench_with_input(
+            criterion::BenchmarkId::from_parameter(limit),
+            &limit,
+            |b, &limit| {
+                b.to_async(rt).iter(|| {
+                    let pool = fx.pool.clone();
+                    let event_id = fx.event_id;
+                    async move {
+                        let rows = sqlx::query_as::<_, (Uuid, String)>(
+                            "SELECT id, status FROM tickets
+                             WHERE event_id = $1
+                             ORDER BY created_at ASC, id ASC
+                             LIMIT $2",
+                        )
+                        .bind(event_id)
+                        .bind(black_box(limit))
+                        .fetch_all(&pool)
+                        .await
+                        .unwrap();
+                        black_box(rows.len());
+                    }
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+fn main() {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!(
+            "db_query_bench: DATABASE_URL not set, skipping (0 benchmarks registered). \
+             Set DATABASE_URL to a migrated Postgres instance to run these benchmarks."
+        );
+        return;
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let pool = rt
+        .block_on(PgPool::connect(&database_url))
+        .expect("connect to DATABASE_URL");
+    let fixture = rt.block_on(BenchFixture::setup(pool));
+
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_checkpoint_save_load_roundtrip(&mut criterion, &rt, &fixture);
+    bench_checkpoint_rollback(&mut criterion, &rt, &fixture);
+    bench_ticket_pagination_query(&mut criterion, &rt, &fixture);
+
+    rt.block_on(fixture.teardown());
+    criterion.final_summary();
+}

--- a/server/benches/handler_bench.rs
+++ b/server/benches/handler_bench.rs
@@ -1,0 +1,134 @@
+//! # Handler & Middleware Stack Benchmarks (Issue #1178)
+//!
+//! Drives real Axum handlers through the same `tower::ServiceExt::oneshot`
+//! path used by the existing integration tests (see
+//! `server/tests/health_integration.rs`) — no TCP listener, no external
+//! services — so these benchmarks isolate in-process request handling cost:
+//! request-id propagation, tracing, panic catching, and per-IP rate limiting.
+//!
+//! Also benchmarks the SHA-256 proof-of-work gate
+//! (`agora_server::services::pow`) that guards entry into the virtual
+//! waiting room, since its cost directly bounds how fast the `queue` phase
+//! of the k6 stress script (`scripts/stress_test.js`) can move.
+//!
+//! ```bash
+//! cargo bench --bench handler_bench
+//! ```
+
+use agora_server::config::request_id::{propagate_request_id_layer, set_request_id_layer};
+use agora_server::middleware::catch_panic::catch_panic_layer;
+use agora_server::middleware::request_id_tracing::{propagate_request_id, trace_request_id};
+use agora_server::services::pow::{generate_challenge, solve_pow, verify_pow, DEFAULT_DIFFICULTY};
+use agora_server::utils::rate_limit::RateLimitLayer;
+use axum::{body::Body, http::Request, middleware, routing::get, Router};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Router builders
+// ---------------------------------------------------------------------------
+
+/// The same middleware stack `routes::create_routes` applies, minus CORS /
+/// security headers / DB-backed layers so the benchmark stays hermetic.
+fn full_stack_router() -> Router {
+    Router::new()
+        .route("/ping", get(|| async { "pong" }))
+        .layer(middleware::from_fn(trace_request_id))
+        .layer(middleware::from_fn(propagate_request_id))
+        .layer(propagate_request_id_layer())
+        .layer(set_request_id_layer())
+        .layer(catch_panic_layer())
+}
+
+fn rate_limited_router(max: usize) -> Router {
+    full_stack_router().layer(RateLimitLayer::new(max, std::time::Duration::from_secs(60)))
+}
+
+fn get_request(path: &str) -> Request<Body> {
+    Request::builder().uri(path).body(Body::empty()).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_middleware_stack_roundtrip(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let router = full_stack_router();
+
+    c.bench_function("middleware_stack_oneshot_roundtrip", |b| {
+        b.to_async(&rt).iter(|| {
+            let router = router.clone();
+            async move {
+                let resp = router.oneshot(get_request("/ping")).await.unwrap();
+                black_box(resp.status());
+            }
+        })
+    });
+}
+
+fn bench_rate_limited_roundtrip_below_capacity(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    // A fresh router per invocation (not per-iteration) with headroom well
+    // above criterion's sample count so every request in the sample stays
+    // in the "allowed" branch of the token bucket — we're isolating the
+    // bucket's steady-state overhead, not its rejection path.
+    let router = rate_limited_router(1_000_000);
+
+    c.bench_function("rate_limit_layer_allowed_request", |b| {
+        b.to_async(&rt).iter(|| {
+            let router = router.clone();
+            async move {
+                let resp = router.oneshot(get_request("/ping")).await.unwrap();
+                black_box(resp.status());
+            }
+        })
+    });
+}
+
+fn bench_pow_challenge_generation(c: &mut Criterion) {
+    c.bench_function("pow_generate_challenge", |b| {
+        b.iter(generate_challenge)
+    });
+}
+
+fn bench_pow_verify(c: &mut Criterion) {
+    let challenge = generate_challenge();
+    let nonce = solve_pow(&challenge, DEFAULT_DIFFICULTY).expect("solvable at default difficulty");
+
+    c.bench_function("pow_verify_single_hash", |b| {
+        b.iter(|| verify_pow(black_box(&challenge), black_box(&nonce), DEFAULT_DIFFICULTY))
+    });
+}
+
+/// The waiting-room `join` step actually pays this cost client-side, but
+/// benchmarking it here quantifies the CPU budget the k6 stress script
+/// (which solves the same puzzle in JS) needs to model per admitted client.
+fn bench_pow_solve_by_difficulty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pow_solve");
+    group.sample_size(20); // solving is expensive; keep wall-clock reasonable
+    for difficulty in [1u32, 2, 3, DEFAULT_DIFFICULTY] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(difficulty),
+            &difficulty,
+            |b, &difficulty| {
+                b.iter_batched(
+                    generate_challenge,
+                    |challenge| solve_pow(black_box(&challenge), difficulty),
+                    criterion::BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_middleware_stack_roundtrip,
+    bench_rate_limited_roundtrip_below_capacity,
+    bench_pow_challenge_generation,
+    bench_pow_verify,
+    bench_pow_solve_by_difficulty,
+);
+criterion_main!(benches);

--- a/server/benches/reorg_indexer_bench.rs
+++ b/server/benches/reorg_indexer_bench.rs
@@ -1,0 +1,262 @@
+//! # Re-org Resilient Indexer Benchmarks (Issue #1178)
+//!
+//! Two halves:
+//!
+//! 1. **Pure decode benchmarks** (`decode_topic_symbol`, `event_kind_for_topic`,
+//!    `backoff_with_jitter`, `RpcNodePool` rotation) — no I/O, always run.
+//! 2. **DB-gated throughput benchmarks** — buffered-event insert throughput
+//!    and the ledger-rollback path exercised by
+//!    `server/tests/chaos_reorg_simulation.rs` when simulating a 5-ledger
+//!    Stellar re-org, run only when `DATABASE_URL` is set.
+//!
+//! ```bash
+//! cargo bench --bench reorg_indexer_bench                     # decode-only
+//! DATABASE_URL=postgres://... cargo bench --bench reorg_indexer_bench  # full suite
+//! ```
+
+use agora_server::models::indexer_event::{decode_topic_symbol, event_kind_for_topic, IndexedEvent};
+use agora_server::models::blockchain_checkpoint::CheckpointStore;
+use agora_server::services::indexer::{backoff_with_jitter, buffer_insert, RpcNodePool};
+use criterion::{black_box, BenchmarkId, Criterion};
+use serde_json::json;
+use sqlx::PgPool;
+use std::time::Duration;
+use stellar_xdr::curr::{Limits, ScSymbol, ScVal, WriteXdr};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Pure decode benchmarks (no I/O)
+// ---------------------------------------------------------------------------
+
+fn bench_decode_topic_symbol(c: &mut Criterion) {
+    let topic = ScVal::Symbol(ScSymbol("PaymentProcessed".parse().unwrap()))
+        .to_xdr_base64(Limits::none())
+        .unwrap();
+
+    c.bench_function("decode_topic_symbol", |b| {
+        b.iter(|| decode_topic_symbol(Some(black_box(&topic))))
+    });
+}
+
+fn bench_event_kind_for_topic(c: &mut Criterion) {
+    let topics = [
+        "PaymentProcessed",
+        "BulkRefundProcessed",
+        "TicketTransferred",
+        "EventRegistered",
+        "CollateralStaked",
+        "TotallyUnknownEvent",
+    ];
+    let mut group = c.benchmark_group("event_kind_for_topic");
+    for topic in topics {
+        group.bench_with_input(BenchmarkId::from_parameter(topic), &topic, |b, topic| {
+            b.iter(|| event_kind_for_topic(black_box(topic)))
+        });
+    }
+    group.finish();
+}
+
+fn bench_indexed_event_decode_end_to_end(c: &mut Criterion) {
+    let topic = ScVal::Symbol(ScSymbol("PaymentProcessed".parse().unwrap()))
+        .to_xdr_base64(Limits::none())
+        .unwrap();
+    let value = json!({
+        "payment_id": "pay-1",
+        "event_id": Uuid::new_v4().to_string(),
+        "buyer": "GABC",
+        "owner": "GDEF",
+        "amount": 5_000_000
+    });
+
+    c.bench_function("indexed_event_decode_purchase", |b| {
+        b.iter(|| {
+            IndexedEvent::decode(
+                black_box("evt-1".to_string()),
+                black_box(100),
+                black_box("CPAY".to_string()),
+                black_box(std::slice::from_ref(&topic)),
+                black_box(&value),
+                black_box(105),
+            )
+        })
+    });
+}
+
+fn bench_backoff_with_jitter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("backoff_with_jitter");
+    for attempt in [0u32, 4, 8, 16] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(attempt),
+            &attempt,
+            |b, &attempt| {
+                b.iter(|| {
+                    backoff_with_jitter(
+                        black_box(attempt),
+                        Duration::from_secs(5),
+                        Duration::from_secs(300),
+                    )
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_rpc_node_pool_rotation(c: &mut Criterion) {
+    c.bench_function("rpc_node_pool_next_url_3_nodes", |b| {
+        let mut pool = RpcNodePool::new(
+            vec![
+                "https://rpc-a.example".to_string(),
+                "https://rpc-b.example".to_string(),
+                "https://rpc-c.example".to_string(),
+            ],
+            Duration::from_secs(60),
+        );
+        b.iter(|| black_box(pool.next_url()))
+    });
+}
+
+// ---------------------------------------------------------------------------
+// DB-gated: re-org rollback & buffer throughput
+// ---------------------------------------------------------------------------
+
+/// Ledger base far above any plausible real Stellar ledger sequence (mainnet
+/// sits in the tens of millions as of 2026) so this benchmark's synthetic
+/// rows can never be confused with — or accidentally purge — real indexer
+/// data if pointed at a populated database. See the equivalent guard in
+/// `server/tests/chaos_reorg_simulation.rs` for the full rationale.
+const SYNTHETIC_LEDGER_BASE: i64 = 3_900_000_000;
+
+async fn seed_buffer_window(pool: &PgPool, contract_id: &str, count: i64) {
+    for i in 0..count {
+        let ledger = SYNTHETIC_LEDGER_BASE + i;
+        let event = IndexedEvent::decode(
+            format!("{contract_id}-evt-{i}"),
+            ledger as u32,
+            contract_id.to_string(),
+            &[],
+            &json!({}),
+            ledger as u32 + 10,
+        );
+        buffer_insert(pool, &event).await.expect("buffer_insert");
+    }
+}
+
+fn bench_buffer_insert_throughput(c: &mut Criterion, rt: &tokio::runtime::Runtime, pool: &PgPool) {
+    let contract_id = format!("bench-buffer-{}", Uuid::new_v4());
+    let mut i = 0i64;
+
+    c.bench_function("buffer_insert_single_event", |b| {
+        b.to_async(rt).iter(|| {
+            i += 1;
+            let pool = pool.clone();
+            let contract_id = contract_id.clone();
+            let ledger = SYNTHETIC_LEDGER_BASE + i;
+            async move {
+                let event = IndexedEvent::decode(
+                    format!("{contract_id}-{ledger}-{i}"),
+                    ledger as u32,
+                    contract_id,
+                    &[],
+                    &json!({}),
+                    ledger as u32 + 10,
+                );
+                black_box(buffer_insert(&pool, &event).await.unwrap());
+            }
+        })
+    });
+
+    rt.block_on(async {
+        let _ = sqlx::query("DELETE FROM indexer_ledger_events WHERE contract_id = $1")
+            .bind(&contract_id)
+            .execute(pool)
+            .await;
+    });
+}
+
+fn bench_rollback_by_window_size(c: &mut Criterion, rt: &tokio::runtime::Runtime, pool: &PgPool) {
+    let mut group = c.benchmark_group("rollback_to_by_buffered_window");
+    for window in [5i64, 50, 500] {
+        let contract_id = format!("bench-rollback-{}", Uuid::new_v4());
+        let chain_key = format!("bench:reorg:{contract_id}");
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(window),
+            &window,
+            |b, &window| {
+                b.to_async(rt).iter_batched(
+                    || {
+                        let pool = pool.clone();
+                        let contract_id = contract_id.clone();
+                        let chain_key = chain_key.clone();
+                        async move {
+                            seed_buffer_window(&pool, &contract_id, window).await;
+                            CheckpointStore::save(
+                                &pool,
+                                &chain_key,
+                                SYNTHETIC_LEDGER_BASE + window,
+                                None,
+                            )
+                            .await
+                            .unwrap();
+                        }
+                    },
+                    |setup| {
+                        let pool = pool.clone();
+                        let chain_key = chain_key.clone();
+                        async move {
+                            setup.await;
+                            black_box(
+                                CheckpointStore::rollback_to(&pool, &chain_key, SYNTHETIC_LEDGER_BASE)
+                                    .await
+                                    .unwrap(),
+                            );
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                )
+            },
+        );
+
+        rt.block_on(async {
+            let _ = sqlx::query("DELETE FROM indexer_ledger_events WHERE contract_id = $1")
+                .bind(&contract_id)
+                .execute(pool)
+                .await;
+            let _ = sqlx::query("DELETE FROM blockchain_checkpoints WHERE chain_key = $1")
+                .bind(&chain_key)
+                .execute(pool)
+                .await;
+        });
+    }
+    group.finish();
+}
+
+fn main() {
+    let mut criterion = Criterion::default().configure_from_args();
+
+    bench_decode_topic_symbol(&mut criterion);
+    bench_event_kind_for_topic(&mut criterion);
+    bench_indexed_event_decode_end_to_end(&mut criterion);
+    bench_backoff_with_jitter(&mut criterion);
+    bench_rpc_node_pool_rotation(&mut criterion);
+
+    match std::env::var("DATABASE_URL") {
+        Ok(database_url) => {
+            let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+            let pool = rt
+                .block_on(PgPool::connect(&database_url))
+                .expect("connect to DATABASE_URL");
+            bench_buffer_insert_throughput(&mut criterion, &rt, &pool);
+            bench_rollback_by_window_size(&mut criterion, &rt, &pool);
+        }
+        Err(_) => {
+            eprintln!(
+                "reorg_indexer_bench: DATABASE_URL not set, skipping DB-gated benchmarks \
+                 (decode benchmarks above still ran)."
+            );
+        }
+    }
+
+    criterion.final_summary();
+}

--- a/server/benches/serialization_bench.rs
+++ b/server/benches/serialization_bench.rs
@@ -1,0 +1,270 @@
+//! # Payload Serialization Benchmarks (Issue #1178)
+//!
+//! Measures the cost of the JSON/XDR encode-decode paths that sit on the hot
+//! path of every request: WebSocket telemetry frames, cursor-paginated list
+//! responses, and Soroban contract-event decoding in the re-org resilient
+//! indexer (`agora_server::services::indexer`, `agora_server::models::indexer_event`).
+//!
+//! None of these benchmarks touch the network or the database — they isolate
+//! CPU-bound (de)serialization cost so a regression here can't be masked by
+//! I/O noise. Run with:
+//!
+//! ```bash
+//! cargo bench --bench serialization_bench
+//! ```
+
+use agora_server::handlers::ws::{
+    GateHeatmapEvent, GateMetrics, OrganizerEvent, PurchaseEvent, ScanVelocityEvent,
+};
+use agora_server::models::blockchain_checkpoint::BlockchainCheckpoint;
+use agora_server::models::indexer_event::{scval_to_json, IndexedEvent};
+use agora_server::utils::cursor_pagination::{encode_cursor, decode_cursor, CursorResponse, EventCursor, ValidatedCursorParams};
+use chrono::Utc;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use serde_json::json;
+use stellar_xdr::curr::{Limits, ReadXdr, ScMap, ScMapEntry, ScString, ScSymbol, ScVal, WriteXdr};
+use uuid::Uuid;
+
+fn sym(name: &str) -> ScSymbol {
+    ScSymbol(name.parse().unwrap())
+}
+
+fn str_val(s: &str) -> ScVal {
+    ScVal::String(ScString(s.parse().unwrap()))
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket telemetry payloads
+// ---------------------------------------------------------------------------
+
+fn sample_purchase_event() -> PurchaseEvent {
+    PurchaseEvent {
+        event_id: Uuid::new_v4(),
+        ticket_tier_id: Uuid::new_v4(),
+        quantity: 2,
+        amount: 149.99,
+        currency: "USDC".to_string(),
+        purchased_at: Utc::now().to_rfc3339(),
+    }
+}
+
+fn sample_gate_heatmap(gate_count: usize) -> OrganizerEvent {
+    let gates = (0..gate_count)
+        .map(|i| GateMetrics {
+            gate_id: format!("gate-{i}"),
+            gate_name: format!("North Entrance {i}"),
+            current_wait_time_minutes: 4.5,
+            throughput_per_minute: 62.0,
+            staff_count: 3,
+            congestion_level: "medium".to_string(),
+        })
+        .collect();
+
+    OrganizerEvent::GateHeatmap(GateHeatmapEvent {
+        event_id: Uuid::new_v4(),
+        gates,
+        timestamp: Utc::now().to_rfc3339(),
+    })
+}
+
+fn bench_purchase_event_roundtrip(c: &mut Criterion) {
+    let event = sample_purchase_event();
+    let json = serde_json::to_string(&event).unwrap();
+
+    let mut group = c.benchmark_group("ws_purchase_event");
+    group.throughput(Throughput::Bytes(json.len() as u64));
+    group.bench_function("serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&event)).unwrap())
+    });
+    group.bench_function("deserialize", |b| {
+        b.iter(|| serde_json::from_str::<PurchaseEvent>(black_box(&json)).unwrap())
+    });
+    group.finish();
+}
+
+fn bench_organizer_heatmap_by_gate_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ws_organizer_gate_heatmap");
+    for gate_count in [1usize, 10, 50, 200] {
+        let event = sample_gate_heatmap(gate_count);
+        let json = serde_json::to_string(&event).unwrap();
+        group.throughput(Throughput::Elements(gate_count as u64));
+        group.bench_with_input(
+            BenchmarkId::new("serialize", gate_count),
+            &event,
+            |b, event| b.iter(|| serde_json::to_string(black_box(event)).unwrap()),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("deserialize", gate_count),
+            &json,
+            |b, json| b.iter(|| serde_json::from_str::<OrganizerEvent>(black_box(json)).unwrap()),
+        );
+    }
+    group.finish();
+}
+
+fn bench_scan_velocity_event(c: &mut Criterion) {
+    let event = ScanVelocityEvent {
+        event_id: Uuid::new_v4(),
+        gate_id: "gate-3".to_string(),
+        scans_per_minute: 87.2,
+        total_scans: 4211,
+        timestamp: Utc::now().to_rfc3339(),
+    };
+    c.bench_function("ws_scan_velocity_event_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&event)).unwrap())
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Cursor pagination
+// ---------------------------------------------------------------------------
+
+fn bench_cursor_encode_decode(c: &mut Criterion) {
+    let cursor = EventCursor {
+        start_time: Utc::now(),
+        id: Uuid::new_v4(),
+        created_at: Some(Utc::now()),
+        minted_tickets: Some(4200),
+        count_of_ratings: Some(318),
+        min_ticket_price: Some(49.5),
+    };
+    let encoded = encode_cursor(&cursor).unwrap();
+
+    let mut group = c.benchmark_group("cursor_pagination");
+    group.bench_function("encode", |b| {
+        b.iter(|| encode_cursor(black_box(&cursor)).unwrap())
+    });
+    group.bench_function("decode", |b| {
+        b.iter(|| decode_cursor::<EventCursor>(black_box(&encoded)).unwrap())
+    });
+    group.finish();
+}
+
+fn bench_cursor_response_wrap_by_page_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cursor_response_wrap");
+    for page_size in [10u32, 20, 50, 100] {
+        let params = ValidatedCursorParams {
+            limit: page_size,
+            cursor: None,
+            include_count: true,
+        };
+        let items: Vec<Uuid> = (0..page_size).map(|_| Uuid::new_v4()).collect();
+        group.throughput(Throughput::Elements(page_size as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(page_size),
+            &(items, params),
+            |b, (items, params)| {
+                b.iter(|| {
+                    let response =
+                        CursorResponse::new(black_box(items.clone()), params, Some("next".into()))
+                            .with_total(10_000, true);
+                    serde_json::to_string(&response).unwrap()
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Soroban XDR event decoding (indexer hot path)
+// ---------------------------------------------------------------------------
+
+fn purchase_processed_xdr(fields: usize) -> String {
+    let mut entries = vec![
+        ScMapEntry {
+            key: ScVal::Symbol(sym("payment_id")),
+            val: str_val("pay-bench-0001"),
+        },
+        ScMapEntry {
+            key: ScVal::Symbol(sym("event_id")),
+            val: str_val(&Uuid::new_v4().to_string()),
+        },
+        ScMapEntry {
+            key: ScVal::Symbol(sym("buyer")),
+            val: str_val("GABCDEF1234567890"),
+        },
+        ScMapEntry {
+            key: ScVal::Symbol(sym("amount")),
+            val: ScVal::I64(12_500_000),
+        },
+    ];
+    // Pad the map with extra fields to model larger real-world event
+    // payloads (metadata, memo fields, discount codes, etc.).
+    for i in 0..fields {
+        entries.push(ScMapEntry {
+            key: ScVal::Symbol(sym(&format!("extra_{i}"))),
+            val: ScVal::U32(i as u32),
+        });
+    }
+    let scval = ScVal::Map(Some(ScMap(entries.try_into().unwrap())));
+    scval.to_xdr_base64(Limits::none()).unwrap()
+}
+
+fn bench_indexed_event_decode_by_payload_size(c: &mut Criterion) {
+    let topic = ScVal::Symbol(sym("PaymentProcessed"))
+        .to_xdr_base64(Limits::none())
+        .unwrap();
+
+    let mut group = c.benchmark_group("indexer_event_decode");
+    for extra_fields in [0usize, 8, 32, 128] {
+        let xdr = purchase_processed_xdr(extra_fields);
+        let value = json!({ "xdr": xdr });
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(extra_fields),
+            &(topic.clone(), value),
+            |b, (topic, value)| {
+                b.iter(|| {
+                    IndexedEvent::decode(
+                        black_box("evt-id-bench".to_string()),
+                        black_box(1_000_000),
+                        black_box("CPAYCONTRACT".to_string()),
+                        black_box(std::slice::from_ref(topic)),
+                        black_box(value),
+                        black_box(1_000_010),
+                    )
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_scval_to_json(c: &mut Criterion) {
+    let xdr = purchase_processed_xdr(32);
+    let scval = ScVal::from_xdr_base64(&xdr, Limits::none()).expect("encoded above");
+    c.bench_function("scval_to_json_32_field_map", |b| {
+        b.iter(|| scval_to_json(black_box(&scval)))
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint model
+// ---------------------------------------------------------------------------
+
+fn bench_checkpoint_serialize(c: &mut Criterion) {
+    let cp = BlockchainCheckpoint {
+        chain_key: "soroban:mainnet".to_string(),
+        ledger_sequence: 68_432_991,
+        event_cursor: Some("cursor-opaque-token-abc123".to_string()),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    c.bench_function("blockchain_checkpoint_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&cp)).unwrap())
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_purchase_event_roundtrip,
+    bench_organizer_heatmap_by_gate_count,
+    bench_scan_velocity_event,
+    bench_cursor_encode_decode,
+    bench_cursor_response_wrap_by_page_size,
+    bench_indexed_event_decode_by_payload_size,
+    bench_scval_to_json,
+    bench_checkpoint_serialize,
+);
+criterion_main!(benches);

--- a/server/tests/chaos_dropped_ws_frames.rs
+++ b/server/tests/chaos_dropped_ws_frames.rs
@@ -1,0 +1,161 @@
+//! # Chaos Test: Dropped WebSocket Frames (Issue #1178)
+//!
+//! Exercises the real broadcaster types dashboard clients connect to
+//! (`agora_server::handlers::ws::{PurchaseBroadcaster, OrganizerBroadcaster}`)
+//! under simulated frame loss, using [`common::chaos::drop_frames`] to model
+//! a lossy network dropping WebSocket frames in transit.
+//!
+//! No database or network is required — these tests exercise the in-process
+//! `tokio::sync::broadcast` channels directly.
+
+mod common;
+
+use agora_server::handlers::ws::{
+    GateHeatmapEvent, OrganizerBroadcaster, OrganizerEvent, PurchaseBroadcaster, PurchaseEvent,
+};
+use common::chaos::drop_frames;
+use chrono::Utc;
+use tokio::sync::broadcast::error::RecvError;
+use uuid::Uuid;
+
+fn sample_purchase(i: u32) -> PurchaseEvent {
+    PurchaseEvent {
+        event_id: Uuid::new_v4(),
+        ticket_tier_id: Uuid::new_v4(),
+        quantity: 1,
+        amount: 10.0 + i as f64,
+        currency: "USDC".to_string(),
+        purchased_at: Utc::now().to_rfc3339(),
+    }
+}
+
+/// The broadcaster's real client-facing lag handling (mirrored from
+/// `handle_socket` in `handlers::ws`): a slow/absent reader must observe
+/// `RecvError::Lagged(n)`, never a silent, undetectable gap in the stream.
+#[tokio::test]
+async fn slow_consumer_observes_lagged_not_silent_loss() {
+    let broadcaster = PurchaseBroadcaster::new();
+    let mut rx = broadcaster.subscribe();
+
+    // Publish well beyond the broadcaster's internal channel capacity (128)
+    // without ever reading, forcing the receiver to fall behind.
+    for i in 0..400u32 {
+        broadcaster.publish(sample_purchase(i));
+    }
+
+    match rx.recv().await {
+        Err(RecvError::Lagged(skipped)) => {
+            assert!(skipped > 0, "lag must report a nonzero skipped count");
+        }
+        other => panic!(
+            "expected the broadcast channel to report Lagged after being overrun, got {other:?}"
+        ),
+    }
+}
+
+/// A reader that keeps up (reads as fast as frames are published) must never
+/// observe drops purely from broadcaster overflow — loss should only come
+/// from the chaos-injected network simulation, not from the broadcaster
+/// itself under normal load.
+#[tokio::test]
+async fn keeping_up_consumer_sees_every_frame_broadcaster_side() {
+    let broadcaster = PurchaseBroadcaster::new();
+    let mut rx = broadcaster.subscribe();
+
+    let publisher = {
+        let broadcaster = broadcaster.clone();
+        tokio::spawn(async move {
+            for i in 0..50u32 {
+                broadcaster.publish(sample_purchase(i));
+                tokio::task::yield_now().await;
+            }
+        })
+    };
+
+    let mut received = 0u32;
+    while received < 50 {
+        match rx.recv().await {
+            Ok(_) => received += 1,
+            Err(RecvError::Lagged(n)) => panic!("unexpected lag of {n} while keeping up"),
+            Err(RecvError::Closed) => break,
+        }
+    }
+    publisher.await.unwrap();
+    assert_eq!(received, 50);
+}
+
+/// [`drop_frames`] simulates a lossy socket on top of a broadcaster that is
+/// itself delivering every frame — the majority of frames must still arrive,
+/// and the consumer must complete instead of hanging when the sender side
+/// closes.
+#[tokio::test]
+async fn dropped_frames_still_deliver_the_majority_of_purchase_events() {
+    let broadcaster = PurchaseBroadcaster::new();
+    let rx = broadcaster.subscribe();
+    let mut lossy_rx = drop_frames(rx, 0.3);
+
+    const TOTAL: u32 = 500;
+    for i in 0..TOTAL {
+        broadcaster.publish(sample_purchase(i));
+    }
+    drop(broadcaster); // close the channel so the forwarder task can exit
+
+    let mut received = 0u32;
+    while lossy_rx.recv().await.is_some() {
+        received += 1;
+    }
+
+    assert!(received > 0, "a 30% drop rate must not eliminate every frame");
+    assert!(
+        received < TOTAL,
+        "a 30% drop rate over {TOTAL} frames should statistically drop at least one"
+    );
+    // Expected ~350 survivors; a wide band keeps this non-flaky.
+    assert!(
+        received > (TOTAL as f64 * 0.5) as u32,
+        "received {received}/{TOTAL} — drop rate behaved far outside its configured 30%"
+    );
+}
+
+#[tokio::test]
+async fn organizer_broadcaster_tolerates_dropped_gate_heatmap_frames() {
+    let broadcaster = OrganizerBroadcaster::new();
+    let rx = broadcaster.subscribe();
+    let mut lossy_rx = drop_frames(rx, 0.25);
+
+    const TOTAL: u32 = 300;
+    for i in 0..TOTAL {
+        broadcaster.publish(OrganizerEvent::GateHeatmap(GateHeatmapEvent {
+            event_id: Uuid::new_v4(),
+            gates: vec![],
+            timestamp: format!("frame-{i}"),
+        }));
+    }
+    drop(broadcaster);
+
+    let mut received = 0u32;
+    while lossy_rx.recv().await.is_some() {
+        received += 1;
+    }
+    assert!(received > (TOTAL as f64 * 0.5) as u32, "received {received}/{TOTAL}");
+}
+
+/// Zero drop rate is the harness's own regression guard: with no chaos
+/// applied, frame delivery must be exact.
+#[tokio::test]
+async fn zero_drop_rate_delivers_every_frame_exactly() {
+    let broadcaster = PurchaseBroadcaster::new();
+    let rx = broadcaster.subscribe();
+    let mut lossy_rx = drop_frames(rx, 0.0);
+
+    for i in 0..40u32 {
+        broadcaster.publish(sample_purchase(i));
+    }
+    drop(broadcaster);
+
+    let mut received = 0u32;
+    while lossy_rx.recv().await.is_some() {
+        received += 1;
+    }
+    assert_eq!(received, 40);
+}

--- a/server/tests/chaos_network_latency.rs
+++ b/server/tests/chaos_network_latency.rs
@@ -1,0 +1,97 @@
+//! # Chaos Test: Network Latency Spikes (Issue #1178)
+//!
+//! Exercises [`common::chaos::LatencyInjector`] — the harness for the
+//! "network latency spikes (100ms–5000ms)" fault class called out in the
+//! issue — both in isolation and wrapped around a real database round trip,
+//! to prove injected latency neither corrupts results nor can hang forever.
+
+mod common;
+
+use common::chaos::LatencyInjector;
+use common::test_pool;
+use std::time::Duration;
+
+#[tokio::test]
+async fn injected_latency_falls_within_configured_range() {
+    // A tight, fast range for routine CI runs — the full issue-specified
+    // 100ms-5000ms spike is covered by the #[ignore] test below.
+    let injector = LatencyInjector::new(Duration::from_millis(30), Duration::from_millis(90));
+
+    for _ in 0..5 {
+        let start = tokio::time::Instant::now();
+        injector.strike().await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(30),
+            "strike() must never resolve faster than the configured minimum, got {elapsed:?}"
+        );
+        // Generous slack for scheduler jitter on a loaded CI runner.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "strike() took implausibly long ({elapsed:?}) — possible harness hang"
+        );
+    }
+}
+
+/// Validates the exact 100ms-5000ms spike range from Issue #1178 end to end.
+/// Marked `#[ignore]` because a full pass can take several seconds; run
+/// explicitly with `cargo test --test chaos_network_latency -- --ignored`.
+#[tokio::test]
+#[ignore]
+async fn full_issue_specified_spike_range_100ms_to_5000ms() {
+    let injector = LatencyInjector::spike_range();
+    let mut min_seen = Duration::from_secs(10);
+    let mut max_seen = Duration::ZERO;
+
+    for _ in 0..15 {
+        let start = tokio::time::Instant::now();
+        injector.strike().await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(100));
+        assert!(elapsed <= Duration::from_millis(6000), "generous slack above the 5000ms cap");
+        min_seen = min_seen.min(elapsed);
+        max_seen = max_seen.max(elapsed);
+    }
+
+    eprintln!("spike range observed over 15 draws: {min_seen:?}..={max_seen:?}");
+}
+
+#[tokio::test]
+async fn wrap_preserves_inner_future_result_under_latency() {
+    let injector = LatencyInjector::new(Duration::from_millis(10), Duration::from_millis(40));
+    let (result, delay) = injector.wrap(async { 2 + 2 }).await;
+    assert_eq!(result, 4, "injected latency must never alter the wrapped computation's outcome");
+    assert!(delay >= Duration::from_millis(10) && delay <= Duration::from_millis(40));
+}
+
+/// Regression guard: the harness itself must be boundable. A chaos tool that
+/// can hang forever is worse than no chaos tool at all.
+#[tokio::test]
+async fn latency_injection_cannot_hang_indefinitely() {
+    let injector = LatencyInjector::spike_range(); // up to 5000ms
+    let outcome = tokio::time::timeout(Duration::from_secs(8), injector.wrap(async { "done" })).await;
+    assert!(outcome.is_ok(), "a single spike-range strike must resolve within 8s");
+}
+
+/// Wraps a real Postgres round trip in injected latency and asserts the
+/// query result is unaffected — proving latency injection is a pure delay,
+/// not a source of flakiness in what gets returned. Skips gracefully when
+/// `DATABASE_URL` is unset (same convention as `auth_integration.rs`).
+#[tokio::test]
+async fn latency_injected_db_round_trip_still_returns_correct_result() {
+    let Some(pool) = test_pool("latency_injected_db_round_trip_still_returns_correct_result").await
+    else {
+        return;
+    };
+
+    let injector = LatencyInjector::new(Duration::from_millis(50), Duration::from_millis(200));
+    let start = tokio::time::Instant::now();
+
+    let (row, delay): (Result<(i32,), sqlx::Error>, Duration) = injector
+        .wrap(async { sqlx::query_as::<_, (i32,)>("SELECT 41 + 1").fetch_one(&pool).await })
+        .await;
+
+    let elapsed = start.elapsed();
+    assert_eq!(row.unwrap().0, 42, "the query result must be exact despite injected latency");
+    assert!(elapsed >= delay, "wall-clock elapsed must be at least the injected delay");
+}

--- a/server/tests/chaos_pool_exhaustion.rs
+++ b/server/tests/chaos_pool_exhaustion.rs
@@ -1,0 +1,148 @@
+//! # Chaos Test: Sudden PostgreSQL Connection-Pool Exhaustion (Issue #1178)
+//!
+//! Uses [`common::chaos::PoolExhaustionGuard`] to hold every connection in a
+//! small, dedicated pool and asserts the application degrades *predictably*
+//! (a bounded, typed timeout) instead of hanging forever — then verifies the
+//! pool recovers cleanly the instant connections are released.
+//!
+//! Runs against its own tiny `max_connections` pool (not the shared test
+//! pool other suites use) so saturating it can't starve unrelated tests
+//! running concurrently in the same `cargo test` invocation.
+
+mod common;
+
+use common::chaos::PoolExhaustionGuard;
+use sqlx::postgres::PgPoolOptions;
+use std::time::Duration;
+
+async fn dedicated_pool(max_connections: u32) -> Option<sqlx::PgPool> {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return None;
+    };
+    match PgPoolOptions::new()
+        .max_connections(max_connections)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(&database_url)
+        .await
+    {
+        Ok(pool) => Some(pool),
+        Err(e) => {
+            eprintln!("skipping: failed to connect a dedicated pool: {e}");
+            None
+        }
+    }
+}
+
+#[tokio::test]
+async fn saturated_pool_times_out_predictably_instead_of_hanging() {
+    const MAX_CONNECTIONS: u32 = 3;
+    let Some(pool) = dedicated_pool(MAX_CONNECTIONS).await else {
+        return;
+    };
+
+    let guard = PoolExhaustionGuard::saturate(&pool, MAX_CONNECTIONS)
+        .await
+        .expect("saturate the whole pool");
+
+    // Every connection is held by `guard` — a further acquire must not hang
+    // the test suite. `pool.acquire_timeout` (5s, set above) is the
+    // production-facing bound; wrap it in an outer timeout too so a harness
+    // bug can't turn this into a suite-wide hang even if that bound is
+    // somehow not respected.
+    let start = tokio::time::Instant::now();
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(10),
+        sqlx::query("SELECT 1").execute(&pool),
+    )
+    .await;
+    let elapsed = start.elapsed();
+
+    match outcome {
+        Ok(query_result) => {
+            assert!(
+                query_result.is_err(),
+                "a query against a fully saturated pool must fail, not silently succeed"
+            );
+            assert!(
+                matches!(query_result.unwrap_err(), sqlx::Error::PoolTimedOut),
+                "the failure mode under exhaustion should be a typed PoolTimedOut error"
+            );
+        }
+        Err(_elapsed) => panic!(
+            "query hung past the 10s outer bound instead of respecting the pool's own \
+             5s acquire_timeout — this is the exact failure mode chaos testing exists to catch"
+        ),
+    }
+    assert!(
+        elapsed < Duration::from_secs(9),
+        "must fail close to the pool's configured acquire_timeout (5s), not linger near the outer bound"
+    );
+
+    drop(guard);
+
+    // Once connections are released, the pool must recover immediately —
+    // proving exhaustion is a transient backpressure signal, not a
+    // permanently wedged state.
+    let recovered = tokio::time::timeout(
+        Duration::from_secs(5),
+        sqlx::query_as::<_, (i32,)>("SELECT 1").fetch_one(&pool),
+    )
+    .await;
+    assert!(
+        recovered.is_ok() && recovered.unwrap().is_ok(),
+        "pool must recover promptly once exhausting connections are released"
+    );
+}
+
+#[tokio::test]
+async fn saturate_fully_acquires_exactly_max_connections() {
+    const MAX_CONNECTIONS: u32 = 4;
+    let Some(pool) = dedicated_pool(MAX_CONNECTIONS).await else {
+        return;
+    };
+
+    assert_eq!(pool.options().get_max_connections(), MAX_CONNECTIONS);
+
+    let guard = PoolExhaustionGuard::saturate_fully(&pool)
+        .await
+        .expect("saturate_fully should acquire every configured connection");
+
+    let blocked = tokio::time::timeout(
+        Duration::from_millis(500),
+        sqlx::query("SELECT 1").execute(&pool),
+    )
+    .await;
+    assert!(
+        blocked.is_err() || blocked.unwrap().is_err(),
+        "with every connection held, a fast-timeout probe must not succeed"
+    );
+
+    drop(guard);
+}
+
+#[tokio::test]
+async fn partial_saturation_leaves_headroom_for_other_queries() {
+    const MAX_CONNECTIONS: u32 = 5;
+    let Some(pool) = dedicated_pool(MAX_CONNECTIONS).await else {
+        return;
+    };
+
+    // Hold all but one connection — the classic "nearly exhausted" state
+    // that's easy to miss in testing but common in production incidents.
+    let guard = PoolExhaustionGuard::saturate(&pool, MAX_CONNECTIONS - 1)
+        .await
+        .expect("saturate all-but-one connection");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(3),
+        sqlx::query_as::<_, (i32,)>("SELECT 7").fetch_one(&pool),
+    )
+    .await;
+    assert!(
+        result.is_ok() && result.unwrap().unwrap().0 == 7,
+        "the one remaining connection must still serve a request correctly"
+    );
+
+    drop(guard);
+}

--- a/server/tests/chaos_reorg_simulation.rs
+++ b/server/tests/chaos_reorg_simulation.rs
@@ -1,0 +1,486 @@
+//! # Simulated Stellar Chain Re-org Runner (Issue #1178)
+//!
+//! Drives the real re-org machinery in `agora_server::services::indexer`
+//! (`CheckpointStore::rollback_to`, `buffer_insert`, `apply_event_state`) —
+//! the same functions the live Soroban event indexer uses — through a
+//! simulated chain fork, without touching the network. This is the "Stellar
+//! ledger re-org rollback" runner called out in the issue: it rolls back a
+//! simulated chain by 5 ledgers and verifies the database recovers without
+//! leaking invalid state.
+//!
+//! ## Running
+//! ```bash
+//! DATABASE_URL=postgres://user:password@localhost:5432/agora cargo test --test chaos_reorg_simulation
+//! ```
+//! Skips gracefully (matching `server/tests/auth_integration.rs`) when
+//! `DATABASE_URL` is unset.
+//!
+//! ## Safety
+//! Every row this suite writes is scoped to a synthetic, randomized ledger
+//! range far above any real Stellar ledger height (see
+//! [`common::random_synthetic_ledger_base`]) and a `chaos-test:` prefixed
+//! `chain_key`, so it is safe to run against a shared, populated dev
+//! database. On an assertion failure mid-test some `chaos-test:` rows may be
+//! left behind; they are inert and safe to delete manually
+//! (`DELETE FROM blockchain_checkpoints WHERE chain_key LIKE 'chaos-test:%'`).
+//!
+//! ## A discovered limitation (see `deep_reorg_beyond_confirmation_window_*`)
+//! `CheckpointStore::rollback_to` rewinds the cursor and purges the
+//! *unfinalized buffer* atomically, but it never reverses state already
+//! written to `tickets` / `events` by `apply_event_state`. That's safe as
+//! long as a re-org can never reach deeper than `INDEXER_CONFIRMATIONS`
+//! ledgers (the whole point of the confirmation window) — but the issue
+//! explicitly asks this suite to simulate rolling back 5 ledgers, which is
+//! deeper than the default confirmation depth of 2. One test below pins
+//! down what currently happens in that case as an honest regression guard,
+//! not as a claim that the behavior is desirable.
+
+mod common;
+
+use agora_server::models::blockchain_checkpoint::CheckpointStore;
+use agora_server::models::indexer_event::IndexedEvent;
+use agora_server::services::indexer::{apply_event_state, buffer_insert, IndexerConfig};
+use common::{cleanup_organizer, random_synthetic_ledger_base, seed_organizer_and_event, test_pool};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+const PAYMENT_PROCESSED_TOPIC: &str = "PaymentProcessed";
+
+fn test_indexer_config(ticket_payment_contract_id: &str) -> IndexerConfig {
+    IndexerConfig {
+        rpc_urls: vec!["https://rpc.invalid".to_string()],
+        ticket_payment_contract_id: ticket_payment_contract_id.to_string(),
+        event_registry_contract_id: "CREG-UNUSED".to_string(),
+        start_ledger: 0,
+        window_ledgers: 100,
+        confirmations: 2,
+        workers: 1,
+        redis_url: None,
+    }
+}
+
+/// Build, buffer-insert, and (optionally) finalize+apply a synthetic
+/// `PaymentProcessed` event at `ledger`, minting ticket `stellar_id` owned by
+/// `owner_wallet` against `event_id` when `apply` is true.
+async fn emit_purchase(
+    pool: &PgPool,
+    config: &IndexerConfig,
+    ledger: u32,
+    latest_ledger: u32,
+    event_id: Uuid,
+    stellar_id: &str,
+    owner_wallet: &str,
+    apply: bool,
+) {
+    let value = json!({
+        "payment_id": stellar_id,
+        "event_id": event_id.to_string(),
+        "buyer": owner_wallet,
+        "owner": owner_wallet,
+        "amount": 25_000_000i64,
+    });
+
+    let event = IndexedEvent::decode(
+        format!("rpc-id-{stellar_id}"),
+        ledger,
+        config.ticket_payment_contract_id.clone(),
+        &[PAYMENT_PROCESSED_TOPIC.to_string()],
+        &value,
+        latest_ledger,
+    );
+
+    let inserted = buffer_insert(pool, &event).await.expect("buffer_insert");
+    assert!(inserted > 0, "buffer_insert must not report a duplicate for a fresh id");
+
+    if apply {
+        apply_event_state(pool, config, None, &event)
+            .await
+            .expect("apply_event_state");
+        sqlx::query("UPDATE indexer_ledger_events SET finalized = TRUE WHERE id = $1")
+            .bind(&event.id)
+            .execute(pool)
+            .await
+            .expect("mark finalized");
+    }
+}
+
+async fn ticket_owner(pool: &PgPool, stellar_id: &str) -> Option<(String, String)> {
+    sqlx::query_as::<_, (String, String)>(
+        "SELECT owner_wallet, status FROM tickets WHERE stellar_id = $1",
+    )
+    .bind(stellar_id)
+    .fetch_optional(pool)
+    .await
+    .expect("query ticket")
+}
+
+async fn buffered_ledgers_at_or_above(pool: &PgPool, contract_id: &str, ledger: i64) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM indexer_ledger_events WHERE contract_id = $1 AND ledger >= $2",
+    )
+    .bind(contract_id)
+    .bind(ledger)
+    .fetch_one(pool)
+    .await
+    .expect("count buffered rows")
+}
+
+// ---------------------------------------------------------------------------
+// 1. The safe case: reorg confined to the unconfirmed window
+// ---------------------------------------------------------------------------
+
+/// Rolls back 5 ledgers' worth of *unconfirmed* (buffered but never applied)
+/// events — the case the indexer's confirmation window exists to make safe.
+/// Finalized/applied state below the fork must survive untouched, and every
+/// buffered row at or after the fork must be purged.
+#[tokio::test]
+async fn five_ledger_reorg_within_unconfirmed_window_recovers_cleanly() {
+    let Some(pool) = test_pool("five_ledger_reorg_within_unconfirmed_window_recovers_cleanly").await else {
+        return;
+    };
+
+    let contract_id = format!("CPAY-{}", Uuid::new_v4());
+    let config = test_indexer_config(&contract_id);
+    let chain_key = format!("chaos-test:reorg:{}", Uuid::new_v4());
+    let base = random_synthetic_ledger_base();
+    let (organizer_id, event_id) =
+        seed_organizer_and_event(&pool, "five-ledger-safe-reorg").await;
+
+    // Ledgers [base, base+4]: finalized and applied — these must survive.
+    for i in 0..5u32 {
+        let stellar_id = format!("chaos-safe-pre-{base}-{i}");
+        emit_purchase(
+            &pool,
+            &config,
+            base + i,
+            base + 9,
+            event_id,
+            &stellar_id,
+            "GPRE0000000000000000000000000000000000000",
+            true,
+        )
+        .await;
+    }
+    CheckpointStore::save(&pool, &chain_key, (base + 4) as i64, None)
+        .await
+        .expect("save checkpoint after finalizing pre-fork ledgers");
+
+    // Ledgers [base+5, base+9]: buffered but NOT YET finalized/applied —
+    // exactly the window a re-org is allowed to invalidate.
+    for i in 5..10u32 {
+        let stellar_id = format!("chaos-safe-post-{base}-{i}");
+        emit_purchase(
+            &pool,
+            &config,
+            base + i,
+            base + 9,
+            event_id,
+            &stellar_id,
+            "GPOST000000000000000000000000000000000000",
+            false,
+        )
+        .await;
+    }
+
+    // Fork detected at base+5 → "rolling back 5 ledgers" (base+5..base+9).
+    let fork_ledger = (base + 5) as i64;
+    let new_checkpoint = CheckpointStore::rollback_to(&pool, &chain_key, fork_ledger)
+        .await
+        .expect("rollback_to");
+    assert_eq!(new_checkpoint, (base + 4) as i64);
+
+    let checkpoint = CheckpointStore::load(&pool, &chain_key)
+        .await
+        .expect("load checkpoint")
+        .expect("checkpoint row must exist");
+    assert_eq!(checkpoint.ledger_sequence, (base + 4) as i64);
+    assert!(checkpoint.event_cursor.is_none(), "rollback clears the opaque cursor");
+
+    assert_eq!(
+        buffered_ledgers_at_or_above(&pool, &contract_id, fork_ledger).await,
+        0,
+        "every buffered row at or after the fork ledger must be purged"
+    );
+
+    for i in 0..5u32 {
+        let stellar_id = format!("chaos-safe-pre-{base}-{i}");
+        let ticket = ticket_owner(&pool, &stellar_id).await;
+        assert!(
+            ticket.is_some(),
+            "finalized ticket for ledger {} must survive the reorg (no invalid state leak below the fork)",
+            base + i
+        );
+    }
+    for i in 5..10u32 {
+        let stellar_id = format!("chaos-safe-post-{base}-{i}");
+        assert!(
+            ticket_owner(&pool, &stellar_id).await.is_none(),
+            "unconfirmed ticket for ledger {} must never have been applied",
+            base + i
+        );
+    }
+
+    cleanup_organizer(&pool, organizer_id).await;
+    let _ = sqlx::query("DELETE FROM blockchain_checkpoints WHERE chain_key = $1")
+        .bind(&chain_key)
+        .execute(&pool)
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Atomicity of the checkpoint + buffer rewind
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rollback_moves_checkpoint_and_purges_buffer_atomically() {
+    let Some(pool) = test_pool("rollback_moves_checkpoint_and_purges_buffer_atomically").await else {
+        return;
+    };
+
+    let contract_id = format!("CPAY-{}", Uuid::new_v4());
+    let config = test_indexer_config(&contract_id);
+    let chain_key = format!("chaos-test:reorg:{}", Uuid::new_v4());
+    let base = random_synthetic_ledger_base();
+    let (organizer_id, event_id) =
+        seed_organizer_and_event(&pool, "atomic-rollback").await;
+
+    for i in 0..3u32 {
+        emit_purchase(
+            &pool,
+            &config,
+            base + i,
+            base + 3,
+            event_id,
+            &format!("chaos-atomic-{base}-{i}"),
+            "GATOMIC0000000000000000000000000000000000",
+            false,
+        )
+        .await;
+    }
+    CheckpointStore::save(&pool, &chain_key, (base + 3) as i64, Some("some-opaque-cursor"))
+        .await
+        .expect("save checkpoint");
+
+    let fork_ledger = base as i64;
+    CheckpointStore::rollback_to(&pool, &chain_key, fork_ledger)
+        .await
+        .expect("rollback_to");
+
+    // Both halves of the rewind must be observable together: nothing left
+    // buffered at/after the fork, and the checkpoint reflects exactly one
+    // ledger before it — never a state where one moved but not the other.
+    let checkpoint = CheckpointStore::load(&pool, &chain_key)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(checkpoint.ledger_sequence, fork_ledger - 1);
+    assert_eq!(
+        buffered_ledgers_at_or_above(&pool, &contract_id, fork_ledger).await,
+        0
+    );
+
+    cleanup_organizer(&pool, organizer_id).await;
+    let _ = sqlx::query("DELETE FROM blockchain_checkpoints WHERE chain_key = $1")
+        .bind(&chain_key)
+        .execute(&pool)
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// 3. The surviving fork replays idempotently after rollback
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn surviving_fork_replays_idempotently_after_rollback() {
+    let Some(pool) = test_pool("surviving_fork_replays_idempotently_after_rollback").await else {
+        return;
+    };
+
+    let contract_id = format!("CPAY-{}", Uuid::new_v4());
+    let config = test_indexer_config(&contract_id);
+    let chain_key = format!("chaos-test:reorg:{}", Uuid::new_v4());
+    let base = random_synthetic_ledger_base();
+    let (organizer_id, event_id) = seed_organizer_and_event(&pool, "fork-replay").await;
+    let stellar_id = format!("chaos-fork-{base}");
+
+    // Original (soon-to-be-orphaned) chain: buffered, never finalized.
+    emit_purchase(
+        &pool,
+        &config,
+        base,
+        base,
+        event_id,
+        &stellar_id,
+        "GORIGINAL000000000000000000000000000000000",
+        false,
+    )
+    .await;
+
+    CheckpointStore::rollback_to(&pool, &chain_key, base as i64)
+        .await
+        .expect("rollback_to");
+
+    // The surviving fork re-emits a purchase at the same ledger height for
+    // the same ticket, with a new RPC envelope id (as a real re-scan would)
+    // but referencing the same on-chain payment — apply must be idempotent.
+    for _ in 0..2 {
+        emit_purchase(
+            &pool,
+            &config,
+            base,
+            base,
+            event_id,
+            &stellar_id,
+            "GFORKOWNER00000000000000000000000000000000",
+            true,
+        )
+        .await;
+    }
+
+    let rows = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tickets WHERE stellar_id = $1")
+        .bind(&stellar_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        rows, 1,
+        "replaying the fork's purchase twice must not create duplicate tickets"
+    );
+
+    let (owner, _status) = ticket_owner(&pool, &stellar_id).await.expect("ticket exists");
+    assert_eq!(owner, "GFORKOWNER00000000000000000000000000000000");
+
+    cleanup_organizer(&pool, organizer_id).await;
+    let _ = sqlx::query("DELETE FROM blockchain_checkpoints WHERE chain_key = $1")
+        .bind(&chain_key)
+        .execute(&pool)
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Rollback is safe to retry
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rollback_to_same_fork_ledger_twice_is_idempotent() {
+    let Some(pool) = test_pool("rollback_to_same_fork_ledger_twice_is_idempotent").await else {
+        return;
+    };
+
+    let chain_key = format!("chaos-test:reorg:{}", Uuid::new_v4());
+    let base = random_synthetic_ledger_base();
+    CheckpointStore::save(&pool, &chain_key, base as i64, None)
+        .await
+        .unwrap();
+
+    let first = CheckpointStore::rollback_to(&pool, &chain_key, base as i64)
+        .await
+        .expect("first rollback");
+    let second = CheckpointStore::rollback_to(&pool, &chain_key, base as i64)
+        .await
+        .expect("retried rollback must not error");
+    assert_eq!(first, second, "retrying the same rollback must be a no-op, not a further rewind");
+
+    let _ = sqlx::query("DELETE FROM blockchain_checkpoints WHERE chain_key = $1")
+        .bind(&chain_key)
+        .execute(&pool)
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Discovered limitation: a reorg deeper than the confirmation window
+// ---------------------------------------------------------------------------
+
+/// `INDEXER_CONFIRMATIONS` defaults to 2 ledgers — the assumption baked into
+/// `services::indexer` is that a re-org can never reach further back than
+/// that, so once an event is "finalized" it's permanently safe to have
+/// applied its state. Issue #1178 explicitly asks this suite to simulate
+/// rolling back **5** ledgers, which exceeds that assumption.
+///
+/// This test does not assert the system "recovers correctly" — it pins down
+/// what actually happens today: the checkpoint and buffer rewind correctly,
+/// but the `tickets` rows written for the now-invalidated ledgers are left
+/// behind, because `rollback_to` never reverses `apply_event_state`'s
+/// writes. That is a real gap between the confirmation-window assumption
+/// and the depth of re-org this suite is asked to simulate — flagged here
+/// as a regression guard / follow-up marker rather than silently patched,
+/// since fixing it is a production-code decision outside this test suite's
+/// scope.
+#[tokio::test]
+async fn deep_reorg_beyond_confirmation_window_can_leave_applied_state_stale() {
+    let Some(pool) =
+        test_pool("deep_reorg_beyond_confirmation_window_can_leave_applied_state_stale").await
+    else {
+        return;
+    };
+
+    let contract_id = format!("CPAY-{}", Uuid::new_v4());
+    let config = test_indexer_config(&contract_id); // confirmations: 2
+    let chain_key = format!("chaos-test:reorg:{}", Uuid::new_v4());
+    let base = random_synthetic_ledger_base();
+    let (organizer_id, event_id) =
+        seed_organizer_and_event(&pool, "deep-reorg-limitation").await;
+
+    // Finalize + apply ledgers [base, base+4] — 5 ledgers deep, i.e. well
+    // past the 2-ledger confirmation margin, exactly as the issue's "roll
+    // back 5 ledgers" scenario implies.
+    for i in 0..5u32 {
+        emit_purchase(
+            &pool,
+            &config,
+            base + i,
+            base + 4,
+            event_id,
+            &format!("chaos-deep-{base}-{i}"),
+            "GDEEP00000000000000000000000000000000000000",
+            true,
+        )
+        .await;
+    }
+    CheckpointStore::save(&pool, &chain_key, (base + 4) as i64, None)
+        .await
+        .unwrap();
+
+    // A fork is now discovered reaching back to base+2 — deeper than what
+    // the confirmation window assumed could ever be invalidated.
+    let fork_ledger = (base + 2) as i64;
+    CheckpointStore::rollback_to(&pool, &chain_key, fork_ledger)
+        .await
+        .expect("rollback_to");
+
+    let checkpoint = CheckpointStore::load(&pool, &chain_key).await.unwrap().unwrap();
+    assert_eq!(
+        checkpoint.ledger_sequence,
+        fork_ledger - 1,
+        "the cursor itself rewinds correctly regardless of confirmation depth"
+    );
+    assert_eq!(
+        buffered_ledgers_at_or_above(&pool, &contract_id, fork_ledger).await,
+        0,
+        "the buffer is purged correctly regardless of confirmation depth"
+    );
+
+    // The gap: tickets for the invalidated ledgers [base+2, base+4] are
+    // still present, because rollback_to never touches `tickets`.
+    let mut stale_survivors = 0;
+    for i in 2..5u32 {
+        let stellar_id = format!("chaos-deep-{base}-{i}");
+        if ticket_owner(&pool, &stellar_id).await.is_some() {
+            stale_survivors += 1;
+        }
+    }
+    assert_eq!(
+        stale_survivors, 3,
+        "documents the current gap: applied tickets for rolled-back ledgers are not \
+         retroactively invalidated by rollback_to. If this assertion ever fails because \
+         it dropped to 0, `services::indexer` gained reversal logic — update this test \
+         to assert the (now fixed) safe behavior instead of removing the coverage."
+    );
+
+    cleanup_organizer(&pool, organizer_id).await;
+    let _ = sqlx::query("DELETE FROM blockchain_checkpoints WHERE chain_key = $1")
+        .bind(&chain_key)
+        .execute(&pool)
+        .await;
+}

--- a/server/tests/common/chaos.rs
+++ b/server/tests/common/chaos.rs
@@ -1,0 +1,258 @@
+//! # Chaos Injection Harness (Issue #1178)
+//!
+//! Fault-injection helpers used by the `chaos_*` integration tests to
+//! simulate the production outage classes called out in the issue:
+//!
+//! * [`LatencyInjector`] — network latency spikes (100ms–5000ms)
+//! * [`PoolExhaustionGuard`] — sudden PostgreSQL connection-pool exhaustion
+//! * [`drop_frames`] — dropped WebSocket frames
+//!
+//! These are deliberately test-only (`server/tests/common/`, not
+//! `server/src/`): they exist to *attack* the running system from outside,
+//! not to run inside it in production.
+
+use rand::Rng;
+use std::time::Duration;
+use tokio::sync::{broadcast, mpsc};
+
+// ---------------------------------------------------------------------------
+// Network latency injection
+// ---------------------------------------------------------------------------
+
+/// Injects a random delay drawn uniformly from `[min, max]` before a future
+/// resolves, modeling the 100ms–5000ms network latency spikes called out in
+/// Issue #1178.
+#[derive(Debug, Clone, Copy)]
+pub struct LatencyInjector {
+    min: Duration,
+    max: Duration,
+}
+
+impl LatencyInjector {
+    pub fn new(min: Duration, max: Duration) -> Self {
+        assert!(min <= max, "min latency must be <= max latency");
+        Self { min, max }
+    }
+
+    /// The issue's specified spike range: 100ms to 5000ms.
+    pub fn spike_range() -> Self {
+        Self::new(Duration::from_millis(100), Duration::from_millis(5000))
+    }
+
+    fn sample_delay(&self) -> Duration {
+        if self.min == self.max {
+            return self.min;
+        }
+        let min_ms = self.min.as_millis() as u64;
+        let max_ms = self.max.as_millis() as u64;
+        Duration::from_millis(rand::thread_rng().gen_range(min_ms..=max_ms))
+    }
+
+    /// Sleep for a sampled delay.
+    pub async fn strike(&self) {
+        tokio::time::sleep(self.sample_delay()).await;
+    }
+
+    /// Run `fut` behind an injected delay, returning its output and the
+    /// delay that was applied (useful for asserting the delay actually
+    /// landed inside the configured range).
+    pub async fn wrap<F: std::future::Future>(&self, fut: F) -> (F::Output, Duration) {
+        let delay = self.sample_delay();
+        tokio::time::sleep(delay).await;
+        (fut.await, delay)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PostgreSQL connection-pool exhaustion
+// ---------------------------------------------------------------------------
+
+/// Holds `count` live connections checked out from a `PgPool` for as long as
+/// the guard is alive, simulating sudden pool exhaustion. Connections are
+/// returned to the pool automatically when the guard is dropped.
+pub struct PoolExhaustionGuard {
+    _connections: Vec<sqlx::pool::PoolConnection<sqlx::Postgres>>,
+}
+
+impl PoolExhaustionGuard {
+    /// Acquire `count` connections from `pool` up front (bounded by a
+    /// timeout so a mis-sized `count` fails fast instead of hanging the
+    /// test suite), holding all of them until the guard is dropped.
+    pub async fn saturate(pool: &sqlx::PgPool, count: u32) -> Result<Self, sqlx::Error> {
+        let mut connections = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            let conn = tokio::time::timeout(Duration::from_secs(10), pool.acquire())
+                .await
+                .map_err(|_| sqlx::Error::PoolTimedOut)??;
+            connections.push(conn);
+        }
+        Ok(Self {
+            _connections: connections,
+        })
+    }
+
+    /// Saturate the *entire* configured pool (its `max_connections`), the
+    /// worst-case scenario from Issue #1178: every connection unavailable.
+    pub async fn saturate_fully(pool: &sqlx::PgPool) -> Result<Self, sqlx::Error> {
+        let max = pool.options().get_max_connections();
+        Self::saturate(pool, max).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dropped WebSocket frames
+// ---------------------------------------------------------------------------
+
+/// Forward messages from a `broadcast::Receiver` into a bounded `mpsc`
+/// channel, deliberately dropping a fraction of them to simulate the network
+/// losing WebSocket frames. Returns the receiving half; the forwarding task
+/// runs until the broadcast channel closes or the mpsc receiver is dropped.
+///
+/// `drop_rate` is clamped to `[0.0, 1.0]`; `0.5` drops roughly half of all
+/// frames.
+pub fn drop_frames<T>(mut rx: broadcast::Receiver<T>, drop_rate: f64) -> mpsc::Receiver<T>
+where
+    T: Clone + Send + 'static,
+{
+    let drop_rate = drop_rate.clamp(0.0, 1.0);
+    let (tx, forwarded_rx) = mpsc::channel(256);
+
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    let dropped = rand::thread_rng().gen_bool(drop_rate);
+                    if dropped {
+                        continue;
+                    }
+                    if tx.send(msg).await.is_err() {
+                        break; // receiver gone
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
+    forwarded_rx
+}
+
+// ---------------------------------------------------------------------------
+// Combined chaos configuration (env-driven, mirrors production tunables)
+// ---------------------------------------------------------------------------
+
+/// Bundles every chaos knob so a test (or, eventually, a dedicated `k6`/CI
+/// chaos run) can be configured from the environment without touching code.
+#[derive(Debug, Clone)]
+pub struct ChaosConfig {
+    pub latency_min_ms: u64,
+    pub latency_max_ms: u64,
+    pub ws_drop_rate: f64,
+    pub pool_exhaustion_connections: u32,
+}
+
+impl ChaosConfig {
+    pub fn from_env() -> Self {
+        Self {
+            latency_min_ms: env_u64("CHAOS_LATENCY_MIN_MS", 100),
+            latency_max_ms: env_u64("CHAOS_LATENCY_MAX_MS", 5000),
+            ws_drop_rate: env_f64("CHAOS_WS_DROP_RATE", 0.2),
+            pool_exhaustion_connections: env_u64("CHAOS_POOL_EXHAUSTION_CONNECTIONS", 5) as u32,
+        }
+    }
+
+    pub fn latency_injector(&self) -> LatencyInjector {
+        LatencyInjector::new(
+            Duration::from_millis(self.latency_min_ms),
+            Duration::from_millis(self.latency_max_ms),
+        )
+    }
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_f64(key: &str, default: f64) -> f64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn latency_injector_stays_within_configured_range() {
+        let injector = LatencyInjector::new(Duration::from_millis(20), Duration::from_millis(60));
+        let start = tokio::time::Instant::now();
+        injector.strike().await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(20));
+        // Generous upper bound to absorb scheduler jitter on a loaded CI box.
+        assert!(elapsed < Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn wrap_returns_inner_future_output() {
+        let injector = LatencyInjector::new(Duration::from_millis(1), Duration::from_millis(5));
+        let (value, delay) = injector.wrap(async { 42 }).await;
+        assert_eq!(value, 42);
+        assert!(delay >= Duration::from_millis(1) && delay <= Duration::from_millis(5));
+    }
+
+    #[tokio::test]
+    async fn drop_frames_never_exceeds_total_sent() {
+        let (tx, rx) = broadcast::channel::<u32>(64);
+        let mut forwarded = drop_frames(rx, 0.5);
+
+        for i in 0..50u32 {
+            let _ = tx.send(i);
+        }
+        drop(tx);
+
+        let mut received = 0u32;
+        while forwarded.recv().await.is_some() {
+            received += 1;
+        }
+        assert!(received <= 50, "cannot forward more than were sent");
+    }
+
+    #[tokio::test]
+    async fn drop_frames_at_zero_rate_forwards_everything() {
+        let (tx, rx) = broadcast::channel::<u32>(64);
+        let mut forwarded = drop_frames(rx, 0.0);
+
+        for i in 0..20u32 {
+            tx.send(i).unwrap();
+        }
+        drop(tx);
+
+        let mut received = 0u32;
+        while forwarded.recv().await.is_some() {
+            received += 1;
+        }
+        assert_eq!(received, 20, "zero drop rate must forward every frame");
+    }
+
+    #[test]
+    fn chaos_config_falls_back_to_defaults() {
+        // Rely on ambient env not setting these in the test process; assert
+        // the shape is sane rather than depending on unset-ness (parallel
+        // test runs may share env).
+        let config = ChaosConfig {
+            latency_min_ms: 100,
+            latency_max_ms: 5000,
+            ws_drop_rate: 0.2,
+            pool_exhaustion_connections: 5,
+        };
+        assert!(config.latency_min_ms <= config.latency_max_ms);
+        assert!(config.ws_drop_rate >= 0.0 && config.ws_drop_rate <= 1.0);
+    }
+}

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -1,0 +1,101 @@
+//! Shared test-support code for the chaos engineering & re-org simulation
+//! suite (Issue #1178). Lives under `tests/common/mod.rs` (not
+//! `tests/common.rs`) specifically so Cargo does not treat it as its own
+//! test binary — see the [integration test guidelines] in the Rust book.
+//!
+//! [integration test guidelines]: https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests
+
+pub mod chaos;
+
+use sqlx::PgPool;
+
+/// Connect to the database named by `DATABASE_URL`, or return `None` with a
+/// message on stderr.
+///
+/// Mirrors the skip-gracefully convention already used by
+/// `server/tests/auth_integration.rs` so these tests behave identically in
+/// environments (local dev without Docker, some CI runners) that don't wire
+/// up Postgres.
+pub async fn test_pool(test_name: &str) -> Option<PgPool> {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipping {test_name}: DATABASE_URL not set");
+        return None;
+    };
+
+    match PgPool::connect(&database_url).await {
+        Ok(pool) => Some(pool),
+        Err(e) => {
+            eprintln!("skipping {test_name}: failed to connect to DATABASE_URL: {e}");
+            None
+        }
+    }
+}
+
+/// Ledger base far above any plausible real Stellar ledger sequence (mainnet
+/// sits in the tens of millions as of 2026 — Stellar closes a ledger roughly
+/// every 5 seconds and has run since 2015). Chaos/re-org tests that write
+/// into `indexer_ledger_events` anchor every synthetic ledger number at or
+/// above this constant so `CheckpointStore::rollback_to`'s
+/// `DELETE FROM indexer_ledger_events WHERE ledger >= $1` — which is not
+/// scoped by chain — can never delete real indexed data if these tests run
+/// against a shared, populated database.
+pub const SYNTHETIC_LEDGER_BASE: u32 = 3_900_000_000;
+
+/// A synthetic ledger base randomized within `[SYNTHETIC_LEDGER_BASE,
+/// SYNTHETIC_LEDGER_BASE + 300_000_000)`.
+///
+/// `CheckpointStore::rollback_to`'s buffer purge (`DELETE FROM
+/// indexer_ledger_events WHERE ledger >= $1`) is not scoped by chain or
+/// contract, and `cargo test` runs multiple `#[tokio::test]` functions —
+/// even across different integration-test binaries — concurrently against
+/// the same database. Randomizing each test's ledger slice on top of the
+/// already-far-from-real `SYNTHETIC_LEDGER_BASE` keeps concurrently running
+/// chaos/re-org tests from purging each other's buffered rows, while still
+/// leaving comfortable headroom below `u32::MAX` (~4.29B) for a small test
+/// window.
+pub fn random_synthetic_ledger_base() -> u32 {
+    use rand::Rng;
+    SYNTHETIC_LEDGER_BASE + rand::thread_rng().gen_range(0..300_000_000)
+}
+
+/// Create a synthetic organizer + event pair for tests that need a valid FK
+/// target for `tickets.event_id`. Returns `(organizer_id, event_id)`.
+///
+/// Deleting the organizer row cascades to the event and every ticket
+/// attached to it (`events.organizer_id` and `tickets.event_id` are both
+/// `ON DELETE CASCADE`), so callers only need to clean up the organizer.
+pub async fn seed_organizer_and_event(pool: &PgPool, label: &str) -> (uuid::Uuid, uuid::Uuid) {
+    let organizer_id = uuid::Uuid::new_v4();
+    let event_id = uuid::Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO organizers (id, name, contact_email) VALUES ($1, $2, 'chaos-suite@agora.test')",
+    )
+    .bind(organizer_id)
+    .bind(format!("Chaos Suite Organizer ({label})"))
+    .execute(pool)
+    .await
+    .expect("seed organizer");
+
+    sqlx::query(
+        "INSERT INTO events (id, organizer_id, title, location, start_time)
+         VALUES ($1, $2, $3, 'Chaos Suite Venue', NOW())",
+    )
+    .bind(event_id)
+    .bind(organizer_id)
+    .bind(format!("Chaos Suite Event ({label})"))
+    .execute(pool)
+    .await
+    .expect("seed event");
+
+    (organizer_id, event_id)
+}
+
+/// Delete an organizer created by [`seed_organizer_and_event`] (cascades to
+/// its event and tickets).
+pub async fn cleanup_organizer(pool: &PgPool, organizer_id: uuid::Uuid) {
+    let _ = sqlx::query("DELETE FROM organizers WHERE id = $1")
+        .bind(organizer_id)
+        .execute(pool)
+        .await;
+}


### PR DESCRIPTION
## Description
- Add criterion benchmarks for database queries, handlers, reorg indexer, and serialization
- Add chaos engineering tests for dropped WebSocket frames, network latency, pool exhaustion, and reorg simulation
- Add k6-based stress testing scripts and baseline performance reporting
- Add `generate_perf_report.mjs` to generate structured performance regression reports for CI
- Add performance baseline tracking in `perf_baseline.json`
- Update `server/Cargo.toml` with benchmark and test dependencies
- Comprehensive test infrastructure for performance monitoring and chaos validation

Closes #1178 