### PR TITLE
Add event OG metadata, build version endpoint, request timeout, and response compression

### DIFF
--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -11,6 +11,11 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { EventPageView } from "@/components/analytics/event-page-view";
 import { SecondaryMarketplaceTab } from "@/components/events/secondary-marketplace-tab";
 
+function truncateDescription(text: string, maxLength = 160): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -18,10 +23,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { id } = await params;
   const event = dataEvents.find((e) => e.id === parseInt(id));
-  if (!event) return {};
+  if (!event) return { title: "Event not found" };
   return buildMetadata({
     title: event.title,
-    description: `Join us for ${event.title} on ${event.date} in ${event.location}. ${event.price === "Free" ? "Free entry." : `Tickets from $${event.price}.`} Secure your spot on Agora.`,
+    description: truncateDescription(
+      `Join us for ${event.title} on ${event.date} in ${event.location}. ${event.price === "Free" ? "Free entry." : `Tickets from $${event.price}.`} Secure your spot on Agora.`
+    ),
     image: event.imageUrl,
     path: `/events/${id}`,
   });

--- a/apps/web/components/layout/seo.tsx
+++ b/apps/web/components/layout/seo.tsx
@@ -24,5 +24,11 @@ export function buildMetadata({ title, description, image, path }: SEOProps): Me
       images: [{ url: ogImage, width: 1200, height: 630, alt: title }],
       type: "website",
     },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImage],
+    },
   };
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.37", features = ["full"] }
 
 # Middleware
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace", "set-header", "request-id", "limit", "catch-panic", "timeout"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "set-header", "request-id", "limit", "catch-panic", "timeout", "compression-gzip", "compression-br"] }
 pin-project = "1.1"
 
 # Serialization

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.37", features = ["full"] }
 
 # Middleware
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace", "set-header", "request-id", "limit", "catch-panic"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "set-header", "request-id", "limit", "catch-panic", "timeout"] }
 pin-project = "1.1"
 
 # Serialization

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -95,3 +95,7 @@ dashmap = "6.2.1"
 temp-env = { version = "0.3", features = ["async_closure"] }
 tower = { version = "0.4", features = ["full"] }
 serde_yaml = "0.9"
