### PR TITLE
feat(web): add mark all as read for notifications and slash search sh…

### DIFF
--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 
 interface NotificationItem {
   id: string;
@@ -50,8 +51,12 @@ const mockNotifications: NotificationItem[] = [
 export default function NotificationsPage() {
   const [notifications, setNotifications] = useState<NotificationItem[]>(mockNotifications);
   
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
   const markAllAsRead = () => {
-    setNotifications(notifications.map(n => ({ ...n, read: true })));
+    if (unreadCount === 0) return;
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    toast.success("All notifications marked as read");
   };
 
   const clearNotifications = () => {
@@ -64,18 +69,29 @@ export default function NotificationsPage() {
       <div className="flex-1 w-full max-w-[800px] mx-auto px-4 py-12 md:py-20">
         
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-4xl font-extrabold italic text-ink-deep">Notifications</h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-4xl font-extrabold italic text-ink-deep">Notifications</h1>
+            {unreadCount > 0 && (
+              <span className="inline-flex items-center justify-center px-2.5 py-0.5 rounded-full text-sm font-bold bg-[#FDDA23] text-black border-2 border-black">
+                {unreadCount}
+              </span>
+            )}
+          </div>
           {notifications.length > 0 && (
-            <div className="flex gap-4">
+            <div className="flex gap-4 items-center">
               <button 
+                type="button"
                 onClick={markAllAsRead}
-                className="text-sm font-semibold text-ink-deep hover:underline"
+                disabled={unreadCount === 0}
+                aria-label="Mark all notifications as read"
+                className="text-sm font-semibold text-ink-deep hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FDDA23] rounded-md px-1 py-0.5"
               >
                 Mark all as read
               </button>
               <button 
+                type="button"
                 onClick={clearNotifications}
-                className="text-sm font-semibold text-error hover:underline"
+                className="text-sm font-semibold text-error hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FDDA23] rounded-md px-1 py-0.5"
               >
                 Clear all
               </button>

--- a/apps/web/components/events/popular-events-section.tsx
+++ b/apps/web/components/events/popular-events-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { motion, Transition } from "framer-motion";
 import Image from "next/image";
 import { EventCard } from "./event-card";
@@ -75,6 +75,54 @@ export function PopularEventsSection({
     ...DEFAULT_FILTERS,
     categories: category ? [category] : [],
   });
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const mobileSearchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ignore if modifier keys are held
+      if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) {
+        return;
+      }
+
+      // 1. Pressing '/' to focus search input
+      if (e.key === "/" || e.code === "Slash") {
+        const target = e.target as HTMLElement | null;
+        if (
+          target &&
+          (target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable)
+        ) {
+          return;
+        }
+
+        e.preventDefault();
+
+        if (window.innerWidth < 640 && mobileSearchInputRef.current) {
+          mobileSearchInputRef.current.focus();
+        } else if (searchInputRef.current) {
+          searchInputRef.current.focus();
+        }
+      }
+
+      // 2. Pressing 'Escape' to blur and clear search field
+      if (e.key === "Escape") {
+        const isDesktopFocused = document.activeElement === searchInputRef.current;
+        const isMobileFocused = document.activeElement === mobileSearchInputRef.current;
+
+        if (isDesktopFocused || isMobileFocused || isFocused) {
+          searchInputRef.current?.blur();
+          mobileSearchInputRef.current?.blur();
+          setSearch("");
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isFocused]);
 
   useEffect(() => {
     setFilters((currentFilters) => ({
@@ -272,7 +320,8 @@ export function PopularEventsSection({
               />
 
               <motion.input
-                className="pl-13 h-9.75 rounded-4xl bg-black pr-4 py-2 text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
+                ref={searchInputRef}
+                className="pl-13 h-9.75 rounded-4xl bg-black pr-9 py-2 text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
                 type="text"
                 placeholder="Search"
                 aria-label="Search events"
@@ -285,6 +334,14 @@ export function PopularEventsSection({
                 animate={isFocused ? "focused" : "unfocused"}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
               />
+              {!isFocused && !search && (
+                <kbd
+                  aria-hidden="true"
+                  className="absolute right-3.5 top-1/2 -translate-y-1/2 pointer-events-none hidden sm:inline-flex h-5 min-w-5 items-center justify-center rounded border border-white/30 bg-white/10 px-1.5 text-[11px] font-mono text-white/70 shadow-xs select-none"
+                >
+                  /
+                </kbd>
+              )}
             </div>
 
             <div className="flex items-center gap-2">
@@ -351,13 +408,22 @@ export function PopularEventsSection({
                 className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
               />
               <input
-                className="w-full pl-10 h-9.75 rounded-4xl bg-black pr-4 py-2 text-sm text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white/70 focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
+                ref={mobileSearchInputRef}
+                className="w-full pl-10 pr-9 h-9.75 rounded-4xl bg-black py-2 text-sm text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white/70 focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
                 type="text"
                 placeholder="Search events"
                 aria-label="Search events"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
               />
+              {!search && (
+                <kbd
+                  aria-hidden="true"
+                  className="absolute right-3.5 top-1/2 -translate-y-1/2 pointer-events-none inline-flex h-5 min-w-5 items-center justify-center rounded border border-white/30 bg-white/10 px-1.5 text-[11px] font-mono text-white/70 shadow-xs select-none"
+                >
+                  /
+                </kbd>
+              )}
             </div>
 
             <Button


### PR DESCRIPTION
# Pull Request: Mark All Notifications as Read & Discover Search Keyboard Shortcut

Closes #1220
Closes #1223
Closes #1221
Closes #1222

## Summary

This PR implements two frontend UX improvements:
1. Adds a **"Mark all as read"** header action with an unread badge, optimistic state updates, and toast confirmation to the Notifications page ([#1220](https://github.com/Agora-Events/agora/issues/1220)).
2. Adds a global **`/` keyboard shortcut** to jump directly to search on the Discover page with an `Escape` blur/clear handler and subtle UI key hint ([#1223](https://github.com/Agora-Events/agora/issues/1223)).

---

## 🛠️ Changes Made

### 1. Notifications Page — "Mark all as read" (#1220)
- **File:** `apps/web/app/notifications/page.tsx`
- **Features:**
  - Added an unread count badge next to the page title when `unreadCount > 0`.
  - Added a "Mark all as read" header button with accessible name (`aria-label`) and keyboard focus ring styles.
  - Button is disabled and visually muted (`disabled:opacity-50 disabled:cursor-not-allowed`) when there are no unread notifications (`unreadCount === 0`).
  - Implemented optimistic local state updates so all items lose unread styling instantly.
  - Triggers a `toast.success("All notifications marked as read")` on action confirmation.

### 2. Discover Page — `/` Search Keyboard Shortcut (#1220, #1223)
- **File:** `apps/web/components/events/popular-events-section.tsx`
- **Features:**
  - Registered a global `keydown` listener for `/` to focus the search field automatically.
  - Safely ignores shortcut when typing inside existing inputs, textareas, `contenteditable` elements, or when modifier keys (`Ctrl`, `Alt`, `Meta`, `Shift`) are held.
  - Calls `preventDefault()` so the `/` character is not inserted into the input.
  - Added `Escape` handler to blur the input and clear the search field.
  - Added a subtle `<kbd>/</kbd>` shortcut hint badge inside the right edge of search inputs.

---

## 📁 Files Modified

| File | Changes |
| --- | --- |
| `apps/web/app/notifications/page.tsx` | Unread badge, mark all read handler, toast notification, accessible button state |
| `apps/web/components/events/popular-events-section.tsx` | Slash & Escape shortcut handlers, search input refs, shortcut key hint badge |

---

## ✅ Acceptance Criteria Checklist

- [x] Clicking "Mark all as read" clears all unread indicators at once.
- [x] "Mark all as read" button is disabled and visually muted when unread count is 0.
- [x] Unread count badge displays next to page title.
- [x] Success toast appears upon marking all as read.
- [x] Pressing `/` anywhere on `/discover` focuses search without inserting a slash.
- [x] Typing `/` while inside an input field behaves normally.
- [x] Pressing `Escape` while search is active blurs and clears the search input.
- [x] Keyboard shortcut hint badge renders inside search input.
