### PR TITLE
feat(mobile): add photo library picker for user avatars.

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -11,6 +11,7 @@ import * as Clipboard from 'expo-clipboard';
 import Colors from '@/constants/Colors';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
+import AvatarEdit from '@/components/AvatarEdit';
 import { useAuth } from '@/hooks/useAuth';
 import { StellarWalletManager, StellarBalances } from '@/services/stellar';
 
@@ -127,11 +128,10 @@ export default function ProfileScreen() {
     <SafeAreaView style={styles.container}>
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.profileHeader}>
-          <View style={styles.avatarPlaceholder}>
-            <Text style={styles.avatarText}>
-              {user?.name ? user.name.charAt(0).toUpperCase() : 'A'}
-            </Text>
-          </View>
+          <AvatarEdit 
+            onImageSelected={(uri) => console.log('New Avatar:', uri)} 
+            userName={user?.name ?? undefined}
+          />
           <Text style={styles.nameText}>{user?.name || 'Agora User'}</Text>
           <Text style={styles.emailText}>{user?.email || 'user@agora.events'}</Text>
         </View>
@@ -217,20 +217,6 @@ const styles = StyleSheet.create({
   profileHeader: {
     alignItems: 'center',
     marginTop: 20,
-  },
-  avatarPlaceholder: {
-    width: 90,
-    height: 90,
-    borderRadius: 45,
-    backgroundColor: Colors.primaryYellow,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  avatarText: {
-    fontSize: 32,
-    fontWeight: 'bold',
-    color: Colors.darkBackground,
   },
   nameText: {
     fontSize: 22,

--- a/apps/mobile/components/AvatarEdit.tsx
+++ b/apps/mobile/components/AvatarEdit.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  Text,
+} from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import Colors from '@/constants/Colors';
+
+interface AvatarEditProps {
+  initialImage?: string | null;
+  onImageSelected: (uri: string) => void;
+  userName?: string;
+}
+
+export const AvatarEdit: React.FC<AvatarEditProps> = ({
+  initialImage,
+  onImageSelected,
+  userName,
+}) => {
+  const [image, setImage] = useState<string | null | undefined>(initialImage);
+
+  const pickImage = async () => {
+    // Request permission
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    
+    if (status !== 'granted') {
+      Alert.alert(
+        'Permission Denied',
+        'Sorry, we need camera roll permissions to make this work!',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'OK' }
+        ]
+      );
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 1,
+    });
+
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      setImage(uri);
+      onImageSelected(uri);
+    }
+  };
+
+  return (
+    <TouchableOpacity style={styles.container} onPress={pickImage} testID="avatar-edit-button">
+      {image ? (
+        <Image source={{ uri: image }} style={styles.avatar} />
+      ) : (
+        <View style={styles.avatarPlaceholder}>
+          <Text style={styles.avatarText}>
+            {userName ? userName.charAt(0).toUpperCase() : 'A'}
+          </Text>
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  avatar: {
+    width: 90,
+    height: 90,
+    borderRadius: 45,
+  },
+  avatarPlaceholder: {
+    width: 90,
+    height: 90,
+    borderRadius: 45,
+    backgroundColor: Colors.primaryYellow,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  avatarText: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: Colors.darkBackground,
+  },
+});
+
+export default AvatarEdit;

--- a/apps/mobile/components/__tests__/AvatarEdit.test.tsx
+++ b/apps/mobile/components/__tests__/AvatarEdit.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import * as ImagePicker from 'expo-image-picker';
+import AvatarEdit from '../AvatarEdit';
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+  MediaTypeOptions: { Images: 'Images' },
+}));
+
+describe('AvatarEdit', () => {
+  it('renders the placeholder correctly', () => {
+    const { getByText } = render(<AvatarEdit onImageSelected={jest.fn()} userName="John" />);
+    expect(getByText('J')).toBeTruthy();
+  });
+
+  it('calls ImagePicker.requestMediaLibraryPermissionsAsync when pressed', async () => {
+    const mockRequest = ImagePicker.requestMediaLibraryPermissionsAsync as jest.Mock;
+    mockRequest.mockResolvedValue({ status: 'granted' });
+
+    const mockLaunch = ImagePicker.launchImageLibraryAsync as jest.Mock;
+    mockLaunch.mockResolvedValue({ canceled: true });
+
+    const { getByTestId } = render(<AvatarEdit onImageSelected={jest.fn()} />);
+
+    fireEvent.press(getByTestId('avatar-edit-button'));
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalled();
+    });
+  });
+
+  it('calls onImageSelected when an image is picked', async () => {
+    const mockRequest = ImagePicker.requestMediaLibraryPermissionsAsync as jest.Mock;
+    mockRequest.mockResolvedValue({ status: 'granted' });
+
+    const mockLaunch = ImagePicker.launchImageLibraryAsync as jest.Mock;
+    mockLaunch.mockResolvedValue({ 
+      canceled: false, 
+      assets: [{ uri: 'file://test.jpg' }] 
+    });
+
+    const onImageSelected = jest.fn();
+    const { getByTestId } = render(<AvatarEdit onImageSelected={onImageSelected} />);
+
+    fireEvent.press(getByTestId('avatar-edit-button'));
+
+    await waitFor(() => {
+      expect(onImageSelected).toHaveBeenCalledWith('file://test.jpg');
+    });
+  });
+});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -35,6 +35,7 @@
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",
     "expo-haptics": "~13.0.1",
+    "expo-image-picker": "~15.0.0",
     "expo-linking": "~6.3.1",
     "expo-local-authentication": "~14.0.1",
     "expo-notifications": "~0.28.19",


### PR DESCRIPTION
The implementation of the photo library picker for user avatars in apps/mobile is complete.

  Summary of Changes:
   1. Dependencies: Added expo-image-picker (~15.0.0) to apps/mobile/package.json.
   2. Component: Created apps/mobile/components/AvatarEdit.tsx. This component handles:
       * Requesting media library permissions with appropriate alert guidance.
       * Launching the image picker.
       * Displaying the selected image within a circular avatar wrapper without distortion.
   3. Integration: Updated apps/mobile/app/(tabs)/profile.tsx to replace the existing avatar placeholder with the new AvatarEdit component.
   4. Testing: Created apps/mobile/components/__tests__/AvatarEdit.test.tsx with unit tests for rendering and component interactions.

closes #1026 