+
+# Build-time metadata (git SHA, build timestamp) for the /version endpoint
+[build-dependencies]
+chrono = "0.4"

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+
+fn command_output(cmd: &str, args: &[&str]) -> Option<String> {
+    Command::new(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn main() {
+    // Falls back to "unknown" when building outside a git checkout (e.g. a
+    // Docker build context with no `.git` directory).
+    let git_sha =
+        command_output("git", &["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let rustc_version =
+        command_output("rustc", &["--version"]).unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_SHA={git_sha}");
+    println!("cargo:rustc-env=BUILT_AT={}", chrono::Utc::now().to_rfc3339());
+    println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
+
+    // Re-run when HEAD moves, but don't fail the build without a `.git` dir.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -115,6 +115,10 @@ pub struct Config {
 
     /// Time in seconds after which an idle connection is closed (DB_IDLE_TIMEOUT_SECS, default: 600).
     pub db_idle_timeout_secs: u64,
+
+    /// Maximum time in seconds a request may take before the server returns
+    /// a 504 (REQUEST_TIMEOUT_SECS, default: 30).
+    pub request_timeout_secs: u64,
 }
 
 /// A collection of configuration errors found during [`Config::validate`].
@@ -217,6 +221,11 @@ impl Config {
             .and_then(|v| v.parse().ok())
             .unwrap_or(600u64);
 
+        let request_timeout_secs = env::var("REQUEST_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30u64);
+
         Ok(Self {
             database_url,
             port,
@@ -241,6 +250,7 @@ impl Config {
             db_min_connections,
             db_acquire_timeout_secs,
             db_idle_timeout_secs,
+            request_timeout_secs,
         })
     }
 
@@ -417,6 +427,7 @@ mod tests {
             db_min_connections: 1,
             db_acquire_timeout_secs: 10,
             db_idle_timeout_secs: 600,
+            request_timeout_secs: 30,
         }
     }
 
@@ -960,6 +971,7 @@ mod tests {
             db_min_connections: 1,
             db_acquire_timeout_secs: 10,
             db_idle_timeout_secs: 600,
+            request_timeout_secs: 30,
         };
 
         let err = cfg.validate().unwrap_err();

--- a/server/src/handlers/health.rs
+++ b/server/src/handlers/health.rs
@@ -225,6 +225,37 @@ struct HealthRedisResponse {
     timestamp: String,
 }
 
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct VersionResponse {
+    version: &'static str,
+    git_sha: &'static str,
+    built_at: &'static str,
+    rust_version: &'static str,
+}
+
+/// GET /version – Build metadata for the running deployment.
+///
+/// Reports the crate version, git commit SHA, build timestamp, and the rustc
+/// version used to compile the binary, captured at compile time by
+/// `build.rs`. The git SHA falls back to `"unknown"` when built outside a
+/// git checkout (e.g. a Docker build context with no `.git` directory).
+#[utoipa::path(
+    get,
+    path = "/version",
+    responses(
+        (status = 200, description = "Build version metadata", body = VersionResponse)
+    )
+)]
+pub async fn version() -> Response {
+    let payload = VersionResponse {
+        version: env!("CARGO_PKG_VERSION"),
+        git_sha: env!("GIT_SHA"),
+        built_at: env!("BUILT_AT"),
+        rust_version: env!("RUSTC_VERSION"),
+    };
+    success(payload, "Build version").into_response()
+}
+
 /// GET /health/redis – Redis connectivity check.
 ///
 /// Returns 200 when Redis is reachable.
@@ -312,5 +343,28 @@ mod tests {
         assert_eq!(json["message"], "API is healthy");
         assert_eq!(json["data"]["status"], "ok");
         assert!(json["data"]["timestamp"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_version_endpoint_returns_200_with_non_empty_version() {
+        let router = Router::new().route("/version", get(version));
+
+        let req = Request::builder()
+            .uri("/version")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(json["success"], true);
+        assert!(!json["data"]["version"].as_str().unwrap().is_empty());
+        assert!(!json["data"]["git_sha"].as_str().unwrap().is_empty());
     }
 }

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -22,6 +22,7 @@
 use crate::handlers::{delta_sync, sync_status, SyncState};
 use crate::handlers::indexer::{replay_indexer, IndexerAdminState};
 use axum::{
+    error_handling::HandleErrorLayer,
     middleware,
     response::IntoResponse,
     response::Response,
@@ -30,7 +31,9 @@ use axum::{
 };
 use sqlx::PgPool;
 use std::time::Duration;
+use tower::ServiceBuilder;
 use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::timeout::TimeoutLayer;
 
 use crate::cache::RedisCache;
 use crate::config::{
@@ -247,6 +250,11 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/challenge", post(request_challenge))
         .route("/join", post(join_queue))
         .route("/status", get(queue_status))
+        .with_state(waiting_room_state.clone());
+
+    // Long-lived SSE stream — kept out of the request timeout layer below so
+    // it isn't cut off while a client is still connected (Issue #1252).
+    let waiting_room_stream_routes = Router::new()
         .route("/stream", get(queue_stream))
         .with_state(waiting_room_state);
 
@@ -414,7 +422,6 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .nest("/categories", category_routes)
         .nest("/auth", auth_routes)
         .nest("/profile", profile_routes)
-        .nest("/ws", ws_routes)
         .nest("/waiting-room", waiting_room_routes)
         .nest("/qr", qr_routes)
         .nest("/zk", zk_routes)
@@ -426,6 +433,17 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         // Per-IP token-bucket rate limit (RATE_LIMIT_MAX / RATE_LIMIT_WINDOW).
         .layer(RateLimitLayer::from_env());
 
+    // WebSocket and SSE routes get the same content-type/body-limit/rate-limit
+    // protections as the rest of the public API, but are exempt from the
+    // request timeout below since they are meant to stay connected
+    // indefinitely (Issue #1252).
+    let streaming_routes = Router::new()
+        .nest("/ws", ws_routes)
+        .nest("/waiting-room", waiting_room_stream_routes)
+        .layer(middleware::from_fn(require_json_content_type))
+        .layer(RequestBodyLimitLayer::new(1024 * 1024))
+        .layer(RateLimitLayer::from_env());
+
     let api_routes = Router::new()
         .merge(sensitive_routes)
         .merge(general_routes)
@@ -434,6 +452,14 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
             utoipa_swagger_ui::SwaggerUi::new("/swagger-ui")
                 .url("/openapi.json", ApiDoc::openapi()),
         )
+        .layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(crate::utils::error::handle_timeout_error))
+                .layer(TimeoutLayer::new(Duration::from_secs(
+                    config.request_timeout_secs,
+                ))),
+        )
+        .merge(streaming_routes)
         .layer(middleware::from_fn(crate::middleware::csrf::check_csrf));
 
     // Deep linking routes
@@ -697,5 +723,42 @@ mod tests {
 
         let status = router.oneshot(req).await.unwrap().status();
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_slow_handler_returns_504_gateway_timeout() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let router = Router::new()
+            .route(
+                "/slow",
+                get(|| async {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    "too slow"
+                }),
+            )
+            .layer(
+                ServiceBuilder::new()
+                    .layer(HandleErrorLayer::new(
+                        crate::utils::error::handle_timeout_error,
+                    ))
+                    .layer(TimeoutLayer::new(Duration::from_millis(10))),
+            );
+
+        let req = Request::builder()
+            .uri("/slow")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["code"], "SERVICE_UNAVAILABLE");
     }
 }

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -60,7 +60,7 @@ use crate::handlers::{
     example_empty_success, example_not_found, example_validation_error,
     health::{
         health_check, health_check_blockchain, health_check_db, health_check_ready,
-        health_check_redis,
+        health_check_redis, version,
     },
     marketplace::{
         cancel_listing, create_key_envelope, create_listing, create_offer, get_key_envelope,
@@ -384,6 +384,7 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
         .route("/examples/validation-error", get(example_validation_error))
         .route("/examples/empty-success", get(example_empty_success))
         .route("/examples/not-found/:id", get(example_not_found))
+        .route("/version", get(version))
         .with_state(pool)
         .layer(RateLimitLayer::new(GENERAL_RATE_LIMIT, GENERAL_WINDOW));
 

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -32,6 +32,10 @@ use axum::{
 use sqlx::PgPool;
 use std::time::Duration;
 use tower::ServiceBuilder;
+use tower_http::compression::{
+    predicate::{DefaultPredicate, Predicate, SizeAbove},
+    CompressionLayer,
+};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::timeout::TimeoutLayer;
 
@@ -459,6 +463,10 @@ pub async fn create_routes(pool: PgPool, config: Config, redis: RedisCache) -> R
                     config.request_timeout_secs,
                 ))),
         )
+        // gzip/br response compression — excludes /metrics (mounted outside
+        // `api_routes`) and the streaming routes merged in below, and skips
+        // small bodies that wouldn't benefit (Issue #1253).
+        .layer(CompressionLayer::new().compress_when(DefaultPredicate::new().and(SizeAbove::new(1024))))
         .merge(streaming_routes)
         .layer(middleware::from_fn(crate::middleware::csrf::check_csrf));
 

--- a/server/src/utils/error.rs
+++ b/server/src/utils/error.rs
@@ -320,6 +320,20 @@ impl IntoResponse for AppError {
     }
 }
 
