### PR TITLE
Add global aria-live region for status announcements

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,6 +8,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { CookieBanner } from "@/components/layout/cookie-banner";
+import { LiveAnnouncer } from "@/components/ui/live-announcer";
 import "./globals.css";
 
 const inter = Inter({
@@ -52,6 +53,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.variable} antialiased`}>
+        <LiveAnnouncer />
         {children}
         <CookieBanner />
       </body>

--- a/apps/web/components/events/organizer-component.tsx
+++ b/apps/web/components/events/organizer-component.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import { fetchOrganizers, type DiscoverOrganizer } from "@/utils/api";
 import { Button } from "@/components/ui/button";
 import { WalletAddress } from "@/components/ui/wallet-address";
+import { announce } from "@/components/ui/live-announcer";
 import Link from "next/link";
 
 const fallbackCardsData: DiscoverOrganizer[] = [
@@ -87,6 +88,7 @@ export function OrganizerComponent({
         // Ignore abort errors — they are intentional and not user-facing.
         if (err instanceof Error && err.name === "AbortError") return;
         setCardsData([]);
+        announce("Could not load organizers");
         onError("Could not load organizers");
       } finally {
         // Only update loading state if the fetch was not aborted.

--- a/apps/web/components/ui/live-announcer.tsx
+++ b/apps/web/components/ui/live-announcer.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Listener = (message: string) => void;
+
+const listeners = new Set<Listener>();
+
+/**
+ * Announces `message` to screen readers via the global live region mounted
+ * once in `app/layout.tsx`. Safe to call from any client component.
+ */
+export function announce(message: string): void {
+  listeners.forEach((listener) => listener(message));
+}
+
+/**
+ * Visually hidden, polite live region. Screen readers read updates to its
+ * text content without moving focus. Mount once near the root of the app;
+ * call `announce()` from anywhere to have a message read aloud.
+ */
+export function LiveAnnouncer() {
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    let clearTimer: ReturnType<typeof setTimeout>;
+
+    const listener: Listener = (next) => {
+      // Clear first so repeating the same message back-to-back still
+      // triggers a fresh announcement (identical text is otherwise a no-op).
+      setMessage("");
+      clearTimer = setTimeout(() => setMessage(next), 50);
+    };
+
+    listeners.add(listener);
+    return () => {
+      clearTimeout(clearTimer);
+      listeners.delete(listener);
+    };
+  }, []);
+
+  return (
+    <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a single global polite live region plus an `announce()` helper so any client component can have status text read by screen readers without moving focus, and wires it into the discover page's organizer-loading error path as a reference implementation.

- New `components/ui/live-announcer.tsx`: a visually hidden (`.sr-only`, not `display: none`) `<div role="status" aria-live="polite" aria-atomic="true">` plus a small module-level `announce(message)` emitter, so callers don't need a context provider.
- Mounted `<LiveAnnouncer />` once in `app/layout.tsx`.
- `organizer-component.tsx` (rendered by the discover page) now calls `announce("Could not load organizers")` alongside its existing error handling when the organizer fetch fails.

Closes #1224