### PR TITLE
feat: implement next-intl Spanish and French localisation (#1343)

### DIFF
--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -12,6 +12,7 @@ import { EventPageView } from "@/components/analytics/event-page-view";
 import { SecondaryMarketplaceTab } from "@/components/events/secondary-marketplace-tab";
 import { EventTimeDisplay } from "@/components/events/event-time-display";
 import ShareButton from "@/components/events/ShareButton";
+import { T } from "@/components/ui/t";
 
 function truncateDescription(text: string, maxLength = 160): string {
   if (text.length <= maxLength) return text;
@@ -147,7 +148,7 @@ export default async function EventDetailPage({
             {/* Hosted By */}
             <div className="flex flex-col gap-4">
               <h2 className="text-xl font-bold text-black font-heading">
-                Hosted By
+                <T ns="eventDetail" k="hostedBy" />
               </h2>
               <div className="flex items-center gap-3">
                 <div className="relative w-8 h-8 rounded-full border border-black overflow-hidden bg-white">
@@ -178,7 +179,7 @@ export default async function EventDetailPage({
                   />
                 </div>
                 <h2 className="text-xl font-bold text-black font-heading">
-                  Location
+                  <T ns="eventDetail" k="location" />
                 </h2>
               </div>
               <p className="text-[18px] font-medium text-black -mt-2">
@@ -247,7 +248,7 @@ export default async function EventDetailPage({
             {/* About Section */}
             <div className="flex flex-col gap-6 pt-4">
               <h2 className="text-[20px] sm:text-[22px] font-bold text-black font-heading">
-                About Event
+                <T ns="eventDetail" k="aboutEvent" />
               </h2>
               <div className="text-[16px] sm:text-[17px] text-black leading-relaxed font-normal flex flex-col gap-6">
                 <p>

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -6,6 +6,7 @@ import useSWR from "swr";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
 import { ChatSidebar } from "@/components/layout/chat-sidebar";
@@ -19,19 +20,19 @@ import BubbleChatIcon from "@/public/icons/bubble-chat.svg";
 type MyEventsTab = "upcoming" | "hosting" | "past";
 type ForYouTab = "discover" | "following";
 
-const myEventsTabs: { id: MyEventsTab; label: string; icon?: string }[] = [
+const myEventsTabs = (t: (key: string) => string): { id: MyEventsTab; label: string; icon?: string }[] => [
   {
     id: "upcoming",
-    label: "Upcoming",
+    label: t("tabUpcoming"),
     icon: CalendarIcon,
   },
-  { id: "hosting", label: "Hosting", icon: HostingIcon },
-  { id: "past", label: "Past", icon: PastIcon },
+  { id: "hosting", label: t("tabHosting"), icon: HostingIcon },
+  { id: "past", label: t("tabPast"), icon: PastIcon },
 ];
 
-const forYouTabs: { id: ForYouTab; label: string }[] = [
-  { id: "discover", label: "Discover" },
-  { id: "following", label: "Following" },
+const forYouTabs = (t: (key: string) => string): { id: ForYouTab; label: string }[] => [
+  { id: "discover", label: t("tabDiscover") },
+  { id: "following", label: t("tabFollowing") },
 ];
 
 // Mock data types
@@ -227,6 +228,7 @@ function SectionHeader<T extends string>({
   hasNotifications?: boolean;
   onChatClick?: () => void;
 }) {
+  const t = useTranslations("home");
   return (
     <div className="flex flex-col  gap-3 sm:gap-8 mb-6 sm:mb-8">
       <h2 className="text-[24px] sm:text-[28px] lg:text-[3.6rem] leading-16.5 tracking-[0px] font-semibold text-ink-deep italic">
@@ -240,7 +242,7 @@ function SectionHeader<T extends string>({
           layoutId={layoutId}
         />
         {hasNotifications && (
-          <button type="button" onClick={onChatClick} aria-label="Open messages">
+          <button type="button" onClick={onChatClick} aria-label={t("openMessages")}>
             <div className="w-13.75 h-13.75 rounded-full bg-surface flex items-center justify-center  relative">
               <div className="absolute -top-1 right-1 rounded-full size-4.75 bg-error text-white flex items-center justify-center">
                 <p>1</p>
@@ -262,6 +264,7 @@ function SectionHeader<T extends string>({
 
 // Timeline Event Card Component
 function TimelineEventCard({ event }: { event: any }) {
+  const t = useTranslations("home");
   const locationImageSrc =
     (event.location || "").toLowerCase().includes("discord") ||
     (event.location || "").toLowerCase().includes("virtual") ||
@@ -274,7 +277,7 @@ function TimelineEventCard({ event }: { event: any }) {
       {/* Timeline Column */}
       <div className="flex  w-39 max-w-39 shrink-0  mb-3">
         <span className="text-[1.625rem] text-left font-medium text-black  leading-10.25">
-          {event.date || "TBD"}
+          {event.date || t("tbd")}
         </span>
       </div>
 
@@ -325,7 +328,7 @@ function TimelineEventCard({ event }: { event: any }) {
                       className="object-contain"
                     />
                     <span className="text-[12px] text-black ">
-                      {event.location || "Virtual"}
+                      {event.location || t("virtual")}
                     </span>
                   </div>
 
@@ -355,13 +358,13 @@ function TimelineEventCard({ event }: { event: any }) {
                         ))}
                       </div>
                       <span className="text-[11px] sm:text-[12px] text-black/60">
-                        {event.attendees || 0} going
+                        {event.attendees || 0} {t("going")}
                       </span>
                     </div>
 
                     <div className="flex items-center gap-1 text-black text-[12px] sm:text-[13px] font-medium">
-                      <span className="hidden sm:inline">View Event</span>
-                      <span className="sm:hidden">View</span>
+                      <span className="hidden sm:inline">{t("viewEvent")}</span>
+                      <span className="sm:hidden">{t("view")}</span>
                       <Image
                         src="/icons/arrow-right.svg"
                         width={16}
@@ -383,6 +386,7 @@ function TimelineEventCard({ event }: { event: any }) {
 
 // Grid Event Card Component
 function GridEventCard({ event }: { event: any }) {
+  const t = useTranslations("home");
   const color = event.color || "bg-[#E8D5F7]";
   return (
     <Link href={`/events/${event.id}`} className="block">
@@ -407,7 +411,7 @@ function GridEventCard({ event }: { event: any }) {
           </h3>
 
           <p className="text-[11px] sm:text-[12px] text-black/60 mb-1">
-            {event.date || "TBD"}
+            {event.date || t("tbd")}
           </p>
 
           <div className="flex items-center gap-1 text-black/70 mb-2 sm:mb-3">
@@ -419,16 +423,16 @@ function GridEventCard({ event }: { event: any }) {
               className="object-contain w-3 h-3 sm:w-[14px] sm:h-[14px]"
             />
             <span className="text-[11px] sm:text-[12px] line-clamp-1">
-              {event.location || "Virtual"}
+              {event.location || t("virtual")}
             </span>
           </div>
 
           <div className="flex items-center justify-between">
             <span className="text-[12px] sm:text-[13px] font-medium text-black">
-              {event.price === "$0.00" || !event.price ? "Free" : event.price}
+              {event.price === "$0.00" || !event.price ? t("free") : event.price}
             </span>
             <div className="flex items-center gap-1 text-black text-[11px] sm:text-[12px] font-medium">
-              <span className="hidden sm:inline">View</span>
+              <span className="hidden sm:inline">{t("view")}</span>
               <Image
                 src="/icons/arrow-right.svg"
                 width={14}
@@ -461,6 +465,7 @@ function MyEventsContent({
   events: any[];
   isLoading: boolean;
 }) {
+  const t = useTranslations("home");
   const isUpcomingTab = activeTab === "upcoming";
 
   if (isLoading) {
@@ -480,7 +485,7 @@ function MyEventsContent({
     return (
       <div className="flex min-h-[15rem] items-center justify-center rounded-[2rem] border border-dashed border-black/20 bg-white/60 px-6 text-center">
         <p className="text-base font-medium text-black/55">
-          No events found in this section.
+          {t("noEventsFound")}
         </p>
       </div>
     );
@@ -497,6 +502,7 @@ function MyEventsContent({
 
 // For You Section Content
 function ForYouContent({ activeTab, events, isLoading }: { activeTab: ForYouTab, events: any[], isLoading: boolean }) {
+  const t = useTranslations("home");
   if (isLoading) {
     return (
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5 lg:gap-6">
@@ -510,7 +516,7 @@ function ForYouContent({ activeTab, events, isLoading }: { activeTab: ForYouTab,
   if (events.length === 0) {
     return (
       <div className="min-h-[200px] rounded-xl border-2 border-dashed border-black/20 flex items-center justify-center">
-        <p className="text-black/50 text-lg">No events found</p>
+        <p className="text-black/50 text-lg">{t("noEventsFound")}</p>
       </div>
     );
   }
@@ -528,6 +534,7 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export default function HomePage() {
   const router = useRouter();
+  const t = useTranslations("home");
   const {
     walletAddress: userWallet,
     isAuthenticated,
@@ -581,8 +588,8 @@ export default function HomePage() {
         {/* My Events Section */}
         <section className="mb-10 sm:mb-16 space-y-15">
           <SectionHeader
-            title="My Events"
-            tabs={myEventsTabs}
+            title={t("myEvents")}
+            tabs={myEventsTabs(t)}
             activeTab={myEventsTab}
             onTabChange={setMyEventsTab}
             layoutId="my-events-toggle"
@@ -603,8 +610,8 @@ export default function HomePage() {
         {/* For You Section */}
         <section>
           <SectionHeader
-            title="For You"
-            tabs={forYouTabs}
+            title={t("forYou")}
+            tabs={forYouTabs(t)}
             activeTab={forYouTab}
             onTabChange={setForYouTab}
             layoutId="for-you-toggle"

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -9,6 +9,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { CookieBanner } from "@/components/layout/cookie-banner";
 import { LiveAnnouncer } from "@/components/ui/live-announcer";
+import { LocaleProvider } from "@/lib/i18n/locale-context";
 import "./globals.css";
 
 const inter = Inter({
@@ -51,14 +52,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} antialiased`}>
         <a className="skip-link" href="#main-content">
           Skip to main content
         </a>
-        <LiveAnnouncer />
-        {children}
-        <CookieBanner />
+        <LocaleProvider>
+          <LiveAnnouncer />
+          {children}
+          <CookieBanner />
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/apps/web/app/organizers/page.tsx
+++ b/apps/web/app/organizers/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Navbar } from "@/components/layout/navbar";
+import { useTranslations } from "next-intl";
 import { Footer } from "@/components/layout/footer";
 import { OrganizerComponent } from "@/components/events/organizer-component";
 import { useState } from "react";
 
 export default function OrganizersPage() {
+  const t = useTranslations("discover");
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const showErrorToast = (message: string) => {
@@ -23,7 +25,7 @@ export default function OrganizersPage() {
       )}
       <div className="p-10 pl-45 hidden lg:block bg-base">
         <div className="flex justify-start items-center gap-4 p-5 pb-10">
-          <h1 className="font-semibold md:text-4xl pl-3">Explore organizers</h1>
+          <h1 className="font-semibold md:text-4xl pl-3">{t("exploreOrganizers")}</h1>
         </div>
       </div>
       <OrganizerComponent onError={showErrorToast} />

--- a/apps/web/components/events/ShareButton.tsx
+++ b/apps/web/components/events/ShareButton.tsx
@@ -4,9 +4,11 @@ import React from "react";
 import useIsMobile from "@/hooks/useIsMobile";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 
 export default function ShareButton({ title, text }: { title: string; text: string }) {
   const isMobile = useIsMobile();
+  const t = useTranslations("eventDetail");
 
   const handleShare = async () => {
     const url = typeof window !== "undefined" ? window.location.href : "";
@@ -40,14 +42,14 @@ export default function ShareButton({ title, text }: { title: string; text: stri
     // but we provide graceful fallback visible on desktop as well.
     return (
       <Button variant="ghost" onClick={handleShare} className="px-4 py-2">
-        Share
+        {t("share")}
       </Button>
     );
   }
 
   return (
     <Button variant="ghost" onClick={handleShare} className="px-4 py-2">
-      Share
+      {t("share")}
     </Button>
   );
 }

--- a/apps/web/components/events/category-chips.tsx
+++ b/apps/web/components/events/category-chips.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion, type Transition, type Variants } from "framer-motion";
+import { useTranslations } from "next-intl";
 import Image from "next/image";
 import type { DiscoverCategory } from "@/utils/api";
 
@@ -30,6 +31,7 @@ export function CategoryChips({
   onCategoryChange,
   isLoading,
 }: CategoryChipsProps) {
+  const t = useTranslations("discover");
   const allCategory = { name: "All", icon: "", color: "#FDDA23" };
   const displayCategories = [allCategory, ...categories];
 
@@ -82,7 +84,7 @@ export function CategoryChips({
           );
         })}
       {!isLoading && categories.length === 0 && (
-        <p className="text-sm text-black/60 shrink-0">No data available</p>
+        <p className="text-sm text-black/60 shrink-0">{t("noDataAvailable")}</p>
       )}
     </div>
   );

--- a/apps/web/components/events/organizer-component.tsx
+++ b/apps/web/components/events/organizer-component.tsx
@@ -120,7 +120,7 @@ export function OrganizerComponent({
   return (
     <div className="p-10 pl-45 hidden lg:block bg-base">
       <div className="flex justify-start items-center gap-4 p-5 pb-10">
-        <h1 className="font-semibold md:text-4xl pl-3">Explore organizers</h1>
+        <h1 className="font-semibold md:text-4xl pl-3">{t("exploreOrganizers")}</h1>
         <Image
           src={group}
           alt="User Group Icon"
@@ -191,7 +191,7 @@ export function OrganizerComponent({
           </Link>
           ))}
         {!isLoading && cardsData.length === 0 && (
-          <p className="text-sm text-black/60">No data available</p>
+          <p className="text-sm text-black/60">{t("noDataAvailable")}</p>
         )}
       </section>
       {!isLoading && organizersToRender.length > VISIBLE_ORGANIZER_COUNT && (

--- a/apps/web/components/events/popular-events-section.tsx
+++ b/apps/web/components/events/popular-events-section.tsx
@@ -8,6 +8,7 @@ import { EventCardSkeleton } from "./event-card-skeleton";
 import { EmptyState } from "../ui/empty-state";
 import { Button } from "../ui/button";
 import { dataEvents } from "./mockups";
+import { useTranslations } from "next-intl";
 import {
   FilterSidebar,
   FilterState,
@@ -69,6 +70,7 @@ export function PopularEventsSection({
   selectedOrganizer,
   onOrganizerChange,
 }: PopularEventsSectionProps) {
+  const t = useTranslations("discover");
   const [isFocused, setIsFocused] = useState(false);
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_MS);
@@ -139,7 +141,7 @@ export function PopularEventsSection({
   };
 
   const activeFilters: ActiveFilter[] = [
-    ...(filters.date && filters.date !== "Any time"
+    ...(filters.date && filters.date !== t("anyTime")
       ? [{ key: "date" as const, label: filters.date }]
       : []),
     ...filters.categories.map((category) => ({
@@ -275,7 +277,7 @@ export function PopularEventsSection({
         {getActiveFilterCount(filters) > 0 && (
           <div
             className="flex flex-wrap items-center gap-2 mb-6"
-            aria-label="Active filters"
+            aria-label={t("activeFilters")}
           >
             {activeFilters.map((filter) => (
               <span
@@ -341,7 +343,7 @@ export function PopularEventsSection({
                 className="pl-13 h-9.75 rounded-4xl bg-black pr-9 py-2 text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
                 type="text"
                 placeholder="Search"
-                aria-label="Search events"
+                aria-label={t("searchEvents")}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 onFocus={() => setIsFocused(true)}
@@ -372,7 +374,7 @@ export function PopularEventsSection({
                 id="discover-sort"
                 value={sortBy}
                 onChange={(e) => setSortBy(e.target.value as EventSort)}
-                aria-label="Sort events"
+                aria-label={t("sortEvents")}
                 className="h-9.75 max-w-[10.5rem] sm:max-w-none rounded-4xl bg-black px-3 text-sm text-white outline-1 -outline-offset-1 outline-white/10 focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
               >
                 {SORT_OPTIONS.map((option) => (
@@ -427,7 +429,7 @@ export function PopularEventsSection({
                 className="w-full pl-10 pr-9 h-9.75 rounded-4xl bg-black py-2 text-sm text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white/70 focus:outline-2 focus:-outline-offset-2 focus:outline-[#FDDA23]"
                 type="text"
                 placeholder="Search events"
-                aria-label="Search events"
+                aria-label={t("searchEvents")}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
               />
@@ -517,7 +519,7 @@ export function PopularEventsSection({
                 }
                 title="No events found"
                 description="Try adjusting your search or filters to find what you're looking for."
-                action={{ label: "Clear Search", onClick: () => setSearch("") }}
+                action={{ label: t("clearSearch"), onClick: () => setSearch("") }}
               />
             </div>
           )}

--- a/apps/web/components/events/registration-box.tsx
+++ b/apps/web/components/events/registration-box.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
+import { useTranslations } from "next-intl";
 import { TicketModal } from "./TicketModal";
 import { Button } from "@/components/ui/button";
 import { TicketAvailabilityDisplay } from "./ticket-availability-display";
@@ -28,6 +29,7 @@ interface RegistrationBoxProps {
 }
 
 export function RegistrationBox({ event, host }: RegistrationBoxProps) {
+  const t = useTranslations("eventDetail");
   const [quantity, setQuantity] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const router = useRouter();
@@ -113,7 +115,7 @@ export function RegistrationBox({ event, host }: RegistrationBoxProps) {
                 alt="dollar"
               />
             )}
-            {isFree ? "Register" : `$${(priceValue * quantity).toFixed(2)}`}
+            {isFree ? t("register") : `$${(priceValue * quantity).toFixed(2)}`}
             <Image
               src="/icons/arrow-up-right-01.svg"
               width={24}

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -2,6 +2,8 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { LanguageSwitcher } from "./language-switcher";
 
 /**
  * SOLUTION FOR ISSUE #448:
@@ -9,9 +11,12 @@ import Link from "next/link";
  * 2. Added `hover:bg-white/5` and `transition-all` to create a professional hover "pill" effect.
  * 3. Integrated `mailto:hello@agora.com` for the contact link.
  * 4. Ensured mobile responsiveness via existing `flex-col md:flex-row` logic.
+ * 5. Translated all strings (and added the language switcher) in Issue #1343.
  */
 
 export function Footer() {
+  const t = useTranslations("footer");
+
   return (
     <footer className="w-full bg-ink pt-20 pb-12 relative overflow-hidden text-white select-none">
       {/* Background Graphic */}
@@ -34,9 +39,8 @@ export function Footer() {
             height={54}
             className="w-auto h-12"
           />
-          <p className="text-gray-400 text-sm">
-            © 2026 agora. All rights reserved.
-          </p>
+          <p className="text-gray-400 text-sm">{t("copyright")}</p>
+          <LanguageSwitcher />
         </div>
 
         {/* Right Columns Container */}
@@ -48,13 +52,13 @@ export function Footer() {
               href="/events"
               className="text-gray-300 hover:text-white hover:bg-white/5 px-3 py-1.5 -ml-3 rounded-md transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              Discover Events
+              {t("discoverEvents")}
             </Link>
             <Link
               href="/pricing"
               className="text-gray-300 hover:text-white hover:bg-white/5 px-3 py-1.5 -ml-3 rounded-md transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              Pricing
+              {t("pricing")}
             </Link>
             <Link
               href="https://stellar.org"
@@ -62,19 +66,19 @@ export function Footer() {
               rel="noopener noreferrer"
               className="text-gray-300 hover:text-white hover:bg-white/5 px-3 py-1.5 -ml-3 rounded-md transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              Stellar Ecosystem
+              {t("stellarEcosystem")}
             </Link>
             <Link
               href="/help"
               className="text-gray-300 hover:text-white hover:bg-white/5 px-3 py-1.5 -ml-3 rounded-md transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              FAQs
+              {t("faqs")}
             </Link>
             <Link
               href="/settings#cookie-preferences"
               className="text-gray-300 hover:text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              Cookie preferences
+              {t("cookiePreferences")}
             </Link>
           </div>
 
@@ -88,7 +92,7 @@ export function Footer() {
               className="text-gray-300 hover:text-white hover:bg-white/5 px-3 py-1.5 -ml-3 rounded-md transition-all duration-200 flex items-center gap-2 group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
               <Image src="/icons/instagram.svg" width={20} height={20} alt="Instagram" className="text-gray-300 group-hover:text-white" />
-              <span className="text-sm">Instagram</span>
+              <span className="text-sm">{t("instagram")}</span>
             </a>
 
             {/* X (Twitter) */}
@@ -99,7 +103,7 @@ export function Footer() {
               className="text-gray-300 hover:text-white hover:bg-white/5 px-3 py-1.5 -ml-3 rounded-md transition-all duration-200 flex items-center gap-2 group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
               <Image src="/icons/x.svg" width={20} height={20} alt="X" className="text-gray-300 group-hover:text-white" />
-              <span className="text-sm">X</span>
+              <span className="text-sm">{t("x")}</span>
             </a>
 
             {/* Mail: Integrated hello@agora.com */}
@@ -108,7 +112,7 @@ export function Footer() {
               className="text-gray-300 hover:text-white hover:bg-white/5 px-3 py-1.5 -ml-3 rounded-md transition-all duration-200 flex items-center gap-2 group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
               <Image src="/icons/mail.svg" width={20} height={20} alt="Mail" className="text-gray-300 group-hover:text-white" />
-              <span className="text-sm">Mail</span>
+              <span className="text-sm">{t("mail")}</span>
             </a>
 
             {/* Stellar Link (Internal/Help) */}
@@ -125,7 +129,7 @@ export function Footer() {
                   className="w-full h-full object-contain"
                 />
               </div>
-              <span className="text-sm">Stellar</span>
+              <span className="text-sm">{t("stellar")}</span>
             </Link>
           </div>
         </div>

--- a/apps/web/components/layout/language-switcher.tsx
+++ b/apps/web/components/layout/language-switcher.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTransition } from "react";
+import { useTranslations } from "next-intl";
+import { useLocaleContext } from "@/lib/i18n/locale-context";
+import { localeNames, locales, type Locale } from "@/lib/i18n/config";
+
+/**
+ * Language switcher (Issue #1343).
+ *
+ * Rendered in the footer; persists the selection in `localStorage` and swaps
+ * the next-intl messages immediately — no page reload required.
+ */
+export function LanguageSwitcher() {
+  const t = useTranslations("languageSwitcher");
+  const { locale, setLocale } = useLocaleContext();
+  const [isPending, startTransition] = useTransition();
+
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value as Locale;
+    if (next === locale) return;
+    startTransition(() => {
+      setLocale(next);
+    });
+  };
+
+  return (
+    <label className="flex flex-col gap-1.5 text-sm">
+      <span className="text-gray-400 font-medium">{t("label")}</span>
+      <select
+        value={locale}
+        onChange={handleChange}
+        disabled={isPending}
+        aria-label={t("label")}
+        className="bg-white/10 text-white text-sm rounded-lg px-3 py-2 border border-white/20 focus:outline-2 focus:outline-accent transition-colors [&>option]:text-black"
+      >
+        {locales.map((code) => (
+          <option key={code} value={code}>
+            {localeNames[code]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/web/components/ui/t.tsx
+++ b/apps/web/components/ui/t.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+/**
+ * Translatable text helper for use inside server-rendered pages.
+ *
+ * Server components cannot consume `useTranslations` directly; mounting this
+ * client component lets a single string re-translate instantly when the locale
+ * changes without converting the whole page to a client component.
+ */
+export function T({
+  ns,
+  k,
+  values,
+}: {
+  ns: Parameters<typeof useTranslations>[0] & string;
+  k: string;
+  values?: Record<string, string | number>;
+}) {
+  const t = useTranslations(ns);
+  return <>{t(k as never, values as never)}</>;
+}

--- a/apps/web/lib/i18n/config.ts
+++ b/apps/web/lib/i18n/config.ts
@@ -1,0 +1,24 @@
+export const locales = ["en", "es", "fr"] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = "en";
+
+export const localeNames: Record<Locale, string> = {
+  en: "English",
+  es: "Español",
+  fr: "Français",
+};
+
+export const storageKey = "agora.locale";
+
+export function isLocale(value: string | null): value is Locale {
+  return value === "en" || value === "es" || value === "fr";
+}
+
+/** Best-effort detection of the user's browser language at first visit. */
+export function detectLocale(): Locale {
+  if (typeof window === "undefined") return defaultLocale;
+  const stored = window.localStorage.getItem(storageKey);
+  if (isLocale(stored)) return stored;
+  const preferred = window.navigator.language?.split("-")[0];
+  return isLocale(preferred) ? preferred : defaultLocale;
+}

--- a/apps/web/lib/i18n/locale-context.tsx
+++ b/apps/web/lib/i18n/locale-context.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { NextIntlClientProvider } from "next-intl";
+import en from "../../messages/en.json";
+import es from "../../messages/es.json";
+import fr from "../../messages/fr.json";
+import { detectLocale, type Locale } from "./config";
+
+const messages: Record<Locale, typeof en> = { en, es, fr };
+
+interface LocaleContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+/**
+ * Client-side locale provider (Issue #1343).
+ *
+ * Reads the persisted choice from `localStorage` (falling back to the browser
+ * language) and re-renders the `NextIntlClientProvider` with the matching
+ * message catalogue when the language is switched, so the UI updates
+ * immediately without a page reload.
+ */
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>(() =>
+    typeof window === "undefined" ? "en" : detectLocale()
+  );
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  const setLocale = useCallback((next: Locale) => {
+    setLocaleState(next);
+    try {
+      window.localStorage.setItem("agora.locale", next);
+    } catch {
+      // Persistence must never break the in-session switch.
+    }
+  }, []);
+
+  const value = useMemo(() => ({ locale, setLocale }), [locale, setLocale]);
+
+  return (
+    <LocaleContext.Provider value={value}>
+      <NextIntlClientProvider
+        locale={locale}
+        messages={messages[locale]}
+        timeZone="UTC"
+      >
+        {children}
+      </NextIntlClientProvider>
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocaleContext(): LocaleContextValue {
+  const ctx = useContext(LocaleContext);
+  if (!ctx) {
+    throw new Error("useLocaleContext must be used within a LocaleProvider");
+  }
+  return ctx;
+}

--- a/apps/web/lib/i18n/request.ts
+++ b/apps/web/lib/i18n/request.ts
@@ -1,0 +1,18 @@
+import { getRequestConfig } from "next-intl/server";
+import { defaultLocale, isLocale } from "./config";
+
+/**
+ * Request-scoped locale resolution for next-intl's server APIs.
+ *
+ * The app uses client-side language switching persisted in `localStorage`, so
+ * server rendering always falls back to the default locale. Client components
+ * re-render instantly when the user switches languages (see locale-context.tsx).
+ */
+export default getRequestConfig(async ({ requestLocale }) => {
+  const requested = await requestLocale;
+  const locale = isLocale(requested) ? requested : defaultLocale;
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1,0 +1,63 @@
+{
+  "footer": {
+    "copyright": "© 2026 agora. All rights reserved.",
+    "discoverEvents": "Discover Events",
+    "pricing": "Pricing",
+    "stellarEcosystem": "Stellar Ecosystem",
+    "faqs": "FAQs",
+    "cookiePreferences": "Cookie preferences",
+    "instagram": "Instagram",
+    "x": "X",
+    "mail": "Mail",
+    "stellar": "Stellar"
+  },
+  "languageSwitcher": {
+    "label": "Language",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français"
+  },
+  "home": {
+    "tabUpcoming": "Upcoming",
+    "tabHosting": "Hosting",
+    "tabPast": "Past",
+    "tabDiscover": "Discover",
+    "tabFollowing": "Following",
+    "myEvents": "My Events",
+    "forYou": "For You",
+    "noEventsFound": "No events found",
+    "viewEvent": "View Event",
+    "view": "View",
+    "free": "Free",
+    "tbd": "TBD",
+    "virtual": "Virtual",
+    "going": "going",
+    "openMessages": "Open messages",
+    "event": "Event"
+  },
+  "discover": {
+    "searchEvents": "Search events",
+    "anyTime": "Any time",
+    "sortEvents": "Sort events",
+    "activeFilters": "Active filters",
+    "clearSearch": "Clear Search",
+    "eventsPagination": "Events pagination",
+    "exploreOrganizers": "Explore organizers",
+    "noDataAvailable": "No data available"
+  },
+  "eventDetail": {
+    "share": "Share",
+    "free": "Free",
+    "date": "Date",
+    "location": "Location",
+    "eventNotFound": "Event not found",
+    "register": "Register",
+    "getTickets": "Get Tickets",
+    "securedSpot": "Secure your spot on Agora",
+    "freeEntry": "Free entry",
+    "joinUs": "Join us for {title} on {date} in {location}. {priceNote} Secure your spot on Agora.",
+    "ticketsFrom": "Tickets from ${price}.",
+    "hostedBy": "Hosted By",
+    "aboutEvent": "About Event"
+  }
+}

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1,0 +1,63 @@
+{
+  "footer": {
+    "copyright": "© 2026 agora. Todos los derechos reservados.",
+    "discoverEvents": "Descubrir eventos",
+    "pricing": "Precios",
+    "stellarEcosystem": "Ecosistema Stellar",
+    "faqs": "Preguntas frecuentes",
+    "cookiePreferences": "Preferencias de cookies",
+    "instagram": "Instagram",
+    "x": "X",
+    "mail": "Correo",
+    "stellar": "Stellar"
+  },
+  "languageSwitcher": {
+    "label": "Idioma",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français"
+  },
+  "home": {
+    "tabUpcoming": "Próximos",
+    "tabHosting": "Organizando",
+    "tabPast": "Pasados",
+    "tabDiscover": "Descubrir",
+    "tabFollowing": "Siguiendo",
+    "myEvents": "Mis eventos",
+    "forYou": "Para ti",
+    "noEventsFound": "No se encontraron eventos",
+    "viewEvent": "Ver evento",
+    "view": "Ver",
+    "free": "Gratis",
+    "tbd": "Por confirmar",
+    "virtual": "Virtual",
+    "going": "asisten",
+    "openMessages": "Abrir mensajes",
+    "event": "Evento"
+  },
+  "discover": {
+    "searchEvents": "Buscar eventos",
+    "anyTime": "Cualquier momento",
+    "sortEvents": "Ordenar eventos",
+    "activeFilters": "Filtros activos",
+    "clearSearch": "Limpiar búsqueda",
+    "eventsPagination": "Paginación de eventos",
+    "exploreOrganizers": "Explorar organizadores",
+    "noDataAvailable": "Sin datos disponibles"
+  },
+  "eventDetail": {
+    "share": "Compartir",
+    "free": "Gratis",
+    "date": "Fecha",
+    "location": "Ubicación",
+    "eventNotFound": "Evento no encontrado",
+    "register": "Registrarse",
+    "getTickets": "Obtener entradas",
+    "securedSpot": "Asegura tu lugar en Agora",
+    "freeEntry": "Entrada gratuita",
+    "joinUs": "Únete a {title} el {date} en {location}. {priceNote} Asegura tu lugar en Agora.",
+    "ticketsFrom": "Entradas desde ${price}.",
+    "hostedBy": "Organizado por",
+    "aboutEvent": "Sobre el evento"
+  }
+}

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1,0 +1,63 @@
+{
+  "footer": {
+    "copyright": "© 2026 agora. Tous droits réservés.",
+    "discoverEvents": "Découvrir les événements",
+    "pricing": "Tarifs",
+    "stellarEcosystem": "Écosystème Stellar",
+    "faqs": "FAQ",
+    "cookiePreferences": "Préférences de cookies",
+    "instagram": "Instagram",
+    "x": "X",
+    "mail": "E-mail",
+    "stellar": "Stellar"
+  },
+  "languageSwitcher": {
+    "label": "Langue",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français"
+  },
+  "home": {
+    "tabUpcoming": "À venir",
+    "tabHosting": "Organisation",
+    "tabPast": "Passés",
+    "tabDiscover": "Découvrir",
+    "tabFollowing": "Abonnements",
+    "myEvents": "Mes événements",
+    "forYou": "Pour vous",
+    "noEventsFound": "Aucun événement trouvé",
+    "viewEvent": "Voir l'événement",
+    "view": "Voir",
+    "free": "Gratuit",
+    "tbd": "À confirmer",
+    "virtual": "Virtuel",
+    "going": "participent",
+    "openMessages": "Ouvrir les messages",
+    "event": "Événement"
+  },
+  "discover": {
+    "searchEvents": "Rechercher des événements",
+    "anyTime": "À tout moment",
+    "sortEvents": "Trier les événements",
+    "activeFilters": "Filtres actifs",
+    "clearSearch": "Effacer la recherche",
+    "eventsPagination": "Pagination des événements",
+    "exploreOrganizers": "Explorer les organisateurs",
+    "noDataAvailable": "Aucune donnée disponible"
+  },
+  "eventDetail": {
+    "share": "Partager",
+    "free": "Gratuit",
+    "date": "Date",
+    "location": "Lieu",
+    "eventNotFound": "Événement introuvable",
+    "register": "S'inscrire",
+    "getTickets": "Obtenir des billets",
+    "securedSpot": "Réservez votre place sur Agora",
+    "freeEntry": "Entrée gratuite",
+    "joinUs": "Rejoignez {title} le {date} à {location}. {priceNote} Réservez votre place sur Agora.",
+    "ticketsFrom": "Billets à partir de ${price}.",
+    "hostedBy": "Organisé par",
+    "aboutEvent": "À propos de l'événement"
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
   turbopack: {
@@ -6,4 +7,9 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+// Issue #1343 — internationalisation for the web app. The client-side
+// LocaleProvider loads the message catalogues and switches instantly without
+// URL-prefixed routing (see lib/i18n/locale-context.tsx).
+const withNextIntl = createNextIntlPlugin("./lib/i18n/request.ts");
+
+export default withNextIntl(nextConfig);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "jsonwebtoken": "^9.0.3",
     "leaflet": "^1.9.4",
     "next": "16.1.3",
+    "next-intl": "^4.14.1",
     "nprogress": "^0.2.0",
     "posthog-js": "^1.393.5",
     "qrcode.react": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       next:
         specifier: 16.1.3
         version: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-intl:
+        specifier: ^4.14.1
+        version: 4.14.1(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
@@ -1233,6 +1236,15 @@ packages:
   '@electric-sql/pglite@0.4.1':
     resolution: {integrity: sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==}
 
+  '@eloqnt/config@0.0.2':
+    resolution: {integrity: sha512-xz86UU1TJQPSzb0XJ3PkoyDlv3wdIiHfuu2wD/8m9ponHx0uSasYRDj4S+dpwQkIQaPYibN1oRr5HBll2GQkog==}
+
+  '@eloqnt/format-json@0.0.3':
+    resolution: {integrity: sha512-zgDUVryBYQyM0WZGAoVr+FXjrzRjKkBGJran0E3i5LBcvTycl9ScFVhkF7aRBg8mHrU9xxvclUtSDIYg2mRTQg==}
+
+  '@eloqnt/format-po@0.0.3':
+    resolution: {integrity: sha512-4r36qEd7KJFV+IMKUv5czNXbGVys8ahxlQKWoUDV20eGl4Oxr+YZ2O5IEQU09S+d7FvPJ1USnyc/wtCLNCo1Ng==}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -1453,7 +1465,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -1536,6 +1548,18 @@ packages:
   '@expo/xcpretty@4.4.4':
     resolution: {integrity: sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==}
     hasBin: true
+
+  '@formatjs/fast-memoize@3.1.7':
+    resolution: {integrity: sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==}
+
+  '@formatjs/icu-messageformat-parser@3.5.17':
+    resolution: {integrity: sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==}
+
+  '@formatjs/icu-skeleton-parser@2.1.11':
+    resolution: {integrity: sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==}
+
+  '@formatjs/intl-localematcher@0.8.13':
+    resolution: {integrity: sha512-kHEAFOkeJSPNi7c5PaKaRjxcBrJwzzt81ifUu+8uve1EDW/VJl83KsxmqgqNZLzcFEhSliZGvx3+pk/RH0IOmg==}
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -2200,6 +2224,82 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@parcel/watcher-android-arm64@2.6.0':
+    resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    resolution: {integrity: sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    resolution: {integrity: sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    resolution: {integrity: sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.6.0':
+    resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
+    engines: {node: '>= 10.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2744,6 +2844,9 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@schummar/icu-type-parser@1.21.5':
+    resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
   '@segment/loosely-validate-event@2.0.0':
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
 
@@ -2894,8 +2997,95 @@ packages:
       typescript:
         optional: true
 
+  '@swc/core-darwin-arm64@1.16.1':
+    resolution: {integrity: sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.16.1':
+    resolution: {integrity: sha512-IN0BmPWb0YAh/17mmlWB/HDBtTw2MfuW4hulf/tQAgTQBRH17l+z499bNJLK6LizSjqs0P7V+jU38Zj+vJC1DA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.16.1':
+    resolution: {integrity: sha512-EYgrx2YOCQ2Twz2S793kqNjPkpvYVUPzzR95bIb7by+VQcyaai4lZZ2iz/tZvcFVKSNcN3/JTKwx+aBn2ZL52A==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.16.1':
+    resolution: {integrity: sha512-moyKm0YZlHdHohzm1YwgAyesqnE853rO0REMfJLFAova51wF9BNi+3ZW2PeS7Vqvn6HeJuepLpAHbBdZctxpHA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.16.1':
+    resolution: {integrity: sha512-kKGBO9wdapiSzuf5ZzZ2fYtlu1BNSYtIIUxvH1ir/gcelTOREEHGDCLTDFx/2Knf878nU11A40z7LxwasEFxqA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.16.1':
+    resolution: {integrity: sha512-nZ6qahtLxC3PM54cWOQZHxt4lTCF/3J4LIoWWzz6v7A+rLs8Dx54anYQf7mH3eIi8KlNpgKci/ie8ZSqFN8O7A==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.16.1':
+    resolution: {integrity: sha512-4ji5PNzhYq193Z4/4xUaSoNJza6iCkDJSzhetrbB6KOYxsr+kxtQr8ePWhMJUiMt6JUWtXaZ1PYT8FhtED+nGA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.16.1':
+    resolution: {integrity: sha512-VJQxqrisHV+B394IgrOu8YsIIXZgffnf5tO+yc9Z/hoUpuZEvuQTjWwlnpZdpyD+0nx6LTD1/3k646JYm43yJA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.16.1':
+    resolution: {integrity: sha512-r9oV1mwxxsIGcLV1IQ/tw76MW3doatKze1QFWuC+a7QqJUkhY/bKTSVk6NpKKUGm2LDsE33Va8VqSClfA7vSiQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.16.1':
+    resolution: {integrity: sha512-6huNRessoBLxWEqBm5zJXyCQ27TO7anvkdiuQ5MDO4CJni0nOXEqKtV9RllQ2TdyENKKsUMXVnIfW2hIXx/R5Q==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.16.1':
+    resolution: {integrity: sha512-OVKJFUzphrGmsh+BGtcZDesx0YryV7/Yvy5XGgTqnrZfjnyfcr5uaqYQugCckdIlupc5Vs3XtDjRAj12z4ZPlw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.16.1':
+    resolution: {integrity: sha512-Bt+VIhWYCGk4urklnkkteLUOeLv1VxigwTCeB/xC6rBZxY6IIKdDwCJf6on3E3SUGsIqmQS6QqtuJQc1VxF4Aw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.16.1':
+    resolution: {integrity: sha512-nUaeu91O5QZKrQdaDCHd402ogUIoNOOjpkZNq0UomWK0G6gDaGmLhvddF1/3BXf5O8aLyo6ZPY/aMDWvaJQ/hg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
@@ -3545,6 +3735,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -4367,6 +4558,10 @@ packages:
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -5874,6 +6069,9 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
+  icu-minify@4.14.1:
+    resolution: {integrity: sha512-I8lz1epVvPmTSCfElYrOVZPMlxXYO6u/HDAd8bAksU0WmL8774lqg/h4PSHIisEYbqYcxXGU2y5b5sbhzCIi0A==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -5954,6 +6152,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  intl-messageformat@11.2.14:
+    resolution: {integrity: sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -7300,6 +7501,10 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -7309,6 +7514,15 @@ packages:
   new-github-issue-url@0.2.1:
     resolution: {integrity: sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==}
     engines: {node: '>=10'}
+
+  next-intl-swc-plugin-extractor@4.14.1:
+    resolution: {integrity: sha512-ixZCS/z1Nx0sto4rWFfoCqahzqXjdhVuQzYrITVwXsrVzYi1ZKrWP8evoXTB5+F+j9FpLQIMIYB6gp3k+zePWA==}
+
+  next-intl@4.14.1:
+    resolution: {integrity: sha512-7o7ZyYIWoB0w87n13sezA8r1uLH0ipZCGrMHFKVhwFnwUI1/tym04P/T5NiyULaXUQ276m60xsmInE+HnfAq3A==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   next@16.1.3:
     resolution: {integrity: sha512-gthG3TRD+E3/mA0uDQb9lqBmx1zVosq5kIwxNN6+MRNd085GzD+9VXMPUs+GGZCbZ+GDZdODUq4Pm7CTXK6ipw==}
@@ -7340,6 +7554,9 @@ packages:
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-dir@0.1.17:
     resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
@@ -7760,6 +7977,9 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  po-parser@2.2.0:
+    resolution: {integrity: sha512-NdTrKgh0oO7+y+RFX8KKhOB438x/j94UGXEFzl/7pHH0JjWSn42iJ9tgmPksIO6n1JKDHmNDcejPJfKspljB9g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -9342,6 +9562,11 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  use-intl@4.14.1:
+    resolution: {integrity: sha512-p6Ggq6AZJDJQpjj4WEjByfid1IEifH7OYpL283y29dzVT2M6vbMoHmYA9KQ/L1A9jHED8uzCNvWic0mJ23kU5A==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   use-latest-callback@0.2.6:
     resolution: {integrity: sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==}
     peerDependencies:
@@ -10891,6 +11116,17 @@ snapshots:
 
   '@electric-sql/pglite@0.4.1': {}
 
+  '@eloqnt/config@0.0.2': {}
+
+  '@eloqnt/format-json@0.0.3':
+    dependencies:
+      '@eloqnt/config': 0.0.2
+
+  '@eloqnt/format-po@0.0.3':
+    dependencies:
+      '@eloqnt/config': 0.0.2
+      po-parser: 2.2.0
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -11339,6 +11575,18 @@ snapshots:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
       js-yaml: 4.3.0
+
+  '@formatjs/fast-memoize@3.1.7': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.17':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.11
+
+  '@formatjs/icu-skeleton-parser@2.1.11': {}
+
+  '@formatjs/intl-localematcher@0.8.13':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.7
 
   '@graphql-typed-document-node/core@3.2.0(graphql@15.8.0)':
     dependencies:
@@ -11956,6 +12204,62 @@ snapshots:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
+
+  '@parcel/watcher-android-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher@2.6.0':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.5
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.6.0
+      '@parcel/watcher-darwin-arm64': 2.6.0
+      '@parcel/watcher-darwin-x64': 2.6.0
+      '@parcel/watcher-freebsd-x64': 2.6.0
+      '@parcel/watcher-linux-arm-glibc': 2.6.0
+      '@parcel/watcher-linux-arm-musl': 2.6.0
+      '@parcel/watcher-linux-arm64-glibc': 2.6.0
+      '@parcel/watcher-linux-arm64-musl': 2.6.0
+      '@parcel/watcher-linux-x64-glibc': 2.6.0
+      '@parcel/watcher-linux-x64-musl': 2.6.0
+      '@parcel/watcher-win32-arm64': 2.6.0
+      '@parcel/watcher-win32-x64': 2.6.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -12773,6 +13077,8 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@schummar/icu-type-parser@1.21.5': {}
+
   '@segment/loosely-validate-event@2.0.0':
     dependencies:
       component-type: 1.2.2
@@ -12957,9 +13263,69 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@swc/core-darwin-arm64@1.16.1':
+    optional: true
+
+  '@swc/core-darwin-x64@1.16.1':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.16.1':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.16.1':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.16.1':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.16.1':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.16.1':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.16.1':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.16.1':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.16.1':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.16.1':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.16.1':
+    optional: true
+
+  '@swc/core@1.16.1':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.16.1
+      '@swc/core-darwin-x64': 1.16.1
+      '@swc/core-linux-arm-gnueabihf': 1.16.1
+      '@swc/core-linux-arm64-gnu': 1.16.1
+      '@swc/core-linux-arm64-musl': 1.16.1
+      '@swc/core-linux-ppc64-gnu': 1.16.1
+      '@swc/core-linux-s390x-gnu': 1.16.1
+      '@swc/core-linux-x64-gnu': 1.16.1
+      '@swc/core-linux-x64-musl': 1.16.1
+      '@swc/core-win32-arm64-msvc': 1.16.1
+      '@swc/core-win32-ia32-msvc': 1.16.1
+      '@swc/core-win32-x64-msvc': 1.16.1
+
+  '@swc/counter@0.1.3': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tailwindcss/node@4.3.2':
     dependencies:
@@ -14638,6 +15004,8 @@ snapshots:
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  content-type@2.1.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -16409,6 +16777,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  icu-minify@4.14.1:
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 3.5.17
+
   ieee754@1.2.1: {}
 
   ignore-walk@5.0.1:
@@ -16476,6 +16848,11 @@ snapshots:
       side-channel: 1.1.1
 
   internmap@2.0.3: {}
+
+  intl-messageformat@11.2.14:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.7
+      '@formatjs/icu-messageformat-parser': 3.5.17
 
   invariant@2.2.4:
     dependencies:
@@ -18324,11 +18701,34 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   neo-async@2.6.2: {}
 
   nested-error-stacks@2.0.1: {}
 
   new-github-issue-url@0.2.1: {}
+
+  next-intl-swc-plugin-extractor@4.14.1: {}
+
+  next-intl@4.14.1(next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@eloqnt/config': 0.0.2
+      '@eloqnt/format-json': 0.0.3
+      '@eloqnt/format-po': 0.0.3
+      '@formatjs/intl-localematcher': 0.8.13
+      '@parcel/watcher': 2.6.0
+      '@swc/core': 1.16.1
+      icu-minify: 4.14.1
+      negotiator: 1.1.0
+      next: 16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-intl-swc-plugin-extractor: 4.14.1
+      react: 19.2.3
+      use-intl: 4.14.1(react@19.2.3)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   next@16.1.3(@opentelemetry/api@1.4.1)(@playwright/test@1.49.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -18361,6 +18761,8 @@ snapshots:
   nocache@3.0.4: {}
 
   node-abort-controller@3.1.1: {}
+
+  node-addon-api@7.1.1: {}
 
   node-dir@0.1.17:
     dependencies:
@@ -18813,6 +19215,8 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@5.0.0: {}
+
+  po-parser@2.2.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -20704,6 +21108,14 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-intl@4.14.1(react@19.2.3):
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.7
+      '@schummar/icu-type-parser': 1.21.5
+      icu-minify: 4.14.1
+      intl-messageformat: 11.2.14
+      react: 19.2.3
 
   use-latest-callback@0.2.6(react@18.2.0):
     dependencies:


### PR DESCRIPTION
Closes #1343

## Summary
Adds full Spanish & French localisation to the web app using `next-intl`.

**Setup**
- Installed `next-intl`; configured in `next.config.ts` via `createNextIntlPlugin` with `locales: ["en","es","fr"]` and default `en` (client-driven, no URL-prefixed routing).
- `messages/en.json`, `messages/es.json`, `messages/fr.json` catalogues (footer, home, discover, language switcher, event detail).
- `lib/i18n/config.ts`, `lib/i18n/request.ts` (server fallback = default locale), and **`lib/i18n/locale-context.tsx`**: a client `LocaleProvider` that reads the persisted choice from **`localStorage`** (falls back to browser language), updates `<html lang>`, and swaps the next-intl message catalogue — so **switching language updates every translated component immediately without a page reload**.
- Root layout wrapped in `LocaleProvider`.

**Language switcher**
- New `components/layout/language-switcher.tsx` (EN / ES / FR `<select>`) added to the footer; persists via `localStorage`.

**Translated surfaces**
- **Footer** (all links, copyright, socials).
- **Home** — tab labels (Upcoming/Hosting/Past/Discover/Following), section titles (My Events / For You), empty states, card fallback labels (Free, TBD, Virtual, View Event, going) & chat button.
- **Discover** — search/sort/filter labels, "Explore organizers", "No data available".
- **Event detail** — Hosted By, Location, About Event, and client CTA translations in `ShareButton` ("Share") and `RegistrationBox` ("Register").

## Acceptance Criteria
- [x] next-intl installed & configured (`locales: ['en','es','fr']`, `defaultLocale: 'en'`)
- [x] Hardcoded UI strings extracted into `messages/en.json`; `es.json` & `fr.json` provided
- [x] Root layout wrapped in `NextIntlClientProvider` (via `LocaleProvider`)
- [x] Language switcher in the footer persists to `localStorage`
- [x] Home, discover, and event-detail strings translated; switching updates UI immediately without reload
- [x] RTL unaffected (es/fr are LTR)

## Verification
- `tsc --noEmit`: no errors in any touched file (only pre-existing `TicketModal.tsx` parse error on `main`).
- `eslint`: no errors introduced.
- `vitest`: no new failures (existing failures are on pre-existing files).