+/// Converts a boxed middleware error into the standard [`ApiError`] body.
+///
+/// Paired with [`tower_http::timeout::TimeoutLayer`] via `HandleErrorLayer` so
+/// a request that exceeds `REQUEST_TIMEOUT_SECS` returns a `504` in the same
+/// shape as every other error response, instead of tower's default plaintext
+/// error body.
+pub async fn handle_timeout_error(err: axum::BoxError) -> ApiError {
+    if err.is::<tower_http::timeout::error::Elapsed>() {
+        ApiError::new(StatusCode::GATEWAY_TIMEOUT, "Request timed out")
+    } else {
+        ApiError::internal(format!("Unhandled internal error: {err}"))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds per-event social-share metadata, a build-version endpoint, a request timeout with 504 mapping, and response compression to the API router.

- Event pages now generate dynamic OpenGraph and Twitter card metadata (title, ~160-char description excerpt, image with fallback), and return an "Event not found" title instead of an empty metadata object for a missing event.
- Added `GET /api/v1/version` returning the crate version, git SHA, build timestamp, and rustc version captured at compile time via a new `build.rs`; falls back to `"unknown"` for the git SHA outside a git checkout.
- Added a configurable request timeout (`REQUEST_TIMEOUT_SECS`, default 30) that maps a timed-out request to a 504 in the standard error body; the WebSocket purchases feed and the waiting-room SSE stream are exempted so they stay connected past the timeout.
- Enabled gzip/brotli response compression for the API router, skipping responses under 1KB and excluding the `/metrics` endpoint and the streaming routes.

Closes #1250
Closes #1251
Closes #1252
Closes #1253