### PR TITLE
feat(notifications): add mark all as read with unread badge

### DIFF
--- a/apps/web/__tests__/notifications-page.test.tsx
+++ b/apps/web/__tests__/notifications-page.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { expect, describe, it, vi } from "vitest";
+import NotificationsPage from "@/app/notifications/page";
+
+// Mock next/image — render a plain img so jsdom doesn't choke on optimization
+vi.mock("next/image", () => ({
+  // eslint-disable-next-line @next/next/no-img-element
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// Mock layout chrome so the page renders independently
+vi.mock("@/components/layout/navbar", () => ({
+  Navbar: () => <nav data-testid="navbar" />,
+}));
+
+vi.mock("@/components/layout/footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
+// Mock sonner toast to assert the confirmation call
+const toastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args) },
+}));
+
+describe("NotificationsPage mark all as read", () => {
+  it("renders the unread count badge next to the title", () => {
+    render(<NotificationsPage />);
+    // mockNotifications has 2 unread, 1 read
+    expect(screen.getByTestId("unread-badge")).toHaveTextContent("2");
+    expect(screen.getByLabelText("2 unread notifications")).toBeInTheDocument();
+  });
+
+  it("renders the Mark all as read button enabled when there are unread items", () => {
+    render(<NotificationsPage />);
+    const btn = screen.getByRole("button", { name: /mark all notifications as read/i });
+    expect(btn).toBeEnabled();
+  });
+
+  it("marks every notification read and clears unread styling on click", () => {
+    render(<NotificationsPage />);
+    const btn = screen.getByRole("button", { name: /mark all notifications as read/i });
+    fireEvent.click(btn);
+
+    // unread badge disappears after all are marked read
+    expect(screen.queryByTestId("unread-badge")).not.toBeInTheDocument();
+    // button becomes disabled
+    expect(screen.getByRole("button", { name: /mark all notifications as read/i })).toBeDisabled();
+    // toast confirmation fired
+    expect(toastSuccess).toHaveBeenCalledWith("All notifications marked as read");
+  });
+
+  it("disables the button and hides the badge when there is nothing unread", () => {
+    // simulate all-read by clicking once first
+    render(<NotificationsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /mark all notifications as read/i }));
+
+    // clicking again should be a no-op (toast not re-fired)
+    toastSuccess.mockClear();
+    const btn = screen.getByRole("button", { name: /mark all notifications as read/i });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("keeps the page title and empty-state behavior intact", () => {
+    render(<NotificationsPage />);
+    expect(screen.getByRole("heading", { name: /notifications/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 
 interface NotificationItem {
   id: string;
@@ -49,9 +50,13 @@ const mockNotifications: NotificationItem[] = [
 
 export default function NotificationsPage() {
   const [notifications, setNotifications] = useState<NotificationItem[]>(mockNotifications);
-  
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
   const markAllAsRead = () => {
-    setNotifications(notifications.map(n => ({ ...n, read: true })));
+    if (unreadCount === 0) return;
+    setNotifications(notifications.map((n) => ({ ...n, read: true })));
+    toast.success("All notifications marked as read");
   };
 
   const clearNotifications = () => {
@@ -62,18 +67,30 @@ export default function NotificationsPage() {
     <main className="flex flex-col min-h-screen bg-base">
       <Navbar />
       <div className="flex-1 w-full max-w-[800px] mx-auto px-4 py-12 md:py-20">
-        
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-4xl font-extrabold italic text-ink-deep">Notifications</h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-4xl font-extrabold italic text-ink-deep">Notifications</h1>
+            {unreadCount > 0 && (
+              <span
+                data-testid="unread-badge"
+                aria-label={`${unreadCount} unread notification${unreadCount === 1 ? "" : "s"}`}
+                className="inline-flex items-center justify-center min-w-[28px] h-7 px-2 rounded-full bg-accent text-black text-sm font-bold border-2 border-black"
+              >
+                {unreadCount}
+              </span>
+            )}
+          </div>
           {notifications.length > 0 && (
             <div className="flex gap-4">
-              <button 
+              <button
                 onClick={markAllAsRead}
-                className="text-sm font-semibold text-ink-deep hover:underline"
+                disabled={unreadCount === 0}
+                aria-label="Mark all notifications as read"
+                className="text-sm font-semibold text-ink-deep hover:underline disabled:text-gray-400 disabled:no-underline disabled:cursor-not-allowed"
               >
                 Mark all as read
               </button>
-              <button 
+              <button
                 onClick={clearNotifications}
                 className="text-sm font-semibold text-error hover:underline"
               >
@@ -86,30 +103,34 @@ export default function NotificationsPage() {
         {notifications.length > 0 ? (
           <div className="flex flex-col gap-4">
             {notifications.map((notification) => (
-              <div 
-                key={notification.id} 
+              <div
+                key={notification.id}
                 className={`flex gap-4 p-6 rounded-2xl border-2 border-black transition-all ${
-                  notification.read 
-                    ? "bg-white shadow-[-4px_4px_0_rgba(0,0,0,1)] opacity-70" 
+                  notification.read
+                    ? "bg-white shadow-[-4px_4px_0_rgba(0,0,0,1)] opacity-70"
                     : "bg-surface shadow-[-6px_6px_0_rgba(0,0,0,1)] hover:-translate-y-1"
                 }`}
               >
                 <div className="w-12 h-12 shrink-0 bg-white rounded-full flex items-center justify-center border-2 border-black">
-                  <Image 
+                  <Image
                     src={
-                      notification.type === "ticket_confirmation" ? "/icons/ticket.svg" :
-                      notification.type === "event_reminder" ? "/icons/calendar.svg" :
-                      "/icons/user-group.svg"
-                    } 
-                    alt={notification.type} 
-                    width={24} 
-                    height={24} 
+                      notification.type === "ticket_confirmation"
+                        ? "/icons/ticket.svg"
+                        : notification.type === "event_reminder"
+                          ? "/icons/calendar.svg"
+                          : "/icons/user-group.svg"
+                    }
+                    alt={notification.type}
+                    width={24}
+                    height={24}
                   />
                 </div>
                 <div className="flex-1">
                   <div className="flex justify-between items-start mb-1">
                     <h3 className="font-bold text-lg text-ink-deep">{notification.title}</h3>
-                    <span className="text-xs font-semibold text-gray-500 whitespace-nowrap">{notification.time}</span>
+                    <span className="text-xs font-semibold text-gray-500 whitespace-nowrap">
+                      {notification.time}
+                    </span>
                   </div>
                   <p className="text-ink-deep/80 mb-3">{notification.message}</p>
                   {notification.link && (
@@ -130,16 +151,21 @@ export default function NotificationsPage() {
             </div>
             <h2 className="text-3xl font-bold italic mb-4">You&apos;re all caught up!</h2>
             <p className="text-ink-deep/70 mb-8 max-w-md mx-auto">
-              You don&apos;t have any new notifications at the moment. Check back later for updates on your events and tickets.
+              You don&apos;t have any new notifications at the moment. Check back later for updates
+              on your events and tickets.
             </p>
             <Link href="/discover">
-              <Button backgroundColor="bg-accent" textColor="text-black" shadowColor="rgba(253,218,35,0.4)" className="px-8 font-bold text-lg">
+              <Button
+                backgroundColor="bg-accent"
+                textColor="text-black"
+                shadowColor="rgba(253,218,35,0.4)"
+                className="px-8 font-bold text-lg"
+              >
                 Discover Events
               </Button>
             </Link>
           </div>
         )}
-
       </div>
       <Footer />
     </main>


### PR DESCRIPTION
## Summary
Adds a **"Mark all as read"** action to the notifications page so users can clear every unread notification in one click, instead of dismissing them one at a time.

## Changes
- Added an **unread count badge** next to the page title (hidden when nothing is unread).
- Added a **"Mark all as read"** button in the page header, **disabled (and visually muted)** when the unread count is 0.
- Marks all notifications read **optimistically** — every item loses its unread styling immediately.
- Shows a **`toast.success`** confirmation after marking all as read.
- The button has an **accessible name** (`aria-label`) and is a native button, so it's keyboard reachable.

## Files
- `apps/web/app/notifications/page.tsx`
- `apps/web/__tests__/notifications-page.test.tsx` (5 new tests)

## Acceptance Criteria
- [x] Clicking the button clears every unread indicator at once.
- [x] The button is disabled (and visually muted) when there is nothing unread.

Closes #1220
