### PR TITLE
feat(events): add share button to event details page

### DIFF
--- a/apps/web/__tests__/share-event-button.test.tsx
+++ b/apps/web/__tests__/share-event-button.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+import { ShareEventButton } from "@/components/events/share-event-button";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { toast } from "sonner";
+
+const mockedToast = vi.mocked(toast);
+
+describe("ShareEventButton component", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Default: no native share, clipboard available
+    Object.assign(navigator, {
+      share: undefined,
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { href: "https://agora.example/events/42" },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a share button with an accessible label", () => {
+    render(<ShareEventButton title="Stellar Asado" />);
+    expect(screen.getByRole("button", { name: "Share this event" })).toBeInTheDocument();
+    expect(screen.getByText("Share")).toBeInTheDocument();
+  });
+
+  it("uses the Web Share API when available", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { share });
+
+    render(<ShareEventButton title="Stellar Asado" />);
+    fireEvent.click(screen.getByRole("button", { name: "Share this event" }));
+
+    await waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: "Stellar Asado",
+        text: "Check out this event: Stellar Asado",
+        url: "https://agora.example/events/42",
+      });
+    });
+    expect(mockedToast.success).not.toHaveBeenCalled();
+  });
+
+  it("falls back to copying the URL and shows a success toast when share is unavailable", async () => {
+    render(<ShareEventButton title="Stellar Asado" />);
+    fireEvent.click(screen.getByRole("button", { name: "Share this event" }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://agora.example/events/42");
+    });
+    expect(mockedToast.success).toHaveBeenCalledWith("Link copied");
+  });
+
+  it("silently ignores a user-cancelled AbortError from the share sheet", async () => {
+    const abortError = new DOMException("The user aborted a request.", "AbortError");
+    Object.assign(navigator, {
+      share: vi.fn().mockRejectedValue(abortError),
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    render(<ShareEventButton title="Stellar Asado" />);
+    fireEvent.click(screen.getByRole("button", { name: "Share this event" }));
+
+    // Let the promise reject and settle
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+    expect(mockedToast.success).not.toHaveBeenCalled();
+    expect(mockedToast.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to clipboard when the share sheet throws a non-Abort error", async () => {
+    Object.assign(navigator, {
+      share: vi.fn().mockRejectedValue(new Error("not allowed")),
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    render(<ShareEventButton title="Stellar Asado" />);
+    fireEvent.click(screen.getByRole("button", { name: "Share this event" }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://agora.example/events/42");
+    });
+    expect(mockedToast.success).toHaveBeenCalledWith("Link copied");
+  });
+});

--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -10,6 +10,7 @@ import { buildMetadata } from "@/components/layout/seo";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { EventPageView } from "@/components/analytics/event-page-view";
 import { SecondaryMarketplaceTab } from "@/components/events/secondary-marketplace-tab";
+import { ShareEventButton } from "@/components/events/share-event-button";
 
 export async function generateMetadata({
   params,
@@ -128,9 +129,12 @@ export default async function EventDetailPage({
           {/* RIGHT COLUMN (Desktop) / BOTTOM ITEMS (Mobile) */}
           <div className="lg:w-[45%] flex flex-col gap-8 lg:gap-10">
             {/* Title */}
-            <h1 className="text-[36px] sm:text-[56px] font-bold leading-[1.1] text-black font-heading">
-              {event.title}
-            </h1>
+            <div className="flex items-start justify-between gap-4">
+              <h1 className="text-[36px] sm:text-[56px] font-bold leading-[1.1] text-black font-heading">
+                {event.title}
+              </h1>
+              <ShareEventButton title={event.title} />
+            </div>
 
             {/* Details (Location & Date) */}
             <div className="flex flex-col gap-6">

--- a/apps/web/components/events/share-event-button.tsx
+++ b/apps/web/components/events/share-event-button.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Share2 } from "@/components/ui/icons";
+
+interface ShareEventButtonProps {
+  title: string;
+}
+
+/**
+ * Share control for the event details page. Uses the Web Share API when
+ * available (`navigator.share`), otherwise falls back to copying the page
+ * URL to the clipboard and showing a success toast via the globally mounted
+ * sonner Toaster.
+ *
+ * A user-cancelled share sheet (AbortError) is silently ignored.
+ */
+export function ShareEventButton({ title }: ShareEventButtonProps) {
+  const [pending, setPending] = useState(false);
+
+  const handleShare = async () => {
+    const url = window.location.href;
+
+    if (typeof navigator.share === "function") {
+      setPending(true);
+      try {
+        await navigator.share({
+          title,
+          text: `Check out this event: ${title}`,
+          url,
+        });
+      } catch (error) {
+        // User dismissed the share sheet — not an error worth surfacing.
+        // Note: DOMException does not satisfy `instanceof Error`, so check
+        // the name alone.
+        const errName = (error as { name?: string } | null)?.name;
+        if (errName === "AbortError") {
+          return;
+        }
+        // Some browsers throw for other reasons (e.g. not allowed);
+        // fall back to the clipboard path below.
+        await copyToClipboard(url);
+        toast.success("Link copied");
+      } finally {
+        setPending(false);
+      }
+      return;
+    }
+
+    await copyToClipboard(url);
+    toast.success("Link copied");
+  };
+
+  const copyToClipboard = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      // Clipboard API unavailable (e.g. insecure context) — last resort.
+      const input = document.createElement("textarea");
+      input.value = url;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      document.body.removeChild(input);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      disabled={pending}
+      aria-label="Share this event"
+      className="inline-flex shrink-0 items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2 text-sm font-semibold text-black shadow-[-3px_3px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-x-[1px] hover:translate-y-[1px] hover:shadow-[-1px_1px_0px_0px_rgba(0,0,0,1)] active:translate-y-[2px] active:shadow-none focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#FDDA23]/60"
+    >
+      <Share2 size={18} className="text-black" />
+      Share
+    </button>
+  );
+}

--- a/apps/web/components/ui/icons.tsx
+++ b/apps/web/components/ui/icons.tsx
@@ -139,6 +139,30 @@ export function ExternalLink({ size = 24, className }: IconProps) {
   );
 }
 
+export function Share2({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+    </svg>
+  );
+}
+
 export function X({ size = 24, className }: IconProps) {
   return (
     <svg


### PR DESCRIPTION
Closes #1216

## Summary

Adds a Share control to the event details page next to the title.

## Changes

- **New** `apps/web/components/events/share-event-button.tsx` (client component):
  - Calls `navigator.share({ title, text, url })` when the Web Share API is available
  - Otherwise copies the page URL via `navigator.clipboard.writeText(url)` and shows `toast.success("Link copied")` using the already-mounted sonner Toaster
  - Handles the user-cancelled `AbortError` from `navigator.share` silently (no error toast)
  - Last-resort textarea/execCommand fallback when the Clipboard API is unavailable
- **New** `Share2` icon in `components/ui/icons.tsx`
- **Mounted** in the event header next to the title in `apps/web/app/events/[id]/page.tsx`

## Tests

5 unit tests in `apps/web/__tests__/share-event-button.test.tsx`: renders with accessible label, uses Web Share API, clipboard+toast fallback, silent AbortError handling, and non-Abort error fallback. All pass locally (vitest).