### PR TITLE
feat(mobile): add terms agreement scroll gate

### DIFF
--- a/apps/mobile/components/legal/TermsAgreementModal.styles.ts
+++ b/apps/mobile/components/legal/TermsAgreementModal.styles.ts
@@ -1,0 +1,36 @@
+import { StyleSheet } from 'react-native';
+import Colors from '@/constants/Colors';
+
+export default StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+    backgroundColor: 'rgba(0, 0, 0, 0.75)',
+  },
+  card: {
+    maxHeight: '82%',
+    padding: 22,
+    borderWidth: 1,
+    borderColor: '#2C2C2E',
+    borderRadius: 16,
+    backgroundColor: '#1E1E20',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  title: { color: Colors.primaryText, fontSize: 20, fontWeight: '700' },
+  close: { color: Colors.primaryYellow, fontSize: 14, fontWeight: '600' },
+  scrollView: { maxHeight: 360 },
+  scrollContent: { paddingRight: 8, paddingBottom: 4 },
+  terms: { color: Colors.primaryText, fontSize: 14, lineHeight: 22 },
+  hint: {
+    marginVertical: 14,
+    color: Colors.secondaryText,
+    fontSize: 12,
+    textAlign: 'center',
+  },
+});

--- a/apps/mobile/components/legal/TermsAgreementModal.tsx
+++ b/apps/mobile/components/legal/TermsAgreementModal.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  LayoutChangeEvent,
+  Modal,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import Button from '@/components/ui/Button';
+import styles from './TermsAgreementModal.styles';
+
+const END_TOLERANCE = 1;
+
+interface TermsAgreementModalProps {
+  visible: boolean;
+  termsText: string;
+  onAgree: () => void;
+  onRequestClose: () => void;
+}
+
+export default function TermsAgreementModal({
+  visible,
+  termsText,
+  onAgree,
+  onRequestClose,
+}: TermsAgreementModalProps) {
+  const [hasReachedEnd, setHasReachedEnd] = useState(false);
+  const scrollOffset = useRef(0);
+  const viewportHeight = useRef(0);
+  const contentHeight = useRef(0);
+
+  const updateEndState = useCallback(() => {
+    if (
+      viewportHeight.current > 0 &&
+      contentHeight.current > 0 &&
+      scrollOffset.current + viewportHeight.current >= contentHeight.current - END_TOLERANCE
+    ) {
+      setHasReachedEnd(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      setHasReachedEnd(false);
+      scrollOffset.current = 0;
+      viewportHeight.current = 0;
+      contentHeight.current = 0;
+    }
+  }, [visible]);
+
+  const handleScroll = ({ nativeEvent }: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffset.current = nativeEvent.contentOffset.y;
+    viewportHeight.current = nativeEvent.layoutMeasurement.height;
+    contentHeight.current = nativeEvent.contentSize.height;
+    updateEndState();
+  };
+
+  const handleLayout = ({ nativeEvent }: LayoutChangeEvent) => {
+    viewportHeight.current = nativeEvent.layout.height;
+    updateEndState();
+  };
+
+  const handleContentSizeChange = (_width: number, height: number) => {
+    contentHeight.current = height;
+    updateEndState();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+      onRequestClose={onRequestClose}
+    >
+      <View style={styles.overlay} accessibilityViewIsModal>
+        <View style={styles.card}>
+          <View style={styles.header}>
+            <Text style={styles.title}>Terms of Service</Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Close terms of service"
+              hitSlop={12}
+              onPress={onRequestClose}
+            >
+              <Text style={styles.close}>Close</Text>
+            </Pressable>
+          </View>
+
+          <ScrollView
+            testID="terms-agreement-scroll"
+            style={styles.scrollView}
+            contentContainerStyle={styles.scrollContent}
+            onScroll={handleScroll}
+            onLayout={handleLayout}
+            onContentSizeChange={handleContentSizeChange}
+            scrollEventThrottle={16}
+          >
+            <Text style={styles.terms}>{termsText}</Text>
+          </ScrollView>
+
+          <Text style={styles.hint}>
+            {hasReachedEnd
+              ? 'You have reached the end of the terms.'
+              : 'Scroll to the bottom to continue.'}
+          </Text>
+          <Button
+            testID="terms-agreement-confirm"
+            title="Agree and Proceed"
+            onPress={onAgree}
+            disabled={!hasReachedEnd}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/components/legal/__tests__/TermsAgreementModal.test.tsx
+++ b/apps/mobile/components/legal/__tests__/TermsAgreementModal.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import TermsAgreementModal from '../TermsAgreementModal';
+
+const termsText = 'These terms explain how Agora services may be used.'.repeat(20);
+
+function renderModal(overrides = {}) {
+  const props = {
+    visible: true,
+    termsText,
+    onAgree: jest.fn(),
+    onRequestClose: jest.fn(),
+    ...overrides,
+  };
+
+  return { ...render(<TermsAgreementModal {...props} />), props };
+}
+
+describe('TermsAgreementModal', () => {
+  it('renders the terms and keeps the agreement action disabled initially', () => {
+    const { getByText, getByTestId, props } = renderModal();
+
+    expect(getByText(termsText)).toBeTruthy();
+    expect(getByTestId('terms-agreement-confirm')).toBeDisabled();
+
+    fireEvent.press(getByTestId('terms-agreement-confirm'));
+    expect(props.onAgree).not.toHaveBeenCalled();
+  });
+
+  it('enables the agreement action only after the user reaches the bottom', () => {
+    const { getByTestId, props } = renderModal();
+    const scrollView = getByTestId('terms-agreement-scroll');
+    const confirmButton = getByTestId('terms-agreement-confirm');
+
+    fireEvent.scroll(scrollView, {
+      nativeEvent: {
+        contentOffset: { y: 150 },
+        layoutMeasurement: { height: 300 },
+        contentSize: { height: 600 },
+      },
+    });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.scroll(scrollView, {
+      nativeEvent: {
+        contentOffset: { y: 300 },
+        layoutMeasurement: { height: 300 },
+        contentSize: { height: 600 },
+      },
+    });
+    expect(confirmButton).toBeEnabled();
+
+    fireEvent.press(confirmButton);
+    expect(props.onAgree).toHaveBeenCalledTimes(1);
+  });
+
+  it('recalculates the end position when the viewport is resized', () => {
+    const { getByTestId } = renderModal();
+    const scrollView = getByTestId('terms-agreement-scroll');
+    const confirmButton = getByTestId('terms-agreement-confirm');
+
+    fireEvent.scroll(scrollView, {
+      nativeEvent: {
+        contentOffset: { y: 100 },
+        layoutMeasurement: { height: 200 },
+        contentSize: { height: 500 },
+      },
+    });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent(scrollView, 'layout', { nativeEvent: { layout: { height: 400 } } });
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('enables the action when all terms already fit inside the viewport', () => {
+    const { getByTestId } = renderModal();
+    const scrollView = getByTestId('terms-agreement-scroll');
+
+    fireEvent(scrollView, 'layout', { nativeEvent: { layout: { height: 400 } } });
+    fireEvent(scrollView, 'contentSizeChange', 300, 250);
+
+    expect(getByTestId('terms-agreement-confirm')).toBeEnabled();
+  });
+
+  it('resets the agreement state when the modal is reopened', () => {
+    const props = {
+      visible: true,
+      termsText,
+      onAgree: jest.fn(),
+      onRequestClose: jest.fn(),
+    };
+    const { getByTestId, rerender } = render(<TermsAgreementModal {...props} />);
+
+    fireEvent.scroll(getByTestId('terms-agreement-scroll'), {
+      nativeEvent: {
+        contentOffset: { y: 300 },
+        layoutMeasurement: { height: 300 },
+        contentSize: { height: 600 },
+      },
+    });
+    expect(getByTestId('terms-agreement-confirm')).toBeEnabled();
+
+    rerender(<TermsAgreementModal {...props} visible={false} />);
+    rerender(<TermsAgreementModal {...props} visible />);
+
+    expect(getByTestId('terms-agreement-confirm')).toBeDisabled();
+  });
+
+  it('allows the user to dismiss the modal without accepting the terms', () => {
+    const { getByLabelText, props } = renderModal();
+
+    fireEvent.press(getByLabelText('Close terms of service'));
+    expect(props.onRequestClose).toHaveBeenCalledTimes(1);
+    expect(props.onAgree).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a reusable mobile `TermsAgreementModal` that accepts the official terms copy from its caller
- keep "Agree and Proceed" disabled until the visible content reaches its scroll boundary
- recalculate the boundary when the viewport or content size changes, preserve agreement after reaching the end, and reset it when the modal is reopened
- include a dismiss action, existing Agora mobile styling, and focused component coverage

## Verification

- [x] `pnpm --filter mobile exec jest --runInBand components/legal/__tests__/TermsAgreementModal.test.tsx` — 6/6 passed
- [x] targeted ESLint for the component, styles, and tests
- [x] Prettier check and `git diff --check`
- [x] isolated React Native Web visual QA: disabled before the end, enabled at the end, and agreement callback verified
- [ ] full mobile Jest suite — 378/380 existing tests pass; unrelated baseline failures remain in `lib/crdt/__tests__/crdt.test.ts` and `lib/zkp/__tests__/ristretto255.test.ts`
- [ ] full mobile typecheck/lint — blocked by existing errors in organizer/CRDT/location code and undeclared mobile dependencies; none are in the files changed here

## Risks / Notes

- The repository currently has no registration flow or approved Terms of Service copy, so this PR keeps the component reusable instead of inventing legal text or attaching it to the login screen.
- No new runtime dependencies are introduced.
- The component is 120 lines, below the repository's 150-line component limit.

Closes #1022
