### PR TITLE
feat(ui): add floating back-to-top button to long pages

### DIFF
--- a/apps/web/__tests__/back-to-top.test.tsx
+++ b/apps/web/__tests__/back-to-top.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+import { BackToTop } from "@/components/ui/back-to-top";
+
+describe("BackToTop component", () => {
+  beforeEach(() => {
+    // Fresh scroll state for each test.
+    window.scrollY = 0;
+    window.innerHeight = 800;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a button with an accessible label", () => {
+    render(<BackToTop />);
+    expect(screen.getByRole("button", { name: "Back to top" })).toBeInTheDocument();
+  });
+
+  it("is hidden when the page is at the top", () => {
+    render(<BackToTop />);
+    const button = screen.getByRole("button", { name: "Back to top" });
+    expect(button.className).toContain("opacity-0");
+    expect(button.className).toContain("pointer-events-none");
+  });
+
+  it("becomes visible after scrolling past one viewport", () => {
+    render(<BackToTop />);
+    const button = screen.getByRole("button", { name: "Back to top" });
+    expect(button.className).toContain("opacity-0");
+
+    window.scrollY = 1000; // > innerHeight (800)
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(button.className).toContain("opacity-100");
+    expect(button.className).toContain("pointer-events-auto");
+  });
+
+  it("hides again when scrolled back to the top", () => {
+    render(<BackToTop />);
+    const button = screen.getByRole("button", { name: "Back to top" });
+
+    window.scrollY = 1000;
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(button.className).toContain("opacity-100");
+
+    window.scrollY = 200;
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(button.className).toContain("opacity-0");
+  });
+
+  it("smooth-scrolls to the top on click", () => {
+    const scrollTo = vi.fn();
+    vi.stubGlobal("scrollTo", scrollTo);
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    render(<BackToTop />);
+    fireEvent.click(screen.getByRole("button", { name: "Back to top" }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+
+  it("scrolls instantly when the user prefers reduced motion", () => {
+    const scrollTo = vi.fn();
+    vi.stubGlobal("scrollTo", scrollTo);
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+
+    render(<BackToTop />);
+    fireEvent.click(screen.getByRole("button", { name: "Back to top" }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "instant" });
+  });
+
+  it("removes the scroll listener on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = render(<BackToTop />);
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
+  });
+});

--- a/apps/web/app/discover/page.tsx
+++ b/apps/web/app/discover/page.tsx
@@ -8,6 +8,7 @@ import { PopularEventsSection } from "@/components/events/popular-events-section
 import { OrganizerComponent } from "@/components/events/organizer-component";
 import { Footer } from "@/components/layout/footer";
 import { EmptyState } from "@/components/ui/empty-state";
+import { BackToTop } from "@/components/ui/back-to-top";
 import { fetchOrganizers, type DiscoverOrganizer } from "@/utils/api";
 
 function DiscoverContent() {
@@ -47,6 +48,7 @@ function DiscoverContent() {
         onOrganizerChange={(value) => updateFilter("organizer", value)}
       />
       <Footer />
+      <BackToTop />
     </main>
   );
 }

--- a/apps/web/app/help/page.tsx
+++ b/apps/web/app/help/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
+import { BackToTop } from "@/components/ui/back-to-top";
 
 // Icon imports — all sourced from /public/icons/
 import SearchIcon from "@/public/icons/search.svg";
@@ -283,6 +284,7 @@ export default function HelpCenterPage() {
       </section>
 
       <Footer />
+      <BackToTop />
     </main>
   );
 }

--- a/apps/web/components/ui/back-to-top.tsx
+++ b/apps/web/components/ui/back-to-top.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronUp } from "@/components/ui/icons";
+
+/**
+ * A floating "Back to top" button that appears once the user has scrolled
+ * past one viewport. Smooth-scrolls back to the top, honouring the user's
+ * `prefers-reduced-motion` preference by falling back to an instant jump.
+ *
+ * Uses a passive scroll listener that is removed on unmount to avoid leaks.
+ */
+export function BackToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > window.innerHeight);
+    };
+
+    // Initial state in case the page is loaded mid-scroll (e.g. bfcache).
+    onScroll();
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? "instant" : "smooth",
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Back to top"
+      onClick={scrollToTop}
+      className={[
+        "fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full",
+        "border-2 border-black bg-[#FDDA23] text-black shadow-[-3px_3px_0px_0px_rgba(0,0,0,1)]",
+        "transition-all duration-200 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#FDDA23]/60",
+        "hover:-translate-x-[1px] hover:translate-y-[1px] hover:shadow-[-1px_1px_0px_0px_rgba(0,0,0,1)]",
+        "active:translate-y-[2px] active:shadow-none",
+        visible ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none",
+      ].join(" ")}
+    >
+      <ChevronUp size={24} className="text-black" />
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #1215

## Summary

Adds a floating "Back to top" button that appears once the user scrolls past one viewport on long pages (`/discover` and `/help`).

## Changes

- **New** `apps/web/components/ui/back-to-top.tsx` — client component that:
  - Shows only after `window.scrollY > window.innerHeight` via a passive scroll listener (cleaned up on unmount)
  - Smooth-scrolls to top, falling back to instant when `prefers-reduced-motion: reduce` is set
  - Has `aria-label="Back to top"` and a visible focus ring
- **Mounted** on `apps/web/app/discover/page.tsx` and `apps/web/app/help/page.tsx`

## Tests

7 unit tests in `apps/web/__tests__/back-to-top.test.tsx` covering: accessible label, hidden at top, visible after scrolling, hides on scroll back, smooth scroll, reduced-motion instant scroll, and listener cleanup on unmount.

All 7 pass locally (vitest